### PR TITLE
ci(release): use RELEASE_TOKEN to bypass branch protection on push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch || github.ref_name }}
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Set up Python 3.13
         uses: actions/setup-python@v6
@@ -66,7 +67,7 @@ jobs:
         id: release
         uses: python-semantic-release/python-semantic-release@v10.5.3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.RELEASE_TOKEN }}
           git_committer_name: "github-actions"
           git_committer_email: "actions@users.noreply.github.com"
 
@@ -97,7 +98,7 @@ jobs:
         uses: python-semantic-release/publish-action@v10.5.3
         if: steps.release.outputs.released == 'true'
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.RELEASE_TOKEN }}
           tag: ${{ steps.release.outputs.tag }}
 
       - name: Publish to PyPI


### PR DESCRIPTION
## Problem

semantic-release can't push version-bump commits + tags to main: `GH006: Protected branch update failed`. The default `GITHUB_TOKEN` doesn't have admin bypass on the branch protection ruleset.

## Fix

- Use `secrets.RELEASE_TOKEN` (PAT with `repo` scope) for checkout, semantic-release, and publish steps
- The PAT acts as the repo admin, matching the ruleset's `RepositoryRole:5` (Admin) bypass actor
- The checkout step's `token:` parameter configures git's credential helper so the subsequent `git push` (in the uv.lock sync step) also uses the PAT

## Changes

3 lines in `.github/workflows/release.yml`:
- `token: ${{ secrets.RELEASE_TOKEN }}` added to checkout step
- `github_token: ${{ secrets.GITHUB_TOKEN }}` → `${{ secrets.RELEASE_TOKEN }}` in both semantic-release and publish steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)