### PR TITLE
fix: suppress false-positive SonarCloud security hotspots

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -22,5 +22,17 @@ sonar.qualitygate.wait=true
 # Exclude test files from duplication analysis
 sonar.cpd.exclusions=src/tests/**
 
+# Suppress false-positive security hotspots for standard specification URIs.
+# identity.py contains WS-Federation/Microsoft/.NET ClaimType namespace URIs
+# (e.g. http://schemas.xmlsoap.org/ws/2005/05/identity/claims/...) and
+# oidc_constants.py contains the OpenID Connect backchannel-logout event URI
+# (http://schemas.openid.net/event/backchannel-logout).
+# These are protocol-defined identifiers, not HTTP connections.
+sonar.issue.ignore.multicriteria=s5332_identity,s5332_oidc_constants
+sonar.issue.ignore.multicriteria.s5332_identity.ruleKey=python:S5332
+sonar.issue.ignore.multicriteria.s5332_identity.resourceKey=src/py_identity_model/identity.py
+sonar.issue.ignore.multicriteria.s5332_oidc_constants.ruleKey=python:S5332
+sonar.issue.ignore.multicriteria.s5332_oidc_constants.resourceKey=src/py_identity_model/oidc_constants.py
+
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary
- Adds `sonar.issue.ignore.multicriteria` rules to `sonar-project.properties` to suppress 9 false-positive `python:S5332` security hotspots
- The flagged `http://` strings in `identity.py` and `oidc_constants.py` are standard protocol namespace URIs (WS-Federation, .NET Claims, OpenID Connect), not HTTP connections
- These URIs are defined by external specifications and cannot be changed to `https://`

## Details

**Files with suppressed hotspots:**
| File | URIs | Standard |
|------|------|----------|
| `identity.py` (8 hotspots) | `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/*`, `http://schemas.microsoft.com/ws/2008/06/identity/claims/*` | WS-Federation, .NET ClaimTypes |
| `oidc_constants.py` (1 hotspot) | `http://schemas.openid.net/event/backchannel-logout` | OpenID Connect Back-Channel Logout |

**Note:** The original 1 vulnerability and 5 code smells from issue #110 appear to have been resolved in prior commits. These 9 security hotspots are the remaining SonarCloud quality items.

Closes #110

## Test plan
- [x] `make lint` passes
- [x] `make test` passes (259 tests, 95.51% coverage)
- [ ] Verify SonarCloud analysis shows 0 security hotspots on the PR