### PR TITLE
fix(conformance): remove S101 suppression to lint-guard against bare asserts (#328)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,6 @@ ignore = [
 "src/tests/**/*.py" = ["S101"]   # 1858 assert violations — all test assertions, 0 in production code
 "examples/**/*.py" = ["S101"]    # 73 assert violations in example integration tests
 "conformance/**/*.py" = [
-    "S101",    # assert used for type narrowing (guarded response fields)
     "S501",    # verify=False required — conformance suite uses self-signed certs
     "PLR0911", # callback handler has many early-return error paths
     "PLR0912", # callback handler has many branches (one per validation step)


### PR DESCRIPTION
## Summary
- Remove `S101` (bare assert) suppression from `conformance/**/*.py` per-file-ignores in `pyproject.toml`
- All bare `assert` statements were already replaced with explicit `if x is None` checks and proper HTTP error responses in prior commits on `main`
- Removing the suppression ensures ruff will flag any future bare `assert` added to conformance code

Part of #242 (OIDC RP Certification)
Closes #328

## Conformance Results
**Basic RP**: 13 passed, 0 failed, 1 skipped (sig-none)
**Config RP**: 5 passed, 0 failed, 1 skipped (sig-none)

No regressions from the suppression removal.

## Test Results
- Unit tests: 848 passed
- Coverage: 95.22%

🤖 Generated with [Claude Code](https://claude.com/claude-code)