### PR TITLE
test(perf): add performance benchmarking tests

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -28,7 +28,7 @@ jobs:
         run: make ci-setup
 
       - name: Run tests with coverage
-        run: uv run pytest src/tests -m unit -v -n auto --cov=src/py_identity_model --cov-report=xml --cov-report=term-missing --cov-fail-under=80
+        run: uv run pytest src/tests -m unit -v -n auto --cov=src/py_identity_model --cov-report=xml --cov-report=term-missing --cov-fail-under=80 -p no:benchmark
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ lint:
 
 .PHONY: test
 test:
-	uv run pytest src/tests -v -n auto --cov=src/py_identity_model --cov-report=term-missing --cov-report=html --cov-fail-under=80
+	uv run pytest src/tests -v -n auto --cov=src/py_identity_model --cov-report=term-missing --cov-report=html --cov-fail-under=80 --ignore=src/tests/benchmarks
 
 .PHONY: test-unit
 test-unit:
@@ -44,6 +44,10 @@ test-integration-node-oidc: ## Run integration tests against node-oidc-provider
 .PHONY: generate-token
 generate-token:
 	uv run python examples/generate_token.py
+
+.PHONY: test-benchmark
+test-benchmark:
+	uv run pytest src/tests/benchmarks -v --benchmark-only --benchmark-sort=name
 
 .PHONY: test-examples
 test-examples:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ test:
 
 .PHONY: test-unit
 test-unit:
-	uv run pytest src/tests -m unit -v -n auto --cov=src/py_identity_model --cov-report=term-missing --cov-report=html --cov-fail-under=80 -p no:benchmark
+	uv run pytest src/tests -m unit -v -n auto --cov=src/py_identity_model --cov-report=term-missing --cov-report=html --cov-fail-under=80 --ignore=src/tests/benchmarks -p no:benchmark
 
 .PHONY: test-integration-local
 test-integration-local:

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ lint:
 
 .PHONY: test
 test:
-	uv run pytest src/tests -v -n auto --cov=src/py_identity_model --cov-report=term-missing --cov-report=html --cov-fail-under=80 --ignore=src/tests/benchmarks
+	uv run pytest src/tests -v -n auto --cov=src/py_identity_model --cov-report=term-missing --cov-report=html --cov-fail-under=80 --ignore=src/tests/benchmarks -p no:benchmark
 
 .PHONY: test-unit
 test-unit:

--- a/Makefile
+++ b/Makefile
@@ -17,20 +17,20 @@ test:
 
 .PHONY: test-unit
 test-unit:
-	uv run pytest src/tests -m unit -v -n auto --cov=src/py_identity_model --cov-report=term-missing --cov-report=html --cov-fail-under=80
+	uv run pytest src/tests -m unit -v -n auto --cov=src/py_identity_model --cov-report=term-missing --cov-report=html --cov-fail-under=80 -p no:benchmark
 
 .PHONY: test-integration-local
 test-integration-local:
-	uv run pytest src/tests -m integration --env-file=.env.local -v -n auto
+	uv run pytest src/tests -m integration --env-file=.env.local -v -n auto -p no:benchmark
 
 .PHONY: test-integration-ory
 test-integration-ory:
-	uv run pytest src/tests -m integration -v -n auto
+	uv run pytest src/tests -m integration -v -n auto -p no:benchmark
 
 .PHONY: test-integration-descope
 test-integration-descope:
 	@echo "Running integration tests against Descope..."
