### PR TITLE
chore(infra): migrate descope provider to fork registry

### DIFF
--- a/infra/descope/.terraform.lock.hcl
+++ b/infra/descope/.terraform.lock.hcl
@@ -1,29 +1,6 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/descope/descope" {
-  version     = "0.3.6"
-  constraints = "~> 0.3"
-  hashes = [
-    "h1:Nas85Rx6V47i+OGQKbdYh/1dR4QJI7AuBqmrxInt4ok=",
-    "zh:2ab176bad927621cd5f107ab6dede2ebf2fa021269f2a7c3f58736a3444a795c",
-    "zh:39b654a5ba26792a4b96fb8c5c468c3e6289ff65fd08ca281fa44db5d681700e",
-    "zh:4944d8e4d8fa7b07d4f217c485f512689e8c2523a69d54a744da24fdff51c7a2",
-    "zh:518d1e261bffe7f892548bf3269994b82de73d4c09306abe0a527e2e244828dc",
-    "zh:61a60f4815e2a9d403dc6f5487248848bdf015b42ef7decb5787658f075d389b",
-    "zh:721fb29377a990b2ea040b0d485915ae052e7b1a1990afbd08dea8da75b238c6",
-    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
-    "zh:91051a9b1be022dccf6d6af965d04c6a9f9e6f0d36675edaa0ad6657183ffed6",
-    "zh:98c07d4122d031754e0b7fa1815ba7505fb76e8b54a5eb7e57feffa8c5e20cb7",
-    "zh:99caecb842816abb5054c7fbe93b2638dfe3d761bf03603de6bd57009091c589",
-    "zh:a9daf36e7f1e28b62b508a959c75c993dc92fb15c84c97c128fd07f7a59b7798",
-    "zh:acd393ca5ccdea7e6532bcf0d15f50546dff067b054174bfc6db4822d953ee6e",
-    "zh:cdfe2c9d2c2c95acede3e9ced4ad7347dda98ab4a2cf84738a493486152b7d03",
-    "zh:d4fd367fcb245a959fdb47b2107ba1071fafabc61338a537ccaa93e072c0e6c6",
-    "zh:dc2063a751b07602f899627603073f33b8cca8c33bad42023c8fa770981e814d",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/local" {
   version = "2.7.0"
   hashes = [

--- a/infra/descope/main.tf
+++ b/infra/descope/main.tf
@@ -3,8 +3,8 @@ terraform {
 
   required_providers {
     descope = {
-      source  = "descope/descope"
-      version = "~> 0.3"
+      source  = "jamescrowley321/descope"
+      version = "~> 1.0"
     }
     github = {
       source  = "integrations/github"


### PR DESCRIPTION
## Summary
- Switch Terraform provider source from `descope/descope` to `jamescrowley321/descope`
- Update version constraint from `~> 0.3` to `~> 1.0`
- Remove stale `.terraform.lock.hcl` entry for old provider (run `terraform init` to regenerate)

Closes #264

## Test plan
- [ ] Run `terraform init` in `infra/descope/` to verify the new provider source resolves
- [ ] Run `terraform plan` to confirm no unexpected resource changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)