### PR TITLE
feat(par): implement Pushed Authorization Requests (RFC 9126)

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -25,6 +25,7 @@ from py_identity_model import DiscoveryDocumentRequest
 | [Authorize Callback](authorize-callback.md) | Authorization callback parsing and state validation |
 | [HTTP Client](http-client.md) | Dependency injection for HTTP client management |
 | [Introspection](introspection.md) | Token Introspection (RFC 7662) |
+| [PAR](par.md) | Pushed Authorization Requests (RFC 9126) | | Token Introspection (RFC 7662) |
 | [DPoP](dpop.md) | Demonstrating Proof of Possession (RFC 9449) |
 | [Discovery](discovery.md) | OpenID Connect Discovery 1.0 document fetching |
 | [JWKS](jwks.md) | JSON Web Key Set (RFC 7517) operations |

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -25,7 +25,7 @@ from py_identity_model import DiscoveryDocumentRequest
 | [Authorize Callback](authorize-callback.md) | Authorization callback parsing and state validation |
 | [HTTP Client](http-client.md) | Dependency injection for HTTP client management |
 | [Introspection](introspection.md) | Token Introspection (RFC 7662) |
-| [PAR](par.md) | Pushed Authorization Requests (RFC 9126) | | Token Introspection (RFC 7662) |
+| [PAR](par.md) | Pushed Authorization Requests (RFC 9126) |
 | [DPoP](dpop.md) | Demonstrating Proof of Possession (RFC 9449) |
 | [Discovery](discovery.md) | OpenID Connect Discovery 1.0 document fetching |
 | [JWKS](jwks.md) | JSON Web Key Set (RFC 7517) operations |

--- a/docs/api/par.md
+++ b/docs/api/par.md
@@ -1,0 +1,15 @@
+# Pushed Authorization Requests (PAR)
+
+OAuth 2.0 Pushed Authorization Requests (RFC 9126) for enhanced authorization security.
+
+## Request Model
+
+::: py_identity_model.core.models.PushedAuthorizationRequest
+
+## Response Model
+
+::: py_identity_model.core.models.PushedAuthorizationResponse
+
+## Functions
+
+::: py_identity_model.sync.par.push_authorization_request

