### PR TITLE
fix: use token issuer for Claim.issuer in to_principal

### DIFF
--- a/src/py_identity_model/identity.py
+++ b/src/py_identity_model/identity.py
@@ -447,6 +447,7 @@ def to_principal(
     Returns:
         ClaimsPrincipal object containing the claims from the token
     """
+    issuer = str(token_claims.get("iss", "LOCAL AUTHORITY"))
     claims = []
 
     for claim_type, claim_value in token_claims.items():
@@ -454,12 +455,18 @@ def to_principal(
         if isinstance(claim_value, list):
             # Multiple values for the same claim type
             claims.extend(
-                Claim(claim_type=claim_type, value=str(value))
+                Claim(claim_type=claim_type, value=str(value), issuer=issuer)
                 for value in claim_value
             )
         else:
             # Single value claim
-            claims.append(Claim(claim_type=claim_type, value=str(claim_value)))
+            claims.append(
+                Claim(
+                    claim_type=claim_type,
+                    value=str(claim_value),
+                    issuer=issuer,
+                )
+            )
 
     # Create a ClaimsIdentity with the claims
     identity = ClaimsIdentity(

--- a/src/tests/unit/test_claims_principal_from_token.py
+++ b/src/tests/unit/test_claims_principal_from_token.py
@@ -32,6 +32,11 @@ def test_create_claims_principal_from_simple_token():
     assert principal.has_claim("iat", "1234567800")
     assert principal.has_claim("email", "user@example.com")
 
+    # Check that issuer is set from the iss claim
+    sub_claim = principal.find_first("sub")
+    assert sub_claim is not None
+    assert sub_claim.issuer == "https://example.com"
+
 
 def test_create_claims_principal_with_custom_auth_type():
     """Test creating ClaimsPrincipal with custom authentication type"""
@@ -71,6 +76,22 @@ def test_create_claims_principal_from_token_with_array_claims():
     # Check other claims
     assert principal.has_claim("sub", "user123")
     assert principal.has_claim("iss", "https://example.com")
+
+    # Array claim values should also have the token issuer
+    role_claims = principal.find_all("roles")
+    for claim in role_claims:
+        assert claim.issuer == "https://example.com"
+
+
+def test_claims_issuer_defaults_to_local_authority_without_iss():
+    """Test that claims default to LOCAL AUTHORITY when no iss claim is present"""
+    token_claims = {"sub": "user123", "email": "user@example.com"}
+
+    principal = to_principal(token_claims)
+
+    sub_claim = principal.find_first("sub")
+    assert sub_claim is not None
+    assert sub_claim.issuer == "LOCAL AUTHORITY"
 
 
 def test_create_claims_principal_from_empty_token():

--- a/uv.lock
+++ b/uv.lock
@@ -763,7 +763,7 @@ wheels = [
 
 [[package]]
 name = "py-identity-model"
-version = "2.1.3"
+version = "2.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "async-lru" },


### PR DESCRIPTION
## Summary
- `to_principal()` was hardcoding `"LOCAL AUTHORITY"` as the issuer for all `Claim` objects
- Now extracts the issuer from the token's `iss` claim, falling back to `"LOCAL AUTHORITY"` when no `iss` is present
- Added tests for issuer propagation on scalar claims, array claims, and the fallback behavior

## Test plan
- [x] Existing `to_principal` tests updated with issuer assertions
- [x] New test for `LOCAL AUTHORITY` fallback when no `iss` claim
- [x] All 7 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)