### PR TITLE
infra(descope): mirror CI secrets to dependabot scope + branch protection scaffold

### DIFF
--- a/infra/descope/github_branch_protection.tf
+++ b/infra/descope/github_branch_protection.tf
@@ -1,0 +1,36 @@
+# Branch protection for py-identity-model/main.
+#
+# Gated behind `var.enable_branch_protection` so it can be applied in a
+# second pass — the intended sequence is:
+#
+#   1. terraform apply (secrets only, flag off) — no-op on protection
+#   2. Next dependabot PR runs, all CI stages go green, capture exact
+#      check names from the rollup
+#   3. Set enable_branch_protection = true and populate
+#      required_status_check_contexts in the tfvars / env
+#   4. terraform apply again — protection goes live
+#
+# Without this staging, required_status_checks would block every PR on
+# names that haven't been observed yet.
+
+resource "github_branch_protection" "main" {
+  count = var.enable_branch_protection ? 1 : 0
+
+  repository_id = var.github_repository
+  pattern       = "main"
+
+  enforce_admins      = false
+  allows_deletions    = false
+  allows_force_pushes = false
+
+  required_status_checks {
+    strict   = false
+    contexts = var.required_status_check_contexts
+  }
+
+  required_pull_request_reviews {
+    required_approving_review_count = var.required_approving_review_count
+    dismiss_stale_reviews           = true
+    require_code_owner_reviews      = false
+  }
+}

--- a/infra/descope/github_ci_secrets.tf
+++ b/infra/descope/github_ci_secrets.tf
@@ -1,0 +1,97 @@
+# Extended CI secret management.
+#
+# The existing github.tf writes Descope-derived credentials to the
+# `github_actions_secret` scope so workflows triggered by human PRs and
+# pushes can reach the Descope integration tests. This file adds two
+# things that file doesn't cover:
+#
+# 1. A parallel set of `github_dependabot_secret` resources mirroring every
+#    CI secret into the Dependabot event scope. Dependabot-authored PRs run
+#    under a separate secret scope from regular workflow_dispatch/pull_request
+#    events, and without these mirrors the Ory + Descope integration tests
+#    (and SonarCloud) fail every dependabot PR, which blocks auto-merge.
+#
+# 2. The Ory integration test credentials (`TEST_*`) and `SONAR_TOKEN`,
+#    which previously had no declarative source. `TEST_*` values live in
+#    the local `.env` at the repo root (provisioned once via the Ory
+#    dashboard); SONAR_TOKEN comes from a Terraform variable.
+
+locals {
+  # Parse ../../.env (repo root) into a map of VAR => value. Handles the
+  # common `KEY=value` and `KEY="value"` forms. Skips blanks and comments.
+  env_file_lines = [
+    for line in split("\n", file("${path.module}/../../.env")) :
+    line
+    if length(regexall("^[A-Z_][A-Z0-9_]*=", line)) > 0
+  ]
+
+  env_vars = {
+    for line in local.env_file_lines :
+    split("=", line)[0] => trim(
+      join("=", slice(split("=", line), 1, length(split("=", line)))),
+      "\"'"
+    )
+  }
+
+  # Ory / local fixture credentials mirrored to CI. These map 1:1 to the
+  # `TEST_*` secret names referenced in .github/workflows/ci.yml.
+  ory_test_secrets = {
+    TEST_DISCO_ADDRESS = local.env_vars["TEST_DISCO_ADDRESS"]
+    TEST_JWKS_ADDRESS  = local.env_vars["TEST_JWKS_ADDRESS"]
+    TEST_CLIENT_ID     = local.env_vars["TEST_CLIENT_ID"]
+    TEST_CLIENT_SECRET = local.env_vars["TEST_CLIENT_SECRET"]
+    TEST_SCOPE         = local.env_vars["TEST_SCOPE"]
+    TEST_AUDIENCE      = lookup(local.env_vars, "TEST_AUDIENCE", "")
+    TEST_EXPIRED_TOKEN = lookup(local.env_vars, "TEST_EXPIRED_TOKEN", "")
+  }
+
+  # Descope-derived CI secrets — source of truth is the existing resources
+  # in github.tf. Re-declared here only so the dependabot mirrors can
+  # iterate over a single merged map.
+  descope_ci_secrets = {
+    DESCOPE_DISCO_ADDRESS = "https://api.descope.com/${var.project_id}/.well-known/openid-configuration"
+    DESCOPE_JWKS_ADDRESS  = "https://api.descope.com/${var.project_id}/.well-known/jwks.json"
+    DESCOPE_CLIENT_ID     = descope_access_key.m2m.client_id
+    DESCOPE_CLIENT_SECRET = descope_access_key.m2m.cleartext
+    DESCOPE_SCOPE         = "openid"
+    DESCOPE_AUDIENCE      = var.project_id
+    DESCOPE_EXPIRED_TOKEN = trimspace(data.local_file.expired_token.content)
+  }
+
+  # Full set of secrets that must exist in BOTH the actions and dependabot
+  # scopes for every CI stage to pass on a dependabot-authored PR.
+  dependabot_mirrored_secrets = merge(
+    local.ory_test_secrets,
+    local.descope_ci_secrets,
+    { SONAR_TOKEN = var.sonar_token },
+  )
+}
+
+# --------------------------------------------------------------------------
+# Actions scope: new secrets only (existing Descope secrets stay in github.tf).
+# --------------------------------------------------------------------------
+
+resource "github_actions_secret" "ory_test" {
+  for_each        = local.ory_test_secrets
+  repository      = var.github_repository
+  secret_name     = each.key
+  plaintext_value = each.value
+}
+
+resource "github_actions_secret" "sonar_token" {
+  repository      = var.github_repository
+  secret_name     = "SONAR_TOKEN"
+  plaintext_value = var.sonar_token
+}
+
+# --------------------------------------------------------------------------
+# Dependabot scope: mirror everything — Descope, Ory, SonarCloud — so the
+# full CI matrix passes on dependabot PRs and auto-merge can actually fire.
+# --------------------------------------------------------------------------
+
+resource "github_dependabot_secret" "ci" {
+  for_each        = local.dependabot_mirrored_secrets
+  repository      = var.github_repository
+  secret_name     = each.key
+  plaintext_value = each.value
+}

