### PR TITLE
fix(infra): make sonar_token optional

### DIFF
--- a/infra/descope/github_ci_secrets.tf
+++ b/infra/descope/github_ci_secrets.tf
@@ -60,10 +60,11 @@ locals {
 
   # Full set of secrets that must exist in BOTH the actions and dependabot
   # scopes for every CI stage to pass on a dependabot-authored PR.
+  # SONAR_TOKEN is only included when the variable is non-empty.
   dependabot_mirrored_secrets = merge(
     local.ory_test_secrets,
     local.descope_ci_secrets,
-    { SONAR_TOKEN = var.sonar_token },
+    var.sonar_token != "" ? { SONAR_TOKEN = var.sonar_token } : {},
   )
 }
 
@@ -79,6 +80,7 @@ resource "github_actions_secret" "ory_test" {
 }
 
 resource "github_actions_secret" "sonar_token" {
+  count           = var.sonar_token != "" ? 1 : 0
   repository      = var.github_repository
   secret_name     = "SONAR_TOKEN"
   plaintext_value = var.sonar_token

--- a/infra/descope/variables.tf
+++ b/infra/descope/variables.tf
@@ -11,8 +11,9 @@ variable "github_repository" {
 
 variable "sonar_token" {
   type        = string
+  default     = ""
   sensitive   = true
-  description = "SonarCloud project token. Provision via https://sonarcloud.io/account/security and supply as TF_VAR_sonar_token."
+  description = "SonarCloud project token. Provision via https://sonarcloud.io/account/security and supply as TF_VAR_sonar_token. Leave empty to skip mirroring SONAR_TOKEN."
 }
 
 variable "enable_branch_protection" {


### PR DESCRIPTION
Quick follow-up to #316 — defaults `sonar_token` to `""` and gates the SONAR_TOKEN resources on it being non-empty so `terraform apply` works immediately without needing a SonarCloud token on hand. The 14 Ory + Descope secrets get mirrored; SONAR_TOKEN can be added in a later apply with `TF_VAR_sonar_token=<value>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)