### PR TITLE
build: consolidate dependabot dependency updates

### DIFF
--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -54,3 +54,36 @@ def setup_test_environment():
     # This fixture runs automatically for all tests
     # Can be used for global setup/teardown if needed
     # Cleanup code can go here if needed
+
+
+@pytest.fixture(autouse=True)
+def _clear_async_caches():
+    """Clear async LRU caches between tests.
+
+    async-lru >= 2.2.0 enforces single event loop per cache instance.
+    Since pytest-asyncio creates a new event loop per test function,
+    stale caches from a previous loop cause RuntimeError. Clearing
+    them and resetting the loop binding before each test prevents this.
+    """
+    from py_identity_model.aio.token_validation import (
+        _get_disco_response,
+        _get_jwks_response,
+        _get_public_key_by_kid,
+    )
+
+    for cache_fn in (
+        _get_disco_response,
+        _get_jwks_response,
+        _get_public_key_by_kid,
+    ):
+        cache_fn.cache_clear()
+        # Reset event loop binding added in async-lru 2.2.0
+        loop_attr = "_LRUCacheWrapper__first_loop"
+        if hasattr(cache_fn, loop_attr):
+            setattr(cache_fn, loop_attr, None)
+
+    # Reset the singleton async HTTP client so it gets recreated
+    # on the new event loop
+    from py_identity_model.aio.http_client import _reset_async_http_client
+
+    _reset_async_http_client()

--- a/uv.lock
+++ b/uv.lock
@@ -41,11 +41,11 @@ wheels = [
 
 [[package]]
 name = "async-lru"
-version = "2.1.0"
+version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ef/c3/bbf34f15ea88dfb649ab2c40f9d75081784a50573a9ea431563cab64adb8/async_lru-2.1.0.tar.gz", hash = "sha256:9eeb2fecd3fe42cc8a787fc32ead53a3a7158cc43d039c3c55ab3e4e5b2a80ed", size = 12041, upload-time = "2026-01-17T22:52:18.931Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8a/ca724066c32a53fa75f59e0f21aa822fdaa8a0dffa112d223634e3caabf9/async_lru-2.2.0.tar.gz", hash = "sha256:80abae2a237dbc6c60861d621619af39f0d920aea306de34cb992c879e01370c", size = 14654, upload-time = "2026-02-20T19:11:43.848Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/e9/eb6a5db5ac505d5d45715388e92bced7a5bb556facc4d0865d192823f2d2/async_lru-2.1.0-py3-none-any.whl", hash = "sha256:fa12dcf99a42ac1280bc16c634bbaf06883809790f6304d85cdab3f666f33a7e", size = 6933, upload-time = "2026-01-17T22:52:17.389Z" },
+    { url = "https://files.pythonhosted.org/packages/13/5c/af990f019b8dd11c5492a6371fe74a5b0276357370030b67254a87329944/async_lru-2.2.0-py3-none-any.whl", hash = "sha256:e2c1cf731eba202b59c5feedaef14ffd9d02ad0037fcda64938699f2c380eafe", size = 7890, upload-time = "2026-02-20T19:11:42.273Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Consolidates 2 open dependabot PRs into a single dependency update

## Dependency Updates

| PR | Package | Type | Update |
|----|---------|------|--------|
| #178 | async-lru | runtime | 2.1.0 → 2.2.0 |
| #167 | uv-build | build | <0.10 → <0.11 (constraint already on main) |

## Breaking Change Fix

`async-lru` 2.2.0 added event loop safety enforcement — `alru_cache` now raises `RuntimeError` if used across different event loops. This broke the test suite since `pytest-asyncio` creates a new event loop per test function (configured via `asyncio_default_fixture_loop_scope = "function"`).

**Fix**: Added an autouse fixture in `conftest.py` that clears the `alru_cache` instances and resets their event loop bindings between tests, plus resets the singleton async HTTP client.

## Test plan
- [x] All tests pass (`make test` — 259 passed, 95.51% coverage)
- [x] All linting checks pass (`make lint`)
- [ ] CI passes on PR

Resolves #178, #167