--- a/infra/descope/variables.tf
+++ b/infra/descope/variables.tf
@@ -8,3 +8,31 @@ variable "github_repository" {
   default     = "py-identity-model"
   description = "GitHub repository name (without owner) for CI secrets"
 }
+
+variable "sonar_token" {
+  type        = string
+  sensitive   = true
+  description = "SonarCloud project token. Provision via https://sonarcloud.io/account/security and supply as TF_VAR_sonar_token."
+}
+
+variable "enable_branch_protection" {
+  type        = bool
+  default     = false
+  description = <<-EOT
+    Toggle branch protection on `main`. Leave false until a dependabot PR
+    has been observed running fully green so required_status_check_contexts
+    can be populated with the exact check names.
+  EOT
+}
+
+variable "required_status_check_contexts" {
+  type        = list(string)
+  default     = []
+  description = "List of status check contexts that must pass before a PR to main can be merged. Only used when enable_branch_protection is true."
+}
+
+variable "required_approving_review_count" {
+  type        = number
+  default     = 0
+  description = "Number of approving reviews required before merge. Dependabot PRs are auto-merged; if set > 0, they stall until manually approved."
+}


### PR DESCRIPTION
## Summary

Extend `infra/descope/` so every CI secret exists in both the `github_actions` and `github_dependabot` scopes. Required for the auto-merge of grouped dep PRs introduced in #315 to actually fire — without dependabot-scope secrets the Ory/Descope integration tests and SonarCloud fail every dependabot PR and block the merge.

Depends on #315 (dependabot groups + auto-merge workflow). The two can merge in either order since they don't share files; this PR is pure TF.

## What changed

**New `infra/descope/github_ci_secrets.tf`:**
- Locals parse `../../.env` to pick up the Ory `TEST_*` credentials. These were previously unmanaged by TF — the existing `github.tf` only handled the Descope-derived secrets because it's the "descope" module, but the CI workflow references both Ory and Descope variants.
- `github_actions_secret.ory_test` (for_each) writes `TEST_*` into the actions scope.
- `github_actions_secret.sonar_token` writes `SONAR_TOKEN` from `var.sonar_token`.
- `github_dependabot_secret.ci` (for_each) mirrors the **full merged set** — Descope + Ory + SonarCloud — into the dependabot scope. This is the missing piece that makes dependabot PRs pass CI.

**New `infra/descope/github_branch_protection.tf`:**
- `github_branch_protection.main`, gated behind `var.enable_branch_protection` (default `false`).
- Intended usage: first apply with flag off to mirror secrets, observe a green dependabot PR, capture the exact check names, flip flag on and re-apply.

**`infra/descope/variables.tf`:**
- `sonar_token` (sensitive, no default — supply via `TF_VAR_sonar_token`)
- `enable_branch_protection` (bool, default false)
- `required_status_check_contexts` (list(string), default [])
- `required_approving_review_count` (number, default 0)

**Not modified:** The existing `github.tf` Descope actions secrets are left alone. The new file references their values via locals but doesn't replace the individual resources — minimizes blast radius of the change.

## Apply sequence

```bash
cd infra/descope
export TF_VAR_sonar_token=<your sonarcloud token>
terraform apply                  # mirrors secrets, no branch protection yet
# ... wait for next dependabot PR, confirm all CI stages green ...
# Edit terraform.tfvars or set TF_VAR_enable_branch_protection=true
# and TF_VAR_required_status_check_contexts='["ci / lint", ...]'
terraform apply                  # enables branch protection
```

## A related module was added for terraform-provider-descope

I also scaffolded `/home/james/repos/auth/infra/tpd-github/` (outside this repo — lives in the workspace root since the fork shouldn't diverge from upstream for local infra) that does the same thing for `jamescrowley321/terraform-provider-descope`: mirrors `DESCOPE_MANAGEMENT_KEY` + `DESCOPE_PROJECT_ID` from `../../terraform-provider-descope/.env`. Uses HCP Terraform for state (workspace `terraform-provider-descope-github` in the `jamescrowley321` org) to match the backend pattern of the other two workspaces. Workspace must be set to **Local execution mode** after creation because `file()` reading only works locally.

## Test plan

- [x] `terraform fmt -check` clean
- [x] `terraform validate` clean
- [x] `make lint` passes (no Python changes, but enforced by repo workflow)
- [ ] Dry-run: `terraform plan` on the actual HCP workspace (requires local execution + `TF_VAR_sonar_token`)
- [ ] Post-apply: verify `gh api repos/jamescrowley321/py-identity-model/dependabot/secrets` lists all 15 mirrored secrets
- [ ] Post-apply: verify next dependabot PR runs the full CI matrix green

🤖 Generated with [Claude Code](https://claude.com/claude-code)