### PR TITLE
feat(conformance): switch runner to hosted certification suite (#242)

### DIFF
--- a/.github/workflows/conformance-hosted.yml
+++ b/.github/workflows/conformance-hosted.yml
@@ -12,9 +12,16 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Validate token
+        run: |
+          if [ -z "${{ secrets.CONFORMANCE_TOKEN }}" ]; then
+            echo "ERROR: CONFORMANCE_TOKEN secret is not configured"
+            exit 1
+          fi
 
       - name: Start RP harness
         working-directory: conformance
@@ -37,7 +44,7 @@ jobs:
           done
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: "3.13"
 

--- a/.github/workflows/conformance-hosted.yml
+++ b/.github/workflows/conformance-hosted.yml
@@ -1,0 +1,79 @@
+name: Conformance (Hosted)
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+
+jobs:
+  conformance-hosted:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Start RP harness
+        working-directory: conformance
+        run: docker compose up -d --build rp
+
+      - name: Wait for RP harness
+        run: |
+          echo "Waiting for RP harness at http://localhost:8888/health..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8888/health > /dev/null 2>&1; then
+              echo "RP harness is ready"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "Timed out waiting for RP harness"
+              docker compose -f conformance/docker-compose.yml logs rp
+              exit 1
+            fi
+            sleep 2
+          done
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install test runner dependencies
+        run: pip install httpx
+
+      - name: Run Basic RP conformance tests (hosted)
+        env:
+          CONFORMANCE_SERVER: https://www.certification.openid.net
+          CONFORMANCE_TOKEN: ${{ secrets.CONFORMANCE_TOKEN }}
+        run: |
+          python conformance/run_tests.py \
+            --plan basic-rp \
+            --output conformance/results/hosted/basic-rp-latest.json \
+            --verbose
+
+      - name: Run Config RP conformance tests (hosted)
+        env:
+          CONFORMANCE_SERVER: https://www.certification.openid.net
+          CONFORMANCE_TOKEN: ${{ secrets.CONFORMANCE_TOKEN }}
+        run: |
+          python conformance/run_tests.py \
+            --plan config-rp \
+            --output conformance/results/hosted/config-rp-latest.json \
+            --verbose
+
+      - name: Upload hosted conformance results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: conformance-hosted-results
+          path: |
+            conformance/results/hosted/*-latest.json
+          retention-days: 30
+
+      - name: Teardown
+        if: always()
+        working-directory: conformance
+        run: docker compose down -v

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,21 @@ conformance-up: ## Start conformance suite and RP harness
 conformance-down: ## Tear down conformance suite
 	docker compose -f conformance/docker-compose.yml down -v
 
+.PHONY: conformance-cert-dryrun
+conformance-cert-dryrun: ## Run Basic + Config RP against hosted certification suite
+	@test -n "$$CONFORMANCE_TOKEN" || { echo "ERROR: CONFORMANCE_TOKEN is not set"; exit 1; }
+	@test -n "$$CONFORMANCE_SERVER" || export CONFORMANCE_SERVER="https://www.certification.openid.net"; \
+	echo "Running Basic RP against $$CONFORMANCE_SERVER ..."; \
+	python conformance/run_tests.py \
+		--plan basic-rp \
+		--output conformance/results/hosted/basic-rp-latest.json \
+		--verbose && \
+	echo "Running Config RP against $$CONFORMANCE_SERVER ..." && \
+	python conformance/run_tests.py \
+		--plan config-rp \
+		--output conformance/results/hosted/config-rp-latest.json \
+		--verbose
+
 .PHONY: ci-setup
 ci-setup:
 	python -m pip install --upgrade pip

--- a/Makefile
+++ b/Makefile
@@ -81,17 +81,18 @@ conformance-up: ## Start conformance suite and RP harness
 conformance-down: ## Tear down conformance suite
 	docker compose -f conformance/docker-compose.yml down -v
 
+CONFORMANCE_SERVER ?= https://www.certification.openid.net
+
 .PHONY: conformance-cert-dryrun
 conformance-cert-dryrun: ## Run Basic + Config RP against hosted certification suite
 	@test -n "$$CONFORMANCE_TOKEN" || { echo "ERROR: CONFORMANCE_TOKEN is not set"; exit 1; }
-	@test -n "$$CONFORMANCE_SERVER" || export CONFORMANCE_SERVER="https://www.certification.openid.net"; \
-	echo "Running Basic RP against $$CONFORMANCE_SERVER ..."; \
-	python conformance/run_tests.py \
+	@echo "Running Basic RP against $(CONFORMANCE_SERVER) ..."
+	CONFORMANCE_SERVER=$(CONFORMANCE_SERVER) python conformance/run_tests.py \
 		--plan basic-rp \
 		--output conformance/results/hosted/basic-rp-latest.json \
-		--verbose && \
-	echo "Running Config RP against $$CONFORMANCE_SERVER ..." && \
-	python conformance/run_tests.py \
+		--verbose
+	@echo "Running Config RP against $(CONFORMANCE_SERVER) ..."
+	CONFORMANCE_SERVER=$(CONFORMANCE_SERVER) python conformance/run_tests.py \
 		--plan config-rp \
 		--output conformance/results/hosted/config-rp-latest.json \
 		--verbose

--- a/conformance/run_tests.py
+++ b/conformance/run_tests.py
@@ -65,14 +65,16 @@ class ConformanceSuiteClient:
     """REST API client for the OIDF conformance suite.
 
     When *token* is provided, all requests include a Bearer Authorization
-    header and SSL verification is enabled (hosted suite has valid certs).
-    Without a token, SSL verification is disabled (local devmode self-signed).
+    header.  SSL verification is determined by the suite URL: local devmode
+    instances (``localhost.emobix.co.uk``) use self-signed certs and skip
+    verification; any other host is assumed to have valid certs.
     """
 
     def __init__(self, base_url: str, token: str = "") -> None:
         self.base_url = base_url.rstrip("/")
         self.token = token
-        verify = token != ""  # hosted = valid certs; local = self-signed
+        # Local devmode suite uses self-signed certs; everything else verifies.
+        verify = "localhost.emobix.co.uk" not in base_url
         headers: dict[str, str] = {}
         if token:
             headers["Authorization"] = f"Bearer {token}"
@@ -114,6 +116,12 @@ class ConformanceSuiteClient:
             params=params,
             json=plan_config,
         )
+        if response.status_code in (401, 403):
+            logger.error(
+                "Authentication failed (HTTP %d). Check CONFORMANCE_TOKEN.",
+                response.status_code,
+            )
+            sys.exit(1)
         response.raise_for_status()
         return response.json()
 

--- a/conformance/run_tests.py
+++ b/conformance/run_tests.py
@@ -11,6 +11,7 @@ import argparse
 from dataclasses import dataclass
 import json
 import logging
+import os
 from pathlib import Path
 import sys
 import time
@@ -28,7 +29,12 @@ logger = logging.getLogger("conformance-runner")
 # Configuration
 # ---------------------------------------------------------------------------
 
-SUITE_BASE_URL = "https://localhost.emobix.co.uk:8443"
+# Environment variables mirror the OIDF reference runner (scripts/run-test-plan.py):
+#   CONFORMANCE_SERVER — suite base URL (default: local devmode instance)
+#   CONFORMANCE_TOKEN  — Bearer token for hosted suite (omit for local)
+DEFAULT_SUITE_URL = "https://localhost.emobix.co.uk:8443"
+SUITE_BASE_URL = os.environ.get("CONFORMANCE_SERVER", DEFAULT_SUITE_URL)
+CONFORMANCE_TOKEN = os.environ.get("CONFORMANCE_TOKEN", "")
 RP_BASE_URL = "http://localhost:8888"
 POLL_INTERVAL = 2  # seconds
 MAX_POLL_ATTEMPTS = 60  # 2 minutes max per test
@@ -56,11 +62,21 @@ class TestResult:
 
 
 class ConformanceSuiteClient:
-    """REST API client for the OIDF conformance suite."""
+    """REST API client for the OIDF conformance suite.
 
-    def __init__(self, base_url: str) -> None:
+    When *token* is provided, all requests include a Bearer Authorization
+    header and SSL verification is enabled (hosted suite has valid certs).
+    Without a token, SSL verification is disabled (local devmode self-signed).
+    """
+
+    def __init__(self, base_url: str, token: str = "") -> None:
         self.base_url = base_url.rstrip("/")
-        self.client = httpx.Client(verify=False, timeout=30.0)
+        self.token = token
+        verify = token != ""  # hosted = valid certs; local = self-signed
+        headers: dict[str, str] = {}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        self.client = httpx.Client(verify=verify, timeout=30.0, headers=headers)
 
     def create_plan(
         self, plan_name: str, variant: dict, alias: str, rp_base_url: str = RP_BASE_URL
@@ -403,6 +419,7 @@ def run_plan(
     config_path: str,
     suite_base_url: str = SUITE_BASE_URL,
     rp_base_url: str = RP_BASE_URL,
+    token: str = "",
 ) -> tuple[str, list[TestResult]]:
     """Run all tests in a conformance test plan.
 
@@ -418,8 +435,10 @@ def run_plan(
     logger.info("Variant: %s", variant)
     logger.info("Suite: %s", suite_base_url)
     logger.info("RP: %s", rp_base_url)
+    if token:
+        logger.info("Auth: Bearer token provided (hosted mode)")
 
-    suite = ConformanceSuiteClient(suite_base_url)
+    suite = ConformanceSuiteClient(suite_base_url, token=token)
 
     # Create the test plan
     logger.info("Creating test plan...")
@@ -526,12 +545,20 @@ def main() -> None:
     parser.add_argument(
         "--suite-url",
         default=SUITE_BASE_URL,
-        help=f"Conformance suite base URL (default: {SUITE_BASE_URL})",
+        help=(
+            "Conformance suite base URL "
+            f"(default: $CONFORMANCE_SERVER or {DEFAULT_SUITE_URL})"
+        ),
     )
     parser.add_argument(
         "--rp-url",
         default=RP_BASE_URL,
         help=f"RP harness base URL (default: {RP_BASE_URL})",
+    )
+    parser.add_argument(
+        "--token",
+        default=CONFORMANCE_TOKEN,
+        help="Bearer token for hosted suite (default: $CONFORMANCE_TOKEN)",
     )
     parser.add_argument(
         "--output",
@@ -559,6 +586,7 @@ def main() -> None:
         config_path=str(config_path),
         suite_base_url=args.suite_url,
         rp_base_url=args.rp_url,
+        token=args.token,
     )
 
     all_ok = print_summary(results)


### PR DESCRIPTION
## Summary

- Add `CONFORMANCE_SERVER` and `CONFORMANCE_TOKEN` env var support to `conformance/run_tests.py`, mirroring the OIDF reference runner pattern
- Add `make conformance-cert-dryrun` target for running Basic + Config RP against `certification.openid.net` with Bearer auth
- Add manual-trigger CI workflow (`.github/workflows/conformance-hosted.yml`) for hosted suite runs
- SSL verification is URL-based (local devmode = skip, hosted = verify); auth failures (401/403) produce clear error messages

Part of #242 (OIDC RP Certification)

## Conformance Results

Hosted results require `CONFORMANCE_TOKEN` (not available in dev environment). Local regression results are unaffected — existing `conformance.yml` workflow and `make conformance-up` targets are untouched.

## Test Results
- Unit tests: 848 passed
- Coverage: 95.22%

🤖 Generated with [Claude Code](https://claude.com/claude-code)