### PR TITLE
fix(test): warm lru_cache before benchmark to avoid 429 rate limits

### DIFF
--- a/src/tests/integration/test_token_validation.py
+++ b/src/tests/integration/test_token_validation.py
@@ -115,6 +115,19 @@ def test_benchmark_validation(test_config, client_credentials_token):
         audience=test_config["TEST_AUDIENCE"],
         options=DEFAULT_OPTIONS,
     )
+
+    # Warm the lru_cache (discovery + JWKS) before benchmarking.
+    # The conftest fixtures fetch discovery/JWKS via get_discovery_document/get_jwks
+    # directly, but validate_token uses its own _get_disco_response/_get_jwks_response
+    # lru_cache wrappers — a separate cache that starts cold in each pytest-xdist worker.
+    # Without this warmup, the first iteration makes real HTTP requests that can hit
+    # Ory's rate limits (429 + 1s retry backoff), pushing the benchmark over budget.
+    validate_token(
+        jwt=client_credentials_token.token["access_token"],
+        disco_doc_address=test_config["TEST_DISCO_ADDRESS"],
+        token_validation_config=validation_config,
+    )
+
     start_time = datetime.datetime.now(tz=datetime.UTC)
 
     for _ in range(100):


### PR DESCRIPTION
## Summary

- The benchmark integration test (`test_benchmark_validation`) measures that 100 cached token validations complete in under 1 second
- `validate_token` uses its own `@lru_cache` wrappers (`_get_disco_response`, `_get_jwks_response`) that are **separate** from the conftest session fixtures which call `get_discovery_document`/`get_jwks` directly
- With `pytest -n auto`, each xdist worker starts with cold caches, so the first `validate_token` call makes real HTTP requests. If Ory is rate-limiting (429), the retry backoff adds 1s+, pushing the benchmark over its 1s budget
- Fix: add a warmup `validate_token` call before the timed loop so only cached performance is measured

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (259 tests, 95.37% coverage)
- [ ] CI integration tests pass without 429-induced benchmark failures