### PR TITLE
chore: ignore ralph review subagent artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,10 @@ dmypy.json
 .claude/mcp.json
 .claude/worktrees/
 .claude/task-state.md
+.claude/task-state*.md
+.claude/review-*.md
+.claude/review-*.patch
+.claude/pre-review-sha.txt
 
 # Ralph orchestrator runtime state
 .ralph/


### PR DESCRIPTION
## Summary
- Add `.claude/review-*.md`, `.claude/review-*.patch`, and `.claude/pre-review-sha.txt` to `.gitignore`
- Also add `.claude/task-state*.md` to cover suffixed task-state files
- Matches the identity-stack convention

## Context

The ralph loop's review phase is being updated (local PROMPT.md change) to spawn independent reviewer subagents (Blind Hunter, Edge Case Hunter, Acceptance Auditor, Sentinel) that write findings to `.claude/review-<persona>.md`. Plus the diff patch and pre-review SHA used by the delta re-review step. These are per-iteration ephemera and must not be committed.

Related: the fresh-context adversarial review on PR #322 surfaced multiple P1 findings that the in-loop review missed, which motivated rewriting the review phase to enforce subagent spawning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)