-	uv run pytest src/tests -m integration $(if $(wildcard .env.descope),--env-file=.env.descope) -v -n auto
+	uv run pytest src/tests -m integration $(if $(wildcard .env.descope),--env-file=.env.descope) -v -n auto -p no:benchmark
 
 .PHONY: test-integration-node-oidc
 test-integration-node-oidc: ## Run integration tests against node-oidc-provider

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dev = [
     "python-dotenv>=1.0.1,<2",
     "pytest>=8.3.2,<10",
     "pytest-asyncio>=0.24.0",
+    "pytest-benchmark>=5.1.0,<6",
     "pytest-cov>=6.0.0,<8",
     "pytest-xdist>=3.6.1,<4",
     "respx>=0.21.0",
@@ -221,6 +222,7 @@ markers = [
     "integration: marks tests as integration tests (deselect with '-m \"not integration\"')",
     "unit: marks tests as unit tests",
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "benchmark: marks tests as performance benchmarks",
 ]
 # Async test configuration
 asyncio_mode = "auto"

--- a/src/tests/benchmarks/conftest.py
+++ b/src/tests/benchmarks/conftest.py
@@ -1,6 +1,7 @@
 """Fixtures for performance benchmark tests."""
 
 import time
+from types import MappingProxyType
 
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
 from cryptography.hazmat.primitives.serialization import (
@@ -72,7 +73,7 @@ def sample_signed_jwt(ec_private_pem):
         "iss": "https://bench.example.com",
         "sub": "user123",
         "aud": "bench-api",
-        "exp": now + 3600,
+        "exp": now + 86400,
         "iat": now,
         "nbf": now,
     }
@@ -81,12 +82,14 @@ def sample_signed_jwt(ec_private_pem):
 
 @pytest.fixture(scope="session")
 def sample_claims():
-    """Sample claims dict for identity benchmarks."""
-    return {
-        "sub": "user123",
-        "name": "Bench User",
-        "email": "bench@example.com",
-        "roles": ["admin", "user"],
-        "iss": "https://bench.example.com",
-        "aud": "bench-api",
-    }
+    """Sample claims dict for identity benchmarks (frozen to prevent mutation)."""
+    return MappingProxyType(
+        {
+            "sub": "user123",
+            "name": "Bench User",
+            "email": "bench@example.com",
+            "roles": ["admin", "user"],
+            "iss": "https://bench.example.com",
+            "aud": "bench-api",
+        }
+    )

--- a/src/tests/benchmarks/conftest.py
+++ b/src/tests/benchmarks/conftest.py
@@ -1,0 +1,92 @@
+"""Fixtures for performance benchmark tests."""
+
+import time
+
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+    PublicFormat,
+)
+import jwt as pyjwt
+import pytest
+
+
+@pytest.fixture(scope="session")
+def ec_private_key():
+    return ec.generate_private_key(ec.SECP256R1())
+
+
+@pytest.fixture(scope="session")
+def ec_private_pem(ec_private_key):
+    return ec_private_key.private_bytes(
+        Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()
+    )
+
+
+@pytest.fixture(scope="session")
+def ec_public_pem(ec_private_key):
+    return ec_private_key.public_key().public_bytes(
+        Encoding.PEM, PublicFormat.SubjectPublicKeyInfo
+    )
+
+
+@pytest.fixture(scope="session")
+def rsa_private_key():
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+@pytest.fixture(scope="session")
+def rsa_private_pem(rsa_private_key):
+    return rsa_private_key.private_bytes(
+        Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()
+    )
+
+
+@pytest.fixture(scope="session")
+def rsa_public_pem(rsa_private_key):
+    return rsa_private_key.public_key().public_bytes(
+        Encoding.PEM, PublicFormat.SubjectPublicKeyInfo
+    )
+
+
+@pytest.fixture(scope="session")
+def sample_jwk_dict():
+    """A sample RSA JWK dict for parsing benchmarks."""
+    return {
+        "kty": "RSA",
+        "n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+        "e": "AQAB",
+        "alg": "RS256",
+        "kid": "bench-key-1",
+        "use": "sig",
+    }
+
+
+@pytest.fixture(scope="session")
+def sample_signed_jwt(ec_private_pem):
+    """A sample signed JWT for validation benchmarks."""
+    now = int(time.time())
+    claims = {
+        "iss": "https://bench.example.com",
+        "sub": "user123",
+        "aud": "bench-api",
+        "exp": now + 3600,
+        "iat": now,
+        "nbf": now,
+    }
+    return pyjwt.encode(claims, ec_private_pem, algorithm="ES256")
+
+
+@pytest.fixture(scope="session")
+def sample_claims():
+    """Sample claims dict for identity benchmarks."""
+    return {
+        "sub": "user123",
+        "name": "Bench User",
+        "email": "bench@example.com",
+        "roles": ["admin", "user"],
+        "iss": "https://bench.example.com",
+        "aud": "bench-api",
+    }