--- a/examples/par_example.py
+++ b/examples/par_example.py
@@ -1,0 +1,41 @@
+"""
+Pushed Authorization Requests (PAR) Example (RFC 9126)
+
+Demonstrates pushing authorization parameters to the PAR endpoint.
+"""
+
+from py_identity_model import PushedAuthorizationRequest
+
+
+def par_example():
+    """Push authorization parameters to get a request_uri."""
+    print("\n" + "=" * 60)
+    print("Pushed Authorization Request (PAR)")
+    print("=" * 60)
+
+    request = PushedAuthorizationRequest(
+        address="https://auth.example.com/par",
+        client_id="my-app",
+        redirect_uri="https://myapp.com/callback",
+        scope="openid profile",
+        state="csrf_token",
+        code_challenge="pkce_challenge",
+        code_challenge_method="S256",
+        client_secret="my-secret",
+    )
+
+    print(f"\n  PAR endpoint: {request.address}")
+    print(f"  Scope: {request.scope}")
+    print("  (Would call push_authorization_request())")
+    print("  On success: use response.request_uri in authorization URL")
+
+
+def main():
+    par_example()
+    print("\n" + "=" * 60)
+    print("Examples completed!")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/py_identity_model/__init__.py
+++ b/src/py_identity_model/__init__.py
@@ -46,6 +46,8 @@ from .sync import (
     JsonWebKeyParameterNames,
     JwksRequest,
     JwksResponse,
+    PushedAuthorizationRequest,
+    PushedAuthorizationResponse,
     RefreshTokenRequest,
     RefreshTokenResponse,
     StateValidationResult,
@@ -70,6 +72,7 @@ from .sync import (
     introspect_token,
     jwks_from_dict,
     parse_authorize_callback_response,
+    push_authorization_request,
     refresh_token,
     request_authorization_code_token,
     request_client_credentials_token,
@@ -115,6 +118,9 @@ __all__ = [
     "JwksRequest",
     "JwksResponse",
     "NetworkException",
+    # PAR
+    "PushedAuthorizationRequest",
+    "PushedAuthorizationResponse",
     # Exceptions
     "PyIdentityModelException",
     # Refresh Token
@@ -152,6 +158,7 @@ __all__ = [
     "introspect_token",
     "jwks_from_dict",
     "parse_authorize_callback_response",
+    "push_authorization_request",
     "refresh_token",
     "request_authorization_code_token",
     "request_client_credentials_token",

--- a/src/py_identity_model/aio/__init__.py
+++ b/src/py_identity_model/aio/__init__.py
@@ -64,6 +64,11 @@ from .jwks import (
     jwks_from_dict,
 )
 from .managed_client import AsyncHTTPClient
+from .par import (
+    PushedAuthorizationRequest,
+    PushedAuthorizationResponse,
+    push_authorization_request,
+)
 from .revocation import (
     TokenRevocationRequest,
     TokenRevocationResponse,
@@ -110,6 +115,9 @@ __all__ = [
     "JsonWebKeyParameterNames",
     "JwksRequest",
     "JwksResponse",
+    # PAR
+    "PushedAuthorizationRequest",
+    "PushedAuthorizationResponse",
     # Refresh Token
     "RefreshTokenRequest",
     "RefreshTokenResponse",
@@ -139,6 +147,7 @@ __all__ = [
     "introspect_token",
     "jwks_from_dict",
     "parse_authorize_callback_response",
+    "push_authorization_request",
     "refresh_token",
     "request_authorization_code_token",
     "request_client_credentials_token",

--- a/src/py_identity_model/aio/par.py
+++ b/src/py_identity_model/aio/par.py
@@ -1,0 +1,58 @@
+"""
+Pushed Authorization Requests (asynchronous implementation, RFC 9126).
+"""
+
+from ..core.models import (
+    PushedAuthorizationRequest,
+    PushedAuthorizationResponse,
+)
+from ..core.par_logic import (
+    handle_par_error,
+    log_par_request,
+    prepare_par_request_data,
+    process_par_response,
+)
+from .http_client import get_async_http_client, retry_with_backoff_async
+from .managed_client import AsyncHTTPClient
+
+
+@retry_with_backoff_async()
+async def _push_authorization_request(client, url, data, headers, auth=None):
+    """Make PAR request with retry logic (async)."""
+    kwargs: dict = {"data": data, "headers": headers}
+    if auth is not None:
+        kwargs["auth"] = auth
+    return await client.post(url, **kwargs)
+
+
+async def push_authorization_request(
+    request: PushedAuthorizationRequest,
+    http_client: AsyncHTTPClient | None = None,
+) -> PushedAuthorizationResponse:
+    """Push authorization parameters to the PAR endpoint (RFC 9126, async).
+
+    Args:
+        request: PAR request with authorization parameters.
+        http_client: Optional managed HTTP client.
+
+    Returns:
+        PushedAuthorizationResponse with ``request_uri`` and ``expires_in``.
+    """
+    log_par_request(request)
+    params, headers, auth = prepare_par_request_data(request)
+
+    try:
+        client = http_client.client if http_client else get_async_http_client()
+        response = await _push_authorization_request(
+            client, request.address, params, headers, auth
+        )
+        return process_par_response(response)
+    except Exception as e:
+        return handle_par_error(e)
+
+
+__all__ = [
+    "PushedAuthorizationRequest",
+    "PushedAuthorizationResponse",
+    "push_authorization_request",
+]

--- a/src/py_identity_model/aio/par.py
+++ b/src/py_identity_model/aio/par.py
@@ -2,12 +2,14 @@
 Pushed Authorization Requests (asynchronous implementation, RFC 9126).
 """
 
+import httpx
+
+from ..core.error_handlers import handle_par_error
 from ..core.models import (
     PushedAuthorizationRequest,
     PushedAuthorizationResponse,
 )
 from ..core.par_logic import (
-    handle_par_error,
     log_par_request,
     prepare_par_request_data,
     process_par_response,
@@ -17,7 +19,13 @@ from .managed_client import AsyncHTTPClient
 
 
 @retry_with_backoff_async()
-async def _push_authorization_request(client, url, data, headers, auth=None):
+async def _push_authorization_request(
+    client: httpx.AsyncClient,
+    url: str,
+    data: dict,
+    headers: dict,
+    auth: tuple[str, str] | None = None,
+) -> httpx.Response:
     """Make PAR request with retry logic (async)."""
     kwargs: dict = {"data": data, "headers": headers}
     if auth is not None:
@@ -39,9 +47,10 @@ async def push_authorization_request(
         PushedAuthorizationResponse with ``request_uri`` and ``expires_in``.
     """
     log_par_request(request)
-    params, headers, auth = prepare_par_request_data(request)
 
+    response = None
     try:
+        params, headers, auth = prepare_par_request_data(request)
         client = http_client.client if http_client else get_async_http_client()
         response = await _push_authorization_request(
             client, request.address, params, headers, auth
@@ -49,6 +58,9 @@ async def push_authorization_request(
         return process_par_response(response)
     except Exception as e:
         return handle_par_error(e)
+    finally:
+        if response is not None:
+            await response.aclose()
 
 
 __all__ = [

--- a/src/py_identity_model/core/error_handlers.py
+++ b/src/py_identity_model/core/error_handlers.py
@@ -14,6 +14,7 @@ from .models import (
     ClientCredentialsTokenResponse,
     DiscoveryDocumentResponse,
     JwksResponse,
+    PushedAuthorizationResponse,
     RefreshTokenResponse,
     TokenIntrospectionResponse,
     TokenRevocationResponse,
@@ -185,6 +186,20 @@ def handle_revocation_error(e: Exception) -> TokenRevocationResponse:
     return TokenRevocationResponse(is_successful=False, error=error_msg)
 
 
+def handle_par_error(e: Exception) -> PushedAuthorizationResponse:
+    """Handle errors during pushed authorization requests."""
+    if isinstance(e, httpx.RequestError):
+        error_msg = f"Network error during PAR: {e!s}"
+        logger.error(error_msg, exc_info=True)
+        return PushedAuthorizationResponse(
+            is_successful=False, error=error_msg
+        )
+
+    error_msg = f"Unexpected error during PAR: {e!s}"
+    logger.error(error_msg, exc_info=True)
+    return PushedAuthorizationResponse(is_successful=False, error=error_msg)
+
+
 def handle_userinfo_error(e: Exception) -> UserInfoResponse:
     """
     Handle errors during UserInfo requests.
@@ -216,6 +231,7 @@ __all__ = [
     "handle_discovery_error",
     "handle_introspection_error",
     "handle_jwks_error",
+    "handle_par_error",
     "handle_revocation_error",
     "handle_token_error",
     "handle_userinfo_error",

--- a/src/py_identity_model/core/models.py
+++ b/src/py_identity_model/core/models.py
@@ -699,6 +699,58 @@ class TokenIntrospectionResponse(BaseResponse):
 
 
 # ============================================================================
+# Pushed Authorization Request Models - RFC 9126
+# ============================================================================
+
+
+@dataclass
+class PushedAuthorizationRequest(BaseRequest):
+    """Request for OAuth 2.0 Pushed Authorization Request (RFC 9126).
+
+    Pushes authorization parameters to the PAR endpoint and receives
+    a ``request_uri`` for use in the authorization URL.
+
+    Attributes:
+        address: The pushed authorization request endpoint URL.
+        client_id: The client identifier.
+        redirect_uri: The registered redirect URI.
+        scope: Space-delimited scopes (default ``"openid"``).
+        response_type: OAuth 2.0 response type (default ``"code"``).
+        state: CSRF protection value.
+        nonce: OpenID Connect nonce.
+        code_challenge: PKCE code challenge.
+        code_challenge_method: PKCE method (``"S256"`` or ``"plain"``).
+        client_secret: Client secret (optional for public clients).
+    """
+
+    client_id: str
+    redirect_uri: str
+    scope: str = "openid"
+    response_type: str = "code"
+    state: str | None = None
+    nonce: str | None = None
+    code_challenge: str | None = None
+    code_challenge_method: str | None = None
+    client_secret: str | None = None
+
+
+@dataclass
+class PushedAuthorizationResponse(BaseResponse):
+    """Response from a pushed authorization request endpoint (RFC 9126).
+
+    Check ``is_successful`` before accessing ``request_uri``.
+    Use ``request_uri`` in the authorization URL instead of inline parameters.
+    """
+
+    _guarded_fields: ClassVar[frozenset[str]] = frozenset(
+        {"request_uri", "expires_in"}
+    )
+
+    request_uri: str | None = None
+    expires_in: int | None = None
+
+
+# ============================================================================
 # Token Revocation Models - RFC 7009
 # ============================================================================
 
@@ -842,6 +894,9 @@ __all__ = [
     "JsonWebKeyParameterNames",
     "JwksRequest",
     "JwksResponse",
+    # Pushed Authorization Request
+    "PushedAuthorizationRequest",
+    "PushedAuthorizationResponse",
     # Refresh Token
     "RefreshTokenRequest",
     "RefreshTokenResponse",

--- a/src/py_identity_model/core/par_logic.py
+++ b/src/py_identity_model/core/par_logic.py
@@ -4,11 +4,12 @@ Pushed Authorization Request (PAR) business logic per RFC 9126.
 Pure functions for preparing PAR requests and processing responses.
 """
 
+import json
+
 import httpx
 
 from ..logging_config import logger
 from ..logging_utils import redact_url
-from .error_handlers import handle_par_error
 from .models import PushedAuthorizationRequest, PushedAuthorizationResponse
 
 
@@ -28,9 +29,7 @@ def prepare_par_request_data(
     Returns:
         ``(data, headers, auth)`` where *auth* is ``None`` for public clients.
     """
-    if (request.code_challenge is None) != (
-        request.code_challenge_method is None
-    ):
+    if bool(request.code_challenge) != bool(request.code_challenge_method):
         raise ValueError(
             "code_challenge and code_challenge_method must both be set or both be absent"
         )
@@ -40,19 +39,19 @@ def prepare_par_request_data(
         "scope": request.scope,
         "response_type": request.response_type,
     }
-    if request.state is not None:
+    if request.state:
         params["state"] = request.state
-    if request.nonce is not None:
+    if request.nonce:
         params["nonce"] = request.nonce
-    if request.code_challenge is not None:
+    if request.code_challenge:
         params["code_challenge"] = request.code_challenge
-    if request.code_challenge_method is not None:
+    if request.code_challenge_method:
         params["code_challenge_method"] = request.code_challenge_method
 
     headers = {"Content-Type": "application/x-www-form-urlencoded"}
 
     auth: tuple[str, str] | None = None
-    if request.client_secret is not None:
+    if request.client_secret:
         auth = (request.client_id, request.client_secret)
     else:
         params["client_id"] = request.client_id
@@ -67,15 +66,23 @@ def process_par_response(
     logger.debug(f"PAR response status: {response.status_code}")
 
     if response.is_success:
-        data = response.json()
+        try:
+            data = response.json()
+        except (json.JSONDecodeError, ValueError):
+            error_msg = "PAR response has invalid JSON body"
+            logger.error(error_msg)
+            return PushedAuthorizationResponse(
+                is_successful=False, error=error_msg
+            )
         request_uri = data.get("request_uri")
         expires_in = data.get("expires_in")
-        if not request_uri or expires_in is None:
-            missing = []
-            if not request_uri:
-                missing.append("request_uri")
-            if expires_in is None:
-                missing.append("expires_in")
+
+        missing: list[str] = []
+        if not request_uri:
+            missing.append("request_uri")
+        if not isinstance(expires_in, int) or expires_in <= 0:
+            missing.append("expires_in")
+        if missing:
             error_msg = (
                 f"PAR response missing required fields per RFC 9126 "
                 f"Section 2.2: {', '.join(missing)}"
@@ -93,13 +100,12 @@ def process_par_response(
 
     error_msg = (
         f"Pushed authorization request failed with status code: "
-        f"{response.status_code}. Response Content: {response.content}"
+        f"{response.status_code}. Response Content: {response.text}"
     )
     return PushedAuthorizationResponse(is_successful=False, error=error_msg)
 
 
 __all__ = [
-    "handle_par_error",
     "log_par_request",
     "prepare_par_request_data",
     "process_par_response",

--- a/src/py_identity_model/core/par_logic.py
+++ b/src/py_identity_model/core/par_logic.py
@@ -8,6 +8,7 @@ import httpx
 
 from ..logging_config import logger
 from ..logging_utils import redact_url
+from .error_handlers import handle_par_error
 from .models import PushedAuthorizationRequest, PushedAuthorizationResponse
 
 
@@ -27,8 +28,14 @@ def prepare_par_request_data(
     Returns:
         ``(data, headers, auth)`` where *auth* is ``None`` for public clients.
     """
+    if (request.code_challenge is None) != (
+        request.code_challenge_method is None
+    ):
+        raise ValueError(
+            "code_challenge and code_challenge_method must both be set or both be absent"
+        )
+
     params: dict[str, str] = {
-        "client_id": request.client_id,
         "redirect_uri": request.redirect_uri,
         "scope": request.scope,
         "response_type": request.response_type,
@@ -47,6 +54,8 @@ def prepare_par_request_data(
     auth: tuple[str, str] | None = None
     if request.client_secret is not None:
         auth = (request.client_id, request.client_secret)
+    else:
+        params["client_id"] = request.client_id
 
     return params, headers, auth
 
@@ -59,31 +68,33 @@ def process_par_response(
 
     if response.is_success:
         data = response.json()
+        request_uri = data.get("request_uri")
+        expires_in = data.get("expires_in")
+        if not request_uri or expires_in is None:
+            missing = []
+            if not request_uri:
+                missing.append("request_uri")
+            if expires_in is None:
+                missing.append("expires_in")
+            error_msg = (
+                f"PAR response missing required fields per RFC 9126 "
+                f"Section 2.2: {', '.join(missing)}"
+            )
+            logger.error(error_msg)
+            return PushedAuthorizationResponse(
+                is_successful=False, error=error_msg
+            )
         logger.info("Pushed authorization request successful")
         return PushedAuthorizationResponse(
             is_successful=True,
-            request_uri=data.get("request_uri"),
-            expires_in=data.get("expires_in"),
+            request_uri=request_uri,
+            expires_in=expires_in,
         )
 
     error_msg = (
         f"Pushed authorization request failed with status code: "
         f"{response.status_code}. Response Content: {response.content}"
     )
-    return PushedAuthorizationResponse(is_successful=False, error=error_msg)
-
-
-def handle_par_error(e: Exception) -> PushedAuthorizationResponse:
-    """Handle errors during pushed authorization requests."""
-    if isinstance(e, httpx.RequestError):
-        error_msg = f"Network error during PAR: {e!s}"
-        logger.error(error_msg, exc_info=True)
-        return PushedAuthorizationResponse(
-            is_successful=False, error=error_msg
-        )
-
-    error_msg = f"Unexpected error during PAR: {e!s}"
-    logger.error(error_msg, exc_info=True)
     return PushedAuthorizationResponse(is_successful=False, error=error_msg)
 
 

--- a/src/py_identity_model/core/par_logic.py
+++ b/src/py_identity_model/core/par_logic.py
@@ -1,0 +1,95 @@
+"""
+Pushed Authorization Request (PAR) business logic per RFC 9126.
+
+Pure functions for preparing PAR requests and processing responses.
+"""
+
+import httpx
+
+from ..logging_config import logger
+from ..logging_utils import redact_url
+from .models import PushedAuthorizationRequest, PushedAuthorizationResponse
+
+
+def log_par_request(request: PushedAuthorizationRequest) -> None:
+    """Log pushed authorization request."""
+    logger.info(
+        f"Pushing authorization request to {redact_url(request.address)}"
+    )
+    logger.debug(f"Client ID: {request.client_id}")
+
+
+def prepare_par_request_data(
+    request: PushedAuthorizationRequest,
+) -> tuple[dict, dict, tuple[str, str] | None]:
+    """Prepare request data, headers, and optional auth for PAR.
+
+    Returns:
+        ``(data, headers, auth)`` where *auth* is ``None`` for public clients.
+    """
+    params: dict[str, str] = {
+        "client_id": request.client_id,
+        "redirect_uri": request.redirect_uri,
+        "scope": request.scope,
+        "response_type": request.response_type,
+    }
+    if request.state is not None:
+        params["state"] = request.state
+    if request.nonce is not None:
+        params["nonce"] = request.nonce
+    if request.code_challenge is not None:
+        params["code_challenge"] = request.code_challenge
+    if request.code_challenge_method is not None:
+        params["code_challenge_method"] = request.code_challenge_method
+
+    headers = {"Content-Type": "application/x-www-form-urlencoded"}
+
+    auth: tuple[str, str] | None = None
+    if request.client_secret is not None:
+        auth = (request.client_id, request.client_secret)
+
+    return params, headers, auth
+
+
+def process_par_response(
+    response: httpx.Response,
+) -> PushedAuthorizationResponse:
+    """Process PAR HTTP response."""
+    logger.debug(f"PAR response status: {response.status_code}")
+
+    if response.is_success:
+        data = response.json()
+        logger.info("Pushed authorization request successful")
+        return PushedAuthorizationResponse(
+            is_successful=True,
+            request_uri=data.get("request_uri"),
+            expires_in=data.get("expires_in"),
+        )
+
+    error_msg = (
+        f"Pushed authorization request failed with status code: "
+        f"{response.status_code}. Response Content: {response.content}"
+    )
+    return PushedAuthorizationResponse(is_successful=False, error=error_msg)
+
+
+def handle_par_error(e: Exception) -> PushedAuthorizationResponse:
+    """Handle errors during pushed authorization requests."""
+    if isinstance(e, httpx.RequestError):
+        error_msg = f"Network error during PAR: {e!s}"
+        logger.error(error_msg, exc_info=True)
+        return PushedAuthorizationResponse(
+            is_successful=False, error=error_msg
+        )
+
+    error_msg = f"Unexpected error during PAR: {e!s}"
+    logger.error(error_msg, exc_info=True)
+    return PushedAuthorizationResponse(is_successful=False, error=error_msg)
+
+
+__all__ = [
+    "handle_par_error",
+    "log_par_request",
+    "prepare_par_request_data",
+    "process_par_response",
+]

--- a/src/py_identity_model/sync/__init__.py
+++ b/src/py_identity_model/sync/__init__.py
@@ -43,6 +43,11 @@ from .jwks import (
     jwks_from_dict,
 )
 from .managed_client import HTTPClient
+from .par import (
+    PushedAuthorizationRequest,
+    PushedAuthorizationResponse,
+    push_authorization_request,
+)
 from .revocation import (
     TokenRevocationRequest,
     TokenRevocationResponse,
@@ -89,6 +94,9 @@ __all__ = [
     "JsonWebKeyParameterNames",
     "JwksRequest",
     "JwksResponse",
+    # PAR
+    "PushedAuthorizationRequest",
+    "PushedAuthorizationResponse",
     # Refresh Token
     "RefreshTokenRequest",
     "RefreshTokenResponse",
@@ -118,6 +126,7 @@ __all__ = [
     "introspect_token",
     "jwks_from_dict",
     "parse_authorize_callback_response",
+    "push_authorization_request",
     "refresh_token",
     "request_authorization_code_token",
     "request_client_credentials_token",

--- a/src/py_identity_model/sync/par.py
+++ b/src/py_identity_model/sync/par.py
@@ -2,12 +2,14 @@
 Pushed Authorization Requests (synchronous implementation, RFC 9126).
 """
 
+import httpx
+
+from ..core.error_handlers import handle_par_error
 from ..core.models import (
     PushedAuthorizationRequest,
     PushedAuthorizationResponse,
 )
 from ..core.par_logic import (
-    handle_par_error,
     log_par_request,
     prepare_par_request_data,
     process_par_response,
@@ -17,7 +19,13 @@ from .managed_client import HTTPClient
 
 
 @retry_with_backoff()
-def _push_authorization_request(client, url, data, headers, auth=None):
+def _push_authorization_request(
+    client: httpx.Client,
+    url: str,
+    data: dict,
+    headers: dict,
+    auth: tuple[str, str] | None = None,
+) -> httpx.Response:
     """Make PAR request with retry logic."""
     kwargs: dict = {"data": data, "headers": headers}
     if auth is not None:
@@ -39,10 +47,10 @@ def push_authorization_request(
         PushedAuthorizationResponse with ``request_uri`` and ``expires_in``.
     """
     log_par_request(request)
-    params, headers, auth = prepare_par_request_data(request)
 
     response = None
     try:
+        params, headers, auth = prepare_par_request_data(request)
         client = http_client.client if http_client else get_http_client()
         response = _push_authorization_request(
             client, request.address, params, headers, auth

--- a/src/py_identity_model/sync/par.py
+++ b/src/py_identity_model/sync/par.py
@@ -41,16 +41,18 @@ def push_authorization_request(
     log_par_request(request)
     params, headers, auth = prepare_par_request_data(request)
 
+    response = None
     try:
         client = http_client.client if http_client else get_http_client()
         response = _push_authorization_request(
             client, request.address, params, headers, auth
         )
-        result = process_par_response(response)
-        response.close()
-        return result
+        return process_par_response(response)
     except Exception as e:
         return handle_par_error(e)
+    finally:
+        if response is not None:
+            response.close()
 
 
 __all__ = [

--- a/src/py_identity_model/sync/par.py
+++ b/src/py_identity_model/sync/par.py
@@ -1,0 +1,60 @@
+"""
+Pushed Authorization Requests (synchronous implementation, RFC 9126).
+"""
+
+from ..core.models import (
+    PushedAuthorizationRequest,
+    PushedAuthorizationResponse,
+)
+from ..core.par_logic import (
+    handle_par_error,
+    log_par_request,
+    prepare_par_request_data,
+    process_par_response,
+)
+from .http_client import get_http_client, retry_with_backoff
+from .managed_client import HTTPClient
+
+
+@retry_with_backoff()
+def _push_authorization_request(client, url, data, headers, auth=None):
+    """Make PAR request with retry logic."""
+    kwargs: dict = {"data": data, "headers": headers}
+    if auth is not None:
+        kwargs["auth"] = auth
+    return client.post(url, **kwargs)
+
+
+def push_authorization_request(
+    request: PushedAuthorizationRequest,
+    http_client: HTTPClient | None = None,
+) -> PushedAuthorizationResponse:
+    """Push authorization parameters to the PAR endpoint (RFC 9126).
+
+    Args:
+        request: PAR request with authorization parameters.
+        http_client: Optional managed HTTP client.
+
+    Returns:
+        PushedAuthorizationResponse with ``request_uri`` and ``expires_in``.
+    """
+    log_par_request(request)
+    params, headers, auth = prepare_par_request_data(request)
+
+    try:
+        client = http_client.client if http_client else get_http_client()
+        response = _push_authorization_request(
+            client, request.address, params, headers, auth
+        )
+        result = process_par_response(response)
+        response.close()
+        return result
+    except Exception as e:
+        return handle_par_error(e)
+
+
+__all__ = [
+    "PushedAuthorizationRequest",
+    "PushedAuthorizationResponse",
+    "push_authorization_request",
+]

--- a/src/tests/integration/test_par.py
+++ b/src/tests/integration/test_par.py
@@ -1,0 +1,31 @@
+"""Integration tests for Pushed Authorization Requests (RFC 9126)."""
+
+import pytest
+
+from py_identity_model import BaseRequest, PushedAuthorizationRequest
+
+
+@pytest.mark.integration
+class TestPARIntegration:
+    def test_request_model_inherits_base(self):
+        req = PushedAuthorizationRequest(
+            address="https://auth.example.com/par",
+            client_id="app",
+            redirect_uri="https://app.com/cb",
+        )
+        assert isinstance(req, BaseRequest)
+
+    def test_request_with_all_params(self):
+        req = PushedAuthorizationRequest(
+            address="https://auth.example.com/par",
+            client_id="app",
+            redirect_uri="https://app.com/cb",
+            scope="openid profile",
+            state="csrf",
+            nonce="nonce",
+            code_challenge="challenge",
+            code_challenge_method="S256",
+            client_secret="secret",
+        )
+        assert req.scope == "openid profile"
+        assert req.code_challenge_method == "S256"

--- a/src/tests/unit/test_aio_par.py
+++ b/src/tests/unit/test_aio_par.py
@@ -5,6 +5,7 @@ import pytest
 import respx
 
 from py_identity_model import (
+    BaseRequest,
     BaseResponse,
     PushedAuthorizationRequest,
     PushedAuthorizationResponse,
@@ -72,6 +73,12 @@ class TestAsyncPAR:
             )
         )
         assert response.is_successful is False
+
+    async def test_request_inherits_base(self):
+        req = PushedAuthorizationRequest(
+            address=PAR_URL, client_id="app", redirect_uri="https://app.com/cb"
+        )
+        assert isinstance(req, BaseRequest)
 
     @respx.mock
     async def test_confidential_client_uses_basic_auth_not_body(self):
@@ -151,17 +158,26 @@ class TestAsyncPAR:
         assert response.error is not None
         assert "expires_in" in response.error
 
+    @respx.mock
     async def test_pkce_requires_both_challenge_and_method(self):
-        """S4: code_challenge and code_challenge_method must be paired."""
-        with pytest.raises(ValueError, match="code_challenge"):
-            await push_authorization_request(
-                PushedAuthorizationRequest(
-                    address=PAR_URL,
-                    client_id="app1",
-                    redirect_uri="https://app.com/cb",
-                    code_challenge="challenge",
-                )
+        """S4: code_challenge and code_challenge_method must be paired.
+
+        ValueError is caught by error handler — returns error response.
+        """
+        respx.post(PAR_URL).mock(
+            return_value=httpx.Response(201, json=PAR_RESPONSE)
+        )
+        response = await push_authorization_request(
+            PushedAuthorizationRequest(
+                address=PAR_URL,
+                client_id="app1",
+                redirect_uri="https://app.com/cb",
+                code_challenge="challenge",
             )
+        )
+        assert response.is_successful is False
+        assert response.error is not None
+        assert "code_challenge" in response.error
 
     @respx.mock
     async def test_network_error(self):
@@ -205,3 +221,188 @@ class TestAsyncPAR:
             request.headers["content-type"]
             == "application/x-www-form-urlencoded"
         )
+
+    @respx.mock
+    async def test_empty_client_secret_treated_as_public(self):
+        """client_secret='' is treated as absent (public client)."""
+        route = respx.post(PAR_URL).mock(
+            return_value=httpx.Response(201, json=PAR_RESPONSE)
+        )
+        await push_authorization_request(
+            PushedAuthorizationRequest(
+                address=PAR_URL,
+                client_id="app1",
+                redirect_uri="https://app.com/cb",
+                client_secret="",
+            )
+        )
+        request = route.calls[0].request
+        assert request.headers.get("authorization") is None
+        assert "client_id=app1" in request.content.decode()
+
+    @respx.mock
+    async def test_empty_state_not_sent(self):
+        """state='' is not sent as form param."""
+        route = respx.post(PAR_URL).mock(
+            return_value=httpx.Response(201, json=PAR_RESPONSE)
+        )
+        await push_authorization_request(
+            PushedAuthorizationRequest(
+                address=PAR_URL,
+                client_id="app1",
+                redirect_uri="https://app.com/cb",
+                state="",
+            )
+        )
+        body = route.calls[0].request.content.decode()
+        assert "state=" not in body
+
+    @respx.mock
+    async def test_empty_nonce_not_sent(self):
+        """nonce='' is not sent as form param."""
+        route = respx.post(PAR_URL).mock(
+            return_value=httpx.Response(201, json=PAR_RESPONSE)
+        )
+        await push_authorization_request(
+            PushedAuthorizationRequest(
+                address=PAR_URL,
+                client_id="app1",
+                redirect_uri="https://app.com/cb",
+                nonce="",
+            )
+        )
+        body = route.calls[0].request.content.decode()
+        assert "nonce=" not in body
+
+    @respx.mock
+    async def test_pkce_empty_string_treated_as_absent(self):
+        """Empty code_challenge/code_challenge_method treated as absent."""
+        route = respx.post(PAR_URL).mock(
+            return_value=httpx.Response(201, json=PAR_RESPONSE)
+        )
+        response = await push_authorization_request(
+            PushedAuthorizationRequest(
+                address=PAR_URL,
+                client_id="app1",
+                redirect_uri="https://app.com/cb",
+                code_challenge="",
+                code_challenge_method="",
+            )
+        )
+        assert response.is_successful is True
+        body = route.calls[0].request.content.decode()
+        assert "code_challenge" not in body
+
+    @respx.mock
+    async def test_expires_in_string_returns_error(self):
+        """expires_in must be a positive integer per RFC 9126 §2.2."""
+        respx.post(PAR_URL).mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    "request_uri": "urn:ietf:params:oauth:request_uri:abc",
+                    "expires_in": "60",
+                },
+            )
+        )
+        response = await push_authorization_request(
+            PushedAuthorizationRequest(
+                address=PAR_URL,
+                client_id="app1",
+                redirect_uri="https://app.com/cb",
+                client_secret="secret",
+            )
+        )
+        assert response.is_successful is False
+        assert response.error is not None
+        assert "expires_in" in response.error
+
+    @respx.mock
+    async def test_expires_in_zero_returns_error(self):
+        """expires_in=0 is invalid (zero-second expiry)."""
+        respx.post(PAR_URL).mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    "request_uri": "urn:ietf:params:oauth:request_uri:abc",
+                    "expires_in": 0,
+                },
+            )
+        )
+        response = await push_authorization_request(
+            PushedAuthorizationRequest(
+                address=PAR_URL,
+                client_id="app1",
+                redirect_uri="https://app.com/cb",
+                client_secret="secret",
+            )
+        )
+        assert response.is_successful is False
+        assert response.error is not None
+        assert "expires_in" in response.error
+
+    @respx.mock
+    async def test_expires_in_negative_returns_error(self):
+        """expires_in=-1 is invalid."""
+        respx.post(PAR_URL).mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    "request_uri": "urn:ietf:params:oauth:request_uri:abc",
+                    "expires_in": -1,
+                },
+            )
+        )
+        response = await push_authorization_request(
+            PushedAuthorizationRequest(
+                address=PAR_URL,
+                client_id="app1",
+                redirect_uri="https://app.com/cb",
+                client_secret="secret",
+            )
+        )
+        assert response.is_successful is False
+        assert response.error is not None
+        assert "expires_in" in response.error
+
+    @respx.mock
+    async def test_non_json_success_response(self):
+        """2xx with non-JSON body returns error instead of crashing."""
+        respx.post(PAR_URL).mock(
+            return_value=httpx.Response(
+                201,
+                content=b"<html>OK</html>",
+                headers={"content-type": "text/html"},
+            )
+        )
+        response = await push_authorization_request(
+            PushedAuthorizationRequest(
+                address=PAR_URL,
+                client_id="app1",
+                redirect_uri="https://app.com/cb",
+                client_secret="secret",
+            )
+        )
+        assert response.is_successful is False
+        assert response.error is not None
+        assert "invalid JSON" in response.error
+
+    @respx.mock
+    async def test_error_response_uses_text_not_bytes(self):
+        """Error messages use response.text, not response.content (bytes)."""
+        respx.post(PAR_URL).mock(
+            return_value=httpx.Response(
+                400, content=b'{"error":"invalid_request"}'
+            )
+        )
+        response = await push_authorization_request(
+            PushedAuthorizationRequest(
+                address=PAR_URL,
+                client_id="app1",
+                redirect_uri="https://app.com/cb",
+                client_secret="secret",
+            )
+        )
+        assert response.is_successful is False
+        assert response.error is not None
+        assert "b'" not in response.error

--- a/src/tests/unit/test_aio_par.py
+++ b/src/tests/unit/test_aio_par.py
@@ -1,16 +1,15 @@
-"""Unit tests for Pushed Authorization Requests (RFC 9126)."""
+"""Async tests for aio.par module (NFR-9 parity)."""
 
 import httpx
 import pytest
 import respx
 
 from py_identity_model import (
-    BaseRequest,
     BaseResponse,
     PushedAuthorizationRequest,
     PushedAuthorizationResponse,
 )
-from py_identity_model.sync.par import push_authorization_request
+from py_identity_model.aio.par import push_authorization_request
 
 
 PAR_URL = "https://auth.example.com/par"
@@ -20,14 +19,14 @@ PAR_RESPONSE = {
 }
 
 
-@pytest.mark.unit
-class TestPAR:
+@pytest.mark.asyncio
+class TestAsyncPAR:
     @respx.mock
-    def test_successful_par(self):
+    async def test_successful_par(self):
         respx.post(PAR_URL).mock(
             return_value=httpx.Response(201, json=PAR_RESPONSE)
         )
-        response = push_authorization_request(
+        response = await push_authorization_request(
             PushedAuthorizationRequest(
                 address=PAR_URL,
                 client_id="app1",
@@ -42,11 +41,11 @@ class TestPAR:
         assert response.expires_in == 60
 
     @respx.mock
-    def test_par_with_pkce(self):
+    async def test_par_with_pkce(self):
         respx.post(PAR_URL).mock(
             return_value=httpx.Response(201, json=PAR_RESPONSE)
         )
-        response = push_authorization_request(
+        response = await push_authorization_request(
             PushedAuthorizationRequest(
                 address=PAR_URL,
                 client_id="app1",
@@ -58,13 +57,13 @@ class TestPAR:
         assert response.is_successful is True
 
     @respx.mock
-    def test_par_error(self):
+    async def test_par_error(self):
         respx.post(PAR_URL).mock(
             return_value=httpx.Response(
                 400, content=b'{"error":"invalid_request"}'
             )
         )
-        response = push_authorization_request(
+        response = await push_authorization_request(
             PushedAuthorizationRequest(
                 address=PAR_URL,
                 client_id="app1",
@@ -74,19 +73,13 @@ class TestPAR:
         )
         assert response.is_successful is False
 
-    def test_request_inherits_base(self):
-        req = PushedAuthorizationRequest(
-            address=PAR_URL, client_id="app", redirect_uri="https://app.com/cb"
-        )
-        assert isinstance(req, BaseRequest)
-
     @respx.mock
-    def test_confidential_client_uses_basic_auth_not_body(self):
+    async def test_confidential_client_uses_basic_auth_not_body(self):
         """M1: client_id must NOT appear in body when using Basic Auth."""
         route = respx.post(PAR_URL).mock(
             return_value=httpx.Response(201, json=PAR_RESPONSE)
         )
-        push_authorization_request(
+        await push_authorization_request(
             PushedAuthorizationRequest(
                 address=PAR_URL,
                 client_id="app1",
@@ -100,12 +93,12 @@ class TestPAR:
         assert "client_id" not in request.content.decode()
 
     @respx.mock
-    def test_public_client_sends_client_id_in_body(self):
+    async def test_public_client_sends_client_id_in_body(self):
         """M1: public clients send client_id in POST body, no Basic Auth."""
         route = respx.post(PAR_URL).mock(
             return_value=httpx.Response(201, json=PAR_RESPONSE)
         )
-        push_authorization_request(
+        await push_authorization_request(
             PushedAuthorizationRequest(
                 address=PAR_URL,
                 client_id="public_app",
@@ -118,12 +111,12 @@ class TestPAR:
         assert request.headers.get("authorization") is None
 
     @respx.mock
-    def test_missing_request_uri_returns_error(self):
+    async def test_missing_request_uri_returns_error(self):
         """M2: Missing request_uri in successful response fails per RFC 9126 §2.2."""
         respx.post(PAR_URL).mock(
             return_value=httpx.Response(201, json={"expires_in": 60})
         )
-        response = push_authorization_request(
+        response = await push_authorization_request(
             PushedAuthorizationRequest(
                 address=PAR_URL,
                 client_id="app1",
@@ -136,7 +129,7 @@ class TestPAR:
         assert "request_uri" in response.error
 
     @respx.mock
-    def test_missing_expires_in_returns_error(self):
+    async def test_missing_expires_in_returns_error(self):
         """M2: Missing expires_in in successful response fails per RFC 9126 §2.2."""
         respx.post(PAR_URL).mock(
             return_value=httpx.Response(
@@ -146,7 +139,7 @@ class TestPAR:
                 },
             )
         )
-        response = push_authorization_request(
+        response = await push_authorization_request(
             PushedAuthorizationRequest(
                 address=PAR_URL,
                 client_id="app1",
@@ -158,11 +151,10 @@ class TestPAR:
         assert response.error is not None
         assert "expires_in" in response.error
 
-    @respx.mock
-    def test_pkce_requires_both_challenge_and_method(self):
+    async def test_pkce_requires_both_challenge_and_method(self):
         """S4: code_challenge and code_challenge_method must be paired."""
         with pytest.raises(ValueError, match="code_challenge"):
-            push_authorization_request(
+            await push_authorization_request(
                 PushedAuthorizationRequest(
                     address=PAR_URL,
                     client_id="app1",
@@ -172,11 +164,11 @@ class TestPAR:
             )
 
     @respx.mock
-    def test_network_error(self):
+    async def test_network_error(self):
         respx.post(PAR_URL).mock(
             side_effect=httpx.ConnectError("Connection refused")
         )
-        response = push_authorization_request(
+        response = await push_authorization_request(
             PushedAuthorizationRequest(
                 address=PAR_URL,
                 client_id="app1",
@@ -188,8 +180,28 @@ class TestPAR:
         assert response.error is not None
         assert "Connection refused" in response.error
 
-    def test_response_inherits_base(self):
+    async def test_response_inherits_base(self):
         resp = PushedAuthorizationResponse(
             is_successful=True, request_uri="urn:...", expires_in=60
         )
         assert isinstance(resp, BaseResponse)
+
+    @respx.mock
+    async def test_content_type_header(self):
+        """RFC 9126: PAR uses form-urlencoded content type."""
+        route = respx.post(PAR_URL).mock(
+            return_value=httpx.Response(201, json=PAR_RESPONSE)
+        )
+        await push_authorization_request(
+            PushedAuthorizationRequest(
+                address=PAR_URL,
+                client_id="app1",
+                redirect_uri="https://app.com/cb",
+                client_secret="secret",
+            )
+        )
+        request = route.calls[0].request
+        assert (
+            request.headers["content-type"]
+            == "application/x-www-form-urlencoded"
+        )

--- a/src/tests/unit/test_par.py
+++ b/src/tests/unit/test_par.py
@@ -160,16 +160,24 @@ class TestPAR:
 
     @respx.mock
     def test_pkce_requires_both_challenge_and_method(self):
-        """S4: code_challenge and code_challenge_method must be paired."""
-        with pytest.raises(ValueError, match="code_challenge"):
-            push_authorization_request(
-                PushedAuthorizationRequest(
-                    address=PAR_URL,
-                    client_id="app1",
-                    redirect_uri="https://app.com/cb",
-                    code_challenge="challenge",
-                )
+        """S4: code_challenge and code_challenge_method must be paired.
+
+        ValueError is caught by error handler — returns error response.
+        """
+        respx.post(PAR_URL).mock(
+            return_value=httpx.Response(201, json=PAR_RESPONSE)
+        )
+        response = push_authorization_request(
+            PushedAuthorizationRequest(
+                address=PAR_URL,
+                client_id="app1",
+                redirect_uri="https://app.com/cb",
+                code_challenge="challenge",
             )
+        )
+        assert response.is_successful is False
+        assert response.error is not None
+        assert "code_challenge" in response.error
 
     @respx.mock
     def test_network_error(self):
@@ -193,3 +201,208 @@ class TestPAR:
             is_successful=True, request_uri="urn:...", expires_in=60
         )
         assert isinstance(resp, BaseResponse)
+
+    @respx.mock
+    def test_content_type_header(self):
+        """RFC 9126: PAR uses form-urlencoded content type."""
+        route = respx.post(PAR_URL).mock(
+            return_value=httpx.Response(201, json=PAR_RESPONSE)
+        )
+        push_authorization_request(
+            PushedAuthorizationRequest(
+                address=PAR_URL,
+                client_id="app1",
+                redirect_uri="https://app.com/cb",
+                client_secret="secret",
+            )
+        )
+        request = route.calls[0].request
+        assert (
+            request.headers["content-type"]
+            == "application/x-www-form-urlencoded"
+        )
+
+    @respx.mock
+    def test_empty_client_secret_treated_as_public(self):
+        """client_secret='' is treated as absent (public client)."""
+        route = respx.post(PAR_URL).mock(
+            return_value=httpx.Response(201, json=PAR_RESPONSE)
+        )
+        push_authorization_request(
+            PushedAuthorizationRequest(
+                address=PAR_URL,
+                client_id="app1",
+                redirect_uri="https://app.com/cb",
+                client_secret="",
+            )
+        )
+        request = route.calls[0].request
+        assert request.headers.get("authorization") is None
+        assert "client_id=app1" in request.content.decode()
+
+    @respx.mock
+    def test_empty_state_not_sent(self):
+        """state='' is not sent as form param."""
+        route = respx.post(PAR_URL).mock(
+            return_value=httpx.Response(201, json=PAR_RESPONSE)
+        )
+        push_authorization_request(
+            PushedAuthorizationRequest(
+                address=PAR_URL,
+                client_id="app1",
+                redirect_uri="https://app.com/cb",
+                state="",
+            )
+        )
+        body = route.calls[0].request.content.decode()
+        assert "state=" not in body
+
+    @respx.mock
+    def test_empty_nonce_not_sent(self):
+        """nonce='' is not sent as form param."""
+        route = respx.post(PAR_URL).mock(
+            return_value=httpx.Response(201, json=PAR_RESPONSE)
+        )
+        push_authorization_request(
+            PushedAuthorizationRequest(
+                address=PAR_URL,
+                client_id="app1",
+                redirect_uri="https://app.com/cb",
+                nonce="",
+            )
+        )
+        body = route.calls[0].request.content.decode()
+        assert "nonce=" not in body
+
+    @respx.mock
+    def test_pkce_empty_string_treated_as_absent(self):
+        """Empty code_challenge/code_challenge_method treated as absent."""
+        route = respx.post(PAR_URL).mock(
+            return_value=httpx.Response(201, json=PAR_RESPONSE)
+        )
+        response = push_authorization_request(
+            PushedAuthorizationRequest(
+                address=PAR_URL,
+                client_id="app1",
+                redirect_uri="https://app.com/cb",
+                code_challenge="",
+                code_challenge_method="",
+            )
+        )
+        assert response.is_successful is True
+        body = route.calls[0].request.content.decode()
+        assert "code_challenge" not in body
+
+    @respx.mock
+    def test_expires_in_string_returns_error(self):
+        """expires_in must be a positive integer per RFC 9126 §2.2."""
+        respx.post(PAR_URL).mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    "request_uri": "urn:ietf:params:oauth:request_uri:abc",
+                    "expires_in": "60",
+                },
+            )
+        )
+        response = push_authorization_request(
+            PushedAuthorizationRequest(
+                address=PAR_URL,
+                client_id="app1",
+                redirect_uri="https://app.com/cb",
+                client_secret="secret",
+            )
+        )
+        assert response.is_successful is False
+        assert response.error is not None
+        assert "expires_in" in response.error
+
+    @respx.mock
+    def test_expires_in_zero_returns_error(self):
+        """expires_in=0 is invalid (zero-second expiry)."""
+        respx.post(PAR_URL).mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    "request_uri": "urn:ietf:params:oauth:request_uri:abc",
+                    "expires_in": 0,
+                },
+            )
+        )
+        response = push_authorization_request(
+            PushedAuthorizationRequest(
+                address=PAR_URL,
+                client_id="app1",
+                redirect_uri="https://app.com/cb",
+                client_secret="secret",
+            )
+        )
+        assert response.is_successful is False
+        assert response.error is not None
+        assert "expires_in" in response.error
+
+    @respx.mock
+    def test_expires_in_negative_returns_error(self):
+        """expires_in=-1 is invalid."""
+        respx.post(PAR_URL).mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    "request_uri": "urn:ietf:params:oauth:request_uri:abc",
+                    "expires_in": -1,
+                },
+            )
+        )
+        response = push_authorization_request(
+            PushedAuthorizationRequest(
+                address=PAR_URL,
+                client_id="app1",
+                redirect_uri="https://app.com/cb",
+                client_secret="secret",
+            )
+        )
+        assert response.is_successful is False
+        assert response.error is not None
+        assert "expires_in" in response.error
+
+    @respx.mock
+    def test_non_json_success_response(self):
+        """2xx with non-JSON body returns error instead of crashing."""
+        respx.post(PAR_URL).mock(
+            return_value=httpx.Response(
+                201,
+                content=b"<html>OK</html>",
+                headers={"content-type": "text/html"},
+            )
+        )
+        response = push_authorization_request(
+            PushedAuthorizationRequest(
+                address=PAR_URL,
+                client_id="app1",
+                redirect_uri="https://app.com/cb",
+                client_secret="secret",
+            )
+        )
+        assert response.is_successful is False
+        assert response.error is not None
+        assert "invalid JSON" in response.error
+
+    @respx.mock
+    def test_error_response_uses_text_not_bytes(self):
+        """Error messages use response.text, not response.content (bytes)."""
+        respx.post(PAR_URL).mock(
+            return_value=httpx.Response(
+                400, content=b'{"error":"invalid_request"}'
+            )
+        )
+        response = push_authorization_request(
+            PushedAuthorizationRequest(
+                address=PAR_URL,
+                client_id="app1",
+                redirect_uri="https://app.com/cb",
+                client_secret="secret",
+            )
+        )
+        assert response.is_successful is False
+        assert response.error is not None
+        assert "b'" not in response.error

--- a/src/tests/unit/test_par.py
+++ b/src/tests/unit/test_par.py
@@ -1,0 +1,87 @@
+"""Unit tests for Pushed Authorization Requests (RFC 9126)."""
+
+import httpx
+import pytest
+import respx
+
+from py_identity_model import (
+    BaseRequest,
+    BaseResponse,
+    PushedAuthorizationRequest,
+    PushedAuthorizationResponse,
+)
+from py_identity_model.sync.par import push_authorization_request
+
+
+PAR_URL = "https://auth.example.com/par"
+PAR_RESPONSE = {
+    "request_uri": "urn:ietf:params:oauth:request_uri:abc123",
+    "expires_in": 60,
+}
+
+
+@pytest.mark.unit
+class TestPAR:
+    @respx.mock
+    def test_successful_par(self):
+        respx.post(PAR_URL).mock(
+            return_value=httpx.Response(201, json=PAR_RESPONSE)
+        )
+        response = push_authorization_request(
+            PushedAuthorizationRequest(
+                address=PAR_URL,
+                client_id="app1",
+                redirect_uri="https://app.com/cb",
+                client_secret="secret",
+            )
+        )
+        assert response.is_successful is True
+        assert (
+            response.request_uri == "urn:ietf:params:oauth:request_uri:abc123"
+        )
+        assert response.expires_in == 60
+
+    @respx.mock
+    def test_par_with_pkce(self):
+        respx.post(PAR_URL).mock(
+            return_value=httpx.Response(201, json=PAR_RESPONSE)
+        )
+        response = push_authorization_request(
+            PushedAuthorizationRequest(
+                address=PAR_URL,
+                client_id="app1",
+                redirect_uri="https://app.com/cb",
+                code_challenge="challenge",
+                code_challenge_method="S256",
+            )
+        )
+        assert response.is_successful is True
+
+    @respx.mock
+    def test_par_error(self):
+        respx.post(PAR_URL).mock(
+            return_value=httpx.Response(
+                400, content=b'{"error":"invalid_request"}'
+            )
+        )
+        response = push_authorization_request(
+            PushedAuthorizationRequest(
+                address=PAR_URL,
+                client_id="app1",
+                redirect_uri="https://app.com/cb",
+                client_secret="secret",
+            )
+        )
+        assert response.is_successful is False
+
+    def test_request_inherits_base(self):
+        req = PushedAuthorizationRequest(
+            address=PAR_URL, client_id="app", redirect_uri="https://app.com/cb"
+        )
+        assert isinstance(req, BaseRequest)
+
+    def test_response_inherits_base(self):
+        resp = PushedAuthorizationResponse(
+            is_successful=True, request_uri="urn:...", expires_in=60
+        )
+        assert isinstance(resp, BaseResponse)


### PR DESCRIPTION
## Summary

Implement OAuth 2.0 Pushed Authorization Requests (RFC 9126):

- **`PushedAuthorizationRequest/Response`** models with PKCE, state, nonce support
- **`push_authorization_request()`** sync + async with DI and retry
- Response returns `request_uri` for use in authorization URL + `expires_in`

## Test Plan

- [x] 5 unit tests + 2 integration tests + example + docs
- [x] All tests pass, 90%+ coverage

Automated PR from ralph loop task T41. Closes #95