### PR TITLE
fix(userinfo): add sub claim mismatch validation per OIDC Core 5.3.4

### DIFF
--- a/src/py_identity_model/aio/userinfo.py
+++ b/src/py_identity_model/aio/userinfo.py
@@ -13,6 +13,7 @@ from ..core.userinfo_logic import (
     log_userinfo_request,
     prepare_userinfo_headers,
     process_userinfo_response,
+    validate_userinfo_sub,
 )
 from .http_client import get_async_http_client, retry_with_backoff_async
 from .managed_client import AsyncHTTPClient
@@ -55,7 +56,8 @@ async def get_userinfo(
     try:
         client = http_client.client if http_client else get_async_http_client()
         response = await _request_userinfo(client, request.address, headers)
-        return process_userinfo_response(response)
+        result = process_userinfo_response(response)
+        return validate_userinfo_sub(result, request.expected_sub)
     except Exception as e:
         return handle_userinfo_error(e)
     finally:

--- a/src/py_identity_model/core/models.py
+++ b/src/py_identity_model/core/models.py
@@ -933,9 +933,14 @@ class UserInfoRequest(BaseRequest):
     Attributes:
         address: The UserInfo endpoint URL.
         token: A valid access token with ``openid`` scope.
+        expected_sub: Expected ``sub`` claim from the ID token for
+            verification per OIDC Core 1.0 Section 5.3.4.  When provided,
+            the ``sub`` in the UserInfo response is compared against this
+            value and a mismatch produces an error response.
     """
 
     token: str
+    expected_sub: str | None = None
 
 
 @dataclass(repr=False, eq=False)

--- a/src/py_identity_model/core/userinfo_logic.py
+++ b/src/py_identity_model/core/userinfo_logic.py
@@ -57,9 +57,57 @@ def process_userinfo_response(response: httpx.Response) -> UserInfoResponse:
         return handle_userinfo_error(e)
 
 
+def validate_userinfo_sub(
+    response: UserInfoResponse,
+    expected_sub: str | None,
+) -> UserInfoResponse:
+    """Validate that the UserInfo ``sub`` matches the ID token ``sub``.
+
+    Per OIDC Core 1.0 Section 5.3.4, the ``sub`` claim in the UserInfo
+    response MUST exactly match the ``sub`` in the ID token.
+
+    Args:
+        response: A parsed UserInfo response.
+        expected_sub: The ``sub`` from the caller's ID token.  When
+            ``None``, validation is skipped (opt-in).
+
+    Returns:
+        The original response when validation passes or is skipped,
+        otherwise an error ``UserInfoResponse``.
+    """
+    # Skip validation when not requested, on failure, or for JWT responses
+    if expected_sub is None or not response.is_successful or response.raw is not None:
+        return response
+
+    claims = object.__getattribute__(response, "claims")
+    if claims is None:
+        return UserInfoResponse(
+            is_successful=False,
+            error="UserInfo response contains no claims to validate sub against",
+        )
+
+    actual_sub = claims.get("sub")
+    if actual_sub is None:
+        return UserInfoResponse(
+            is_successful=False,
+            error="UserInfo response is missing required 'sub' claim",
+        )
+
+    if actual_sub != expected_sub:
+        return UserInfoResponse(
+            is_successful=False,
+            error=(
+                f"UserInfo sub mismatch: expected '{expected_sub}', got '{actual_sub}'"
+            ),
+        )
+
+    return response
+
+
 __all__ = [
     "log_userinfo_request",
     "log_userinfo_status",
     "prepare_userinfo_headers",
     "process_userinfo_response",
+    "validate_userinfo_sub",
 ]

--- a/src/py_identity_model/sync/userinfo.py
+++ b/src/py_identity_model/sync/userinfo.py
@@ -13,6 +13,7 @@ from ..core.userinfo_logic import (
     log_userinfo_request,
     prepare_userinfo_headers,
     process_userinfo_response,
+    validate_userinfo_sub,
 )
 from .http_client import get_http_client, retry_with_backoff
 from .managed_client import HTTPClient
@@ -55,7 +56,8 @@ def get_userinfo(
     try:
         client = http_client.client if http_client else get_http_client()
         response = _request_userinfo(client, request.address, headers)
-        return process_userinfo_response(response)
+        result = process_userinfo_response(response)
+        return validate_userinfo_sub(result, request.expected_sub)
     except Exception as e:
         return handle_userinfo_error(e)
     finally:

--- a/src/tests/unit/test_aio_userinfo.py
+++ b/src/tests/unit/test_aio_userinfo.py
@@ -95,3 +95,124 @@ class TestAsyncUserInfo:
         assert result.is_successful is False
         assert result.error is not None
         assert "Network error" in result.error
+
+
+@pytest.mark.asyncio
+class TestAsyncUserInfoSubValidation:
+    """Test sub claim validation per OIDC Core 1.0 Section 5.3.4."""
+
+    @respx.mock
+    async def test_sub_validation_match(self):
+        """Matching expected_sub passes through successfully."""
+        url = "https://example.com/userinfo"
+        respx.get(url).mock(
+            return_value=httpx.Response(
+                200,
+                json={"sub": "user-123", "name": "Test"},
+                headers={"Content-Type": "application/json"},
+            )
+        )
+
+        request = UserInfoRequest(
+            address=url,
+            token="tok",
+            expected_sub="user-123",
+        )
+        result = await get_userinfo(request)
+
+        assert result.is_successful is True
+        assert result.claims is not None
+        assert result.claims["sub"] == "user-123"
+
+    @respx.mock
+    async def test_sub_validation_mismatch(self):
+        """Mismatched expected_sub returns error response."""
+        url = "https://example.com/userinfo"
+        respx.get(url).mock(
+            return_value=httpx.Response(
+                200,
+                json={"sub": "user-999", "name": "Test"},
+                headers={"Content-Type": "application/json"},
+            )
+        )
+
+        request = UserInfoRequest(
+            address=url,
+            token="tok",
+            expected_sub="user-123",
+        )
+        result = await get_userinfo(request)
+
+        assert result.is_successful is False
+        assert result.error is not None
+        assert "sub mismatch" in result.error
+        assert "user-123" in result.error
+        assert "user-999" in result.error
+
+    @respx.mock
+    async def test_sub_validation_missing_sub(self):
+        """Missing sub claim in response returns error."""
+        url = "https://example.com/userinfo"
+        respx.get(url).mock(
+            return_value=httpx.Response(
+                200,
+                json={"name": "Test"},
+                headers={"Content-Type": "application/json"},
+            )
+        )
+
+        request = UserInfoRequest(
+            address=url,
+            token="tok",
+            expected_sub="user-123",
+        )
+        result = await get_userinfo(request)
+
+        assert result.is_successful is False
+        assert result.error is not None
+        assert "missing" in result.error.lower()
+
+    @respx.mock
+    async def test_sub_validation_not_requested(self):
+        """No expected_sub skips validation entirely."""
+        url = "https://example.com/userinfo"
+        respx.get(url).mock(
+            return_value=httpx.Response(
+                200,
+                json={"sub": "user-123", "name": "Test"},
+                headers={"Content-Type": "application/json"},
+            )
+        )
+
+        request = UserInfoRequest(
+            address=url,
+            token="tok",
+        )
+        result = await get_userinfo(request)
+
+        assert result.is_successful is True
+        assert result.claims is not None
+        assert result.claims["sub"] == "user-123"
+
+    @respx.mock
+    async def test_sub_validation_jwt_response(self):
+        """JWT responses skip sub validation (caller must decode first)."""
+        url = "https://example.com/userinfo"
+        jwt_string = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIyNDgyODk3NjEwMDEifQ.sig"
+        respx.get(url).mock(
+            return_value=httpx.Response(
+                200,
+                text=jwt_string,
+                headers={"Content-Type": "application/jwt"},
+            )
+        )
+
+        request = UserInfoRequest(
+            address=url,
+            token="tok",
+            expected_sub="user-123",
+        )
+        result = await get_userinfo(request)
+
+        assert result.is_successful is True
+        assert result.raw == jwt_string

--- a/src/tests/unit/test_sync_userinfo.py
+++ b/src/tests/unit/test_sync_userinfo.py
@@ -106,3 +106,118 @@ class TestSyncUserInfo:
         assert response.is_successful is False
         assert response.error is not None
         assert "Network error" in response.error
+
+
+class TestSyncUserInfoSubValidation:
+    """Test sub claim validation per OIDC Core 1.0 Section 5.3.4."""
+
+    @respx.mock
+    def test_sub_validation_match(self):
+        """Matching expected_sub passes through successfully."""
+        respx.get("https://example.com/userinfo").mock(
+            return_value=httpx.Response(
+                200,
+                json={"sub": "user-123", "name": "Test"},
+                headers={"Content-Type": "application/json"},
+            )
+        )
+
+        request = UserInfoRequest(
+            address="https://example.com/userinfo",
+            token="tok",
+            expected_sub="user-123",
+        )
+        response = get_userinfo(request)
+
+        assert response.is_successful is True
+        assert response.claims is not None
+        assert response.claims["sub"] == "user-123"
+
+    @respx.mock
+    def test_sub_validation_mismatch(self):
+        """Mismatched expected_sub returns error response."""
+        respx.get("https://example.com/userinfo").mock(
+            return_value=httpx.Response(
+                200,
+                json={"sub": "user-999", "name": "Test"},
+                headers={"Content-Type": "application/json"},
+            )
+        )
+
+        request = UserInfoRequest(
+            address="https://example.com/userinfo",
+            token="tok",
+            expected_sub="user-123",
+        )
+        response = get_userinfo(request)
+
+        assert response.is_successful is False
+        assert response.error is not None
+        assert "sub mismatch" in response.error
+        assert "user-123" in response.error
+        assert "user-999" in response.error
+
+    @respx.mock
+    def test_sub_validation_missing_sub(self):
+        """Missing sub claim in response returns error."""
+        respx.get("https://example.com/userinfo").mock(
+            return_value=httpx.Response(
+                200,
+                json={"name": "Test"},
+                headers={"Content-Type": "application/json"},
+            )
+        )
+
+        request = UserInfoRequest(
+            address="https://example.com/userinfo",
+            token="tok",
+            expected_sub="user-123",
+        )
+        response = get_userinfo(request)
+
+        assert response.is_successful is False
+        assert response.error is not None
+        assert "missing" in response.error.lower()
+
+    @respx.mock
+    def test_sub_validation_not_requested(self):
+        """No expected_sub skips validation entirely."""
+        respx.get("https://example.com/userinfo").mock(
+            return_value=httpx.Response(
+                200,
+                json={"sub": "user-123", "name": "Test"},
+                headers={"Content-Type": "application/json"},
+            )
+        )
+
+        request = UserInfoRequest(
+            address="https://example.com/userinfo",
+            token="tok",
+        )
+        response = get_userinfo(request)
+
+        assert response.is_successful is True
+        assert response.claims is not None
+        assert response.claims["sub"] == "user-123"
+
+    @respx.mock
+    def test_sub_validation_jwt_response(self):
+        """JWT responses skip sub validation (caller must decode first)."""
+        jwt_string = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIyNDgyODk3NjEwMDEifQ.sig"
+        respx.get("https://example.com/userinfo").mock(
+            return_value=httpx.Response(
+                200,
+                text=jwt_string,
+                headers={"Content-Type": "application/jwt"},
+            )
+        )
+
+        request = UserInfoRequest(
+            address="https://example.com/userinfo",
+            token="tok",
+            expected_sub="user-123",
+        )
+        response = get_userinfo(request)
+
+        assert response.is_successful is True
+        assert response.raw == jwt_string


### PR DESCRIPTION
## Summary
- Add `expected_sub` optional parameter to `UserInfoRequest` for sub claim validation
- Add `validate_userinfo_sub()` in `core/userinfo_logic.py` — returns error response on mismatch (follows existing pattern)
- Wire validation into both sync and async UserInfo paths
- Opt-in: existing callers unaffected (defaults to `None`)
- Implements OIDC Core 1.0 Section 5.3.4: "The sub Claim in the UserInfo Response MUST be verified to exactly match the sub Claim in the ID Token"

## Test plan
- [x] Unit tests pass (5 sync + 5 async: match, mismatch, missing sub, opt-out, JWT bypass)
- [x] Integration tests pass against node-oidc-provider
- [x] Lint passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)