### PR TITLE
chore: add PROMPT.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,7 @@ dmypy.json
 
 # Ralph orchestrator runtime state
 .ralph/
+PROMPT.md
 
 # Terraform
 infra/**/.terraform/


### PR DESCRIPTION
## Summary
- Add `PROMPT.md` to `.gitignore` so ralph loop prompts stay local-only
- Matches the convention already used in identity-stack
- PROMPT.md was already removed from tracking in #319; this prevents accidental re-addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)