--- a/src/tests/benchmarks/test_benchmarks.py
+++ b/src/tests/benchmarks/test_benchmarks.py
@@ -133,7 +133,7 @@ def test_bench_validate_fapi_request(benchmark):
 def test_bench_validate_fapi_client(benchmark):
     result = benchmark(
         validate_fapi_client_config,
-        has_client_authentication=True,
+        auth_method="private_key_jwt",
         use_dpop=True,
     )
     assert result is not None

--- a/src/tests/benchmarks/test_benchmarks.py
+++ b/src/tests/benchmarks/test_benchmarks.py
@@ -35,18 +35,22 @@ from py_identity_model.identity import to_principal
 
 @pytest.mark.benchmark(group="pkce")
 def test_bench_generate_pkce_pair(benchmark):
-    benchmark(generate_pkce_pair)
+    result = benchmark(generate_pkce_pair)
+    assert result is not None
+    assert len(result) == 2
 
 
 @pytest.mark.benchmark(group="pkce")
 def test_bench_generate_code_verifier(benchmark):
-    benchmark(generate_code_verifier)
+    result = benchmark(generate_code_verifier)
+    assert isinstance(result, str)
 
 
 @pytest.mark.benchmark(group="pkce")
 def test_bench_generate_code_challenge(benchmark):
     verifier = generate_code_verifier()
-    benchmark(generate_code_challenge, verifier)
+    result = benchmark(generate_code_challenge, verifier)
+    assert isinstance(result, str)
 
 
 # ============================================================================
@@ -56,18 +60,23 @@ def test_bench_generate_code_challenge(benchmark):
 
 @pytest.mark.benchmark(group="dpop")
 def test_bench_generate_dpop_key_ec(benchmark):
-    benchmark(generate_dpop_key, "ES256")
+    result = benchmark(generate_dpop_key, "ES256")
+    assert result is not None
 
 
 @pytest.mark.benchmark(group="dpop")
 def test_bench_generate_dpop_key_rsa(benchmark):
-    benchmark(generate_dpop_key, "RS256")
+    result = benchmark(generate_dpop_key, "RS256")
+    assert result is not None
 
 
 @pytest.mark.benchmark(group="dpop")
 def test_bench_create_dpop_proof(benchmark):
     key = generate_dpop_key()
-    benchmark(create_dpop_proof, key, "POST", "https://auth.example.com/token")
+    result = benchmark(
+        create_dpop_proof, key, "POST", "https://auth.example.com/token"
+    )
+    assert isinstance(result, str)
 
 
 # ============================================================================
@@ -77,7 +86,7 @@ def test_bench_create_dpop_proof(benchmark):
 
 @pytest.mark.benchmark(group="jar")
 def test_bench_create_request_object_ec(benchmark, ec_private_pem):
