### PR TITLE
ci: split CI workflow into parallel jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ on:
         default: false
 
 jobs:
-  lint-and-test:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -41,14 +41,76 @@ jobs:
         with:
           python-version: 3.13
 
+      - name: Cache uv dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/uv
+            .venv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-
+
       - name: Install dependencies
         run: make ci-setup
 
       - name: Lint
         run: make lint
 
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.13
+
+      - name: Cache uv dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/uv
+            .venv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: make ci-setup
+
       - name: Unit Tests
         run: make test-unit
+
+  integration-tests-ory:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.13
+
+      - name: Cache uv dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/uv
+            .venv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: make ci-setup
 
       - name: Integration Tests (ORY)
         run: make test-integration-ory
@@ -61,8 +123,34 @@ jobs:
           TEST_EXPIRED_TOKEN: ${{ secrets.TEST_EXPIRED_TOKEN }}
           TEST_AUDIENCE: ${{ secrets.TEST_AUDIENCE }}
 
+  integration-tests-descope:
+    if: inputs.run-descope-integration
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.13
+
+      - name: Cache uv dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/uv
+            .venv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: make ci-setup
+
       - name: Integration Tests (Descope)
-        if: inputs.run-descope-integration
         run: make test-integration-descope
         env:
           TEST_DISCO_ADDRESS: ${{ secrets.DESCOPE_DISCO_ADDRESS }}
@@ -73,14 +161,88 @@ jobs:
           TEST_EXPIRED_TOKEN: ${{ secrets.DESCOPE_EXPIRED_TOKEN }}
           TEST_AUDIENCE: ${{ secrets.DESCOPE_AUDIENCE }}
 
+  example-tests:
+    if: inputs.run-example-tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.13
+
+      - name: Cache uv dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/uv
+            .venv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: make ci-setup
+
       - name: Set up Docker Buildx
-        if: inputs.run-example-tests
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Example Integration Tests
-        if: inputs.run-example-tests
         run: make test-examples
 
+  build:
+    if: inputs.run-build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.13
+
+      - name: Cache uv dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/uv
+            .venv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: make ci-setup
+
       - name: Build
-        if: inputs.run-build
         run: make build-dist
+
+  ci-complete:
+    if: always()
+    needs: [lint, unit-tests, integration-tests-ory, integration-tests-descope, example-tests, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check CI results
+        run: |
+          results=( \
+            "${{ needs.lint.result }}" \
+            "${{ needs.unit-tests.result }}" \
+            "${{ needs.integration-tests-ory.result }}" \
+            "${{ needs.integration-tests-descope.result }}" \
+            "${{ needs.example-tests.result }}" \
+            "${{ needs.build.result }}" \
+          )
+          for result in "${results[@]}"; do
+            if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
+              echo "CI failed: found job with result '$result'"
+              exit 1
+            fi
+          done
+          echo "All CI jobs passed"


### PR DESCRIPTION
## Summary
- Split the single sequential `lint-and-test` job into six parallel jobs: `lint`, `unit-tests`, `integration-tests-ory`, `integration-tests-descope`, `example-tests`, and `build`
- Added uv dependency caching (`actions/cache@v4`) to each job to avoid slow reinstalls across parallel runners
- Added a `ci-complete` sentinel job that aggregates all job results, ensuring callers like `release.yml` (`needs: ci`) still work cleanly

## Test plan
- [ ] Verify the Build workflow triggers on push and all six jobs run in parallel
- [ ] Verify conditional jobs (`integration-tests-descope`, `example-tests`, `build`) are correctly skipped/enabled based on inputs
- [ ] Verify `release.yml` still gates the `release` job on all CI jobs completing via the reusable workflow call
- [ ] Verify uv cache hits on subsequent runs reduce setup time

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)