### PR TITLE
fix(hooks): remove unnecessary bash -c wrappers from pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,14 +12,14 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: pyrefly check
-        entry: bash -c 'uv run pyrefly check src/'
+        entry: uv run pyrefly check src/
         language: system
         types_or: [python, pyi]
         pass_filenames: false
         require_serial: true
       - id: pytest-coverage
         name: pytest coverage check (80% minimum)
-        entry: bash -c 'uv run pytest src/tests -m unit -q --cov=src/py_identity_model --cov-report=term-missing:skip-covered --cov-fail-under=80'
+        entry: uv run pytest src/tests -m unit -q --cov=src/py_identity_model --cov-report=term-missing:skip-covered --cov-fail-under=80
         language: system
         types: [python]
         pass_filenames: false


### PR DESCRIPTION
## Summary

Closes #114

The pre-commit hook failures described in #114 had two causes:

1. **Pyrefly type errors** — The `NoneType.lower` error in `test_async_sync_equivalence.py:130` that blocked commits has been resolved in subsequent PRs. Pyrefly now passes with 0 errors (4 suppressed — all intentional `# type: ignore` for None-argument error-path tests).

2. **Unnecessary `bash -c` wrappers** — The pyrefly and pytest hooks used `entry: bash -c '...'` to wrap commands. With `pass_filenames: false`, pre-commit executes the `entry` directly without appending filenames, so the shell wrapper is unnecessary. Removing it eliminates a layer of indirection and avoids potential shell quoting issues.

The hook ordering concern (ruff modifies files → commit fails → re-stage → commit again) is standard pre-commit behavior and works correctly. With the type errors resolved, commits succeed without `--no-verify`.

## Test plan

- [x] `make lint` passes — all 4 hooks (ruff, ruff-format, pyrefly, pytest) pass
- [x] `make test` passes — 259 tests, 95.51% coverage
- [x] Real commit workflow tested — hooks execute correctly during `git commit`
- [x] `uv run pyrefly check src/` reports 0 errors