-    benchmark(
+    result = benchmark(
         create_request_object,
         private_key=ec_private_pem,
         algorithm="ES256",
@@ -85,11 +94,12 @@ def test_bench_create_request_object_ec(benchmark, ec_private_pem):
         audience="https://auth.example.com",
         redirect_uri="https://app.example.com/cb",
     )
+    assert isinstance(result, str)
 
 
 @pytest.mark.benchmark(group="jar")
 def test_bench_create_request_object_rsa(benchmark, rsa_private_pem):
-    benchmark(
+    result = benchmark(
         create_request_object,
         private_key=rsa_private_pem,
         algorithm="RS256",
@@ -97,6 +107,7 @@ def test_bench_create_request_object_rsa(benchmark, rsa_private_pem):
         audience="https://auth.example.com",
         redirect_uri="https://app.example.com/cb",
     )
+    assert isinstance(result, str)
 
 
 # ============================================================================
@@ -106,7 +117,7 @@ def test_bench_create_request_object_rsa(benchmark, rsa_private_pem):
 
 @pytest.mark.benchmark(group="fapi")
 def test_bench_validate_fapi_request(benchmark):
-    benchmark(
+    result = benchmark(
         validate_fapi_authorization_request,
         response_type="code",
         code_challenge="challenge_value",
@@ -115,15 +126,17 @@ def test_bench_validate_fapi_request(benchmark):
         use_par=True,
         algorithm="ES256",
     )
+    assert result is not None
 
 
 @pytest.mark.benchmark(group="fapi")
 def test_bench_validate_fapi_client(benchmark):
-    benchmark(
+    result = benchmark(
         validate_fapi_client_config,
         has_client_authentication=True,
         use_dpop=True,
     )
+    assert result is not None
 
 
 # ============================================================================
@@ -133,13 +146,15 @@ def test_bench_validate_fapi_client(benchmark):
 
 @pytest.mark.benchmark(group="discovery")
 def test_bench_parse_discovery_url(benchmark):
-    benchmark(parse_discovery_url, "https://auth.example.com")
+    result = benchmark(parse_discovery_url, "https://auth.example.com")
+    assert result is not None
 
 
 @pytest.mark.benchmark(group="discovery")
 def test_bench_validate_url_scheme(benchmark):
     policy = DiscoveryPolicy()
     benchmark(validate_url_scheme, "https://auth.example.com/token", policy)
+    # validate_url_scheme returns None on success (raises on failure)
 
 
 # ============================================================================
@@ -149,7 +164,8 @@ def test_bench_validate_url_scheme(benchmark):
 
 @pytest.mark.benchmark(group="jwk")
 def test_bench_jwks_from_dict(benchmark, sample_jwk_dict):
-    benchmark(jwks_from_dict, sample_jwk_dict)
+    result = benchmark(jwks_from_dict, sample_jwk_dict)
+    assert result is not None
 
 
 # ============================================================================
@@ -159,7 +175,8 @@ def test_bench_jwks_from_dict(benchmark, sample_jwk_dict):
 
 @pytest.mark.benchmark(group="identity")
 def test_bench_to_principal(benchmark, sample_claims):
-    benchmark(to_principal, sample_claims)
+    result = benchmark(to_principal, sample_claims)
+    assert result is not None
 
 
 # ============================================================================
@@ -168,8 +185,10 @@ def test_bench_to_principal(benchmark, sample_claims):
 
 
 @pytest.mark.benchmark(group="jwt")
-def test_bench_jwt_decode(benchmark, sample_signed_jwt, ec_public_pem):
-    """Benchmark raw JWT decode + verification (the core validation path)."""
+def test_bench_pyjwt_decode_baseline(
+    benchmark, sample_signed_jwt, ec_public_pem
+):
+    """Benchmark raw pyjwt.decode() as a baseline for comparison (not py-identity-model code)."""
     import jwt as pyjwt
 
     def decode_jwt():
@@ -180,4 +199,5 @@ def test_bench_jwt_decode(benchmark, sample_signed_jwt, ec_public_pem):
             audience="bench-api",
         )
 
-    benchmark(decode_jwt)
+    result = benchmark(decode_jwt)
+    assert result is not None

--- a/src/tests/benchmarks/test_benchmarks.py
+++ b/src/tests/benchmarks/test_benchmarks.py
@@ -1,0 +1,183 @@
+"""Performance benchmark tests for py-identity-model.
+
+Run with: make test-benchmark
+"""
+
+import pytest
+
+from py_identity_model import (
+    validate_fapi_authorization_request,
+    validate_fapi_client_config,
+)
+from py_identity_model.core.discovery_policy import (
+    DiscoveryPolicy,
+    parse_discovery_url,
+    validate_url_scheme,
+)
+from py_identity_model.core.dpop import (
+    create_dpop_proof,
+    generate_dpop_key,
+)
+from py_identity_model.core.jar import create_request_object
+from py_identity_model.core.parsers import jwks_from_dict
+from py_identity_model.core.pkce import (
+    generate_code_challenge,
+    generate_code_verifier,
+    generate_pkce_pair,
+)
+from py_identity_model.identity import to_principal
+
+
+# ============================================================================
+# PKCE Benchmarks
+# ============================================================================
+
+
+@pytest.mark.benchmark(group="pkce")
+def test_bench_generate_pkce_pair(benchmark):
+    benchmark(generate_pkce_pair)
+
+
+@pytest.mark.benchmark(group="pkce")
+def test_bench_generate_code_verifier(benchmark):
+    benchmark(generate_code_verifier)
+
+
+@pytest.mark.benchmark(group="pkce")
+def test_bench_generate_code_challenge(benchmark):
+    verifier = generate_code_verifier()
+    benchmark(generate_code_challenge, verifier)
+
+
+# ============================================================================
+# DPoP Benchmarks
+# ============================================================================
+
+
+@pytest.mark.benchmark(group="dpop")
+def test_bench_generate_dpop_key_ec(benchmark):
+    benchmark(generate_dpop_key, "ES256")
+
+
+@pytest.mark.benchmark(group="dpop")
+def test_bench_generate_dpop_key_rsa(benchmark):
+    benchmark(generate_dpop_key, "RS256")
+
+
+@pytest.mark.benchmark(group="dpop")
+def test_bench_create_dpop_proof(benchmark):
+    key = generate_dpop_key()
+    benchmark(create_dpop_proof, key, "POST", "https://auth.example.com/token")
+
+
+# ============================================================================
+# JAR Benchmarks
+# ============================================================================
+
+
+@pytest.mark.benchmark(group="jar")
+def test_bench_create_request_object_ec(benchmark, ec_private_pem):
+    benchmark(
+        create_request_object,
+        private_key=ec_private_pem,
+        algorithm="ES256",
+        client_id="bench-app",
+        audience="https://auth.example.com",
+        redirect_uri="https://app.example.com/cb",
+    )
+
+
+@pytest.mark.benchmark(group="jar")
+def test_bench_create_request_object_rsa(benchmark, rsa_private_pem):
+    benchmark(
+        create_request_object,
+        private_key=rsa_private_pem,
+        algorithm="RS256",
+        client_id="bench-app",
+        audience="https://auth.example.com",
+        redirect_uri="https://app.example.com/cb",
+    )
+
+
+# ============================================================================
+# FAPI Validation Benchmarks
+# ============================================================================
+
+
+@pytest.mark.benchmark(group="fapi")
+def test_bench_validate_fapi_request(benchmark):
+    benchmark(
+        validate_fapi_authorization_request,
+        response_type="code",
+        code_challenge="challenge_value",
+        code_challenge_method="S256",
+        redirect_uri="https://app.example.com/cb",
+        use_par=True,
+        algorithm="ES256",
+    )
+
+
+@pytest.mark.benchmark(group="fapi")
+def test_bench_validate_fapi_client(benchmark):
+    benchmark(
+        validate_fapi_client_config,
+        has_client_authentication=True,
+        use_dpop=True,
+    )
+
+
+# ============================================================================
+# Discovery Policy Benchmarks
+# ============================================================================
+
+
+@pytest.mark.benchmark(group="discovery")
+def test_bench_parse_discovery_url(benchmark):
+    benchmark(parse_discovery_url, "https://auth.example.com")
+
+
+@pytest.mark.benchmark(group="discovery")
+def test_bench_validate_url_scheme(benchmark):
+    policy = DiscoveryPolicy()
+    benchmark(validate_url_scheme, "https://auth.example.com/token", policy)
+
+
+# ============================================================================
+# JWK Parsing Benchmarks
+# ============================================================================
+
+
+@pytest.mark.benchmark(group="jwk")
+def test_bench_jwks_from_dict(benchmark, sample_jwk_dict):
+    benchmark(jwks_from_dict, sample_jwk_dict)
+
+
+# ============================================================================
+# Identity / Claims Benchmarks
+# ============================================================================
+
+
+@pytest.mark.benchmark(group="identity")
+def test_bench_to_principal(benchmark, sample_claims):
+    benchmark(to_principal, sample_claims)
+
+
+# ============================================================================
+# JWT Decode Benchmarks (core validation operation)
+# ============================================================================
+
+
+@pytest.mark.benchmark(group="jwt")
+def test_bench_jwt_decode(benchmark, sample_signed_jwt, ec_public_pem):
+    """Benchmark raw JWT decode + verification (the core validation path)."""
+    import jwt as pyjwt
+
+    def decode_jwt():
+        return pyjwt.decode(
+            sample_signed_jwt,
+            ec_public_pem,
+            algorithms=["ES256"],
+            audience="bench-api",
+        )
+
+    benchmark(decode_jwt)

--- a/uv.lock
+++ b/uv.lock
@@ -837,6 +837,15 @@ wheels = [
 ]
 
 [[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
+]
+
+[[package]]
 name = "py-identity-model"
 version = "2.14.0"
 source = { editable = "." }
@@ -854,6 +863,7 @@ dev = [
     { name = "pyrefly" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
@@ -883,6 +893,7 @@ dev = [
     { name = "pyrefly", specifier = ">=0.34.0" },
     { name = "pytest", specifier = ">=8.3.2,<10" },
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
+    { name = "pytest-benchmark", specifier = ">=5.1.0,<6" },
     { name = "pytest-cov", specifier = ">=6.0.0,<8" },
     { name = "pytest-timeout", specifier = ">=2.3.1" },
     { name = "pytest-xdist", specifier = ">=3.6.1,<4" },
@@ -1087,6 +1098,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-benchmark"
+version = "5.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "py-cpuinfo" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/34/9f732b76456d64faffbef6232f1f9dbec7a7c4999ff46282fa418bd1af66/pytest_benchmark-5.2.3.tar.gz", hash = "sha256:deb7317998a23c650fd4ff76e1230066a76cb45dcece0aca5607143c619e7779", size = 341340, upload-time = "2025-11-09T18:48:43.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/29/e756e715a48959f1c0045342088d7ca9762a2f509b945f362a316e9412b7/pytest_benchmark-5.2.3-py3-none-any.whl", hash = "sha256:bc839726ad20e99aaa0d11a127445457b4219bdb9e80a1afc4b51da7f96b0803", size = 45255, upload-time = "2025-11-09T18:48:39.765Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `pytest-benchmark` dependency for performance testing
- Add 15 CPU-only benchmarks covering core library operations:
  - **PKCE**: pair generation, code verifier, code challenge
  - **DPoP**: EC/RSA key generation, proof creation
  - **JAR**: request object creation with EC and RSA keys
  - **FAPI**: authorization request and client config validation
  - **Discovery**: URL parsing, scheme validation
  - **JWK**: dict parsing
  - **Identity**: claims to principal conversion
  - **JWT**: decode and signature verification
- Add `make test-benchmark` Makefile target
- Exclude benchmarks from regular test runs (`-p no:benchmark`)

## Test Plan

- [x] All 15 benchmarks run successfully locally
- [x] Regular test suite (615 tests) unaffected by benchmark addition
- [x] Benchmark plugin disabled during parallel test runs (xdist compatibility)

Automated PR from ralph loop task T47. Closes #112