### PR TITLE
feat(conformance): switch conformance runner to hosted certification.openid.net REST API

### DIFF
--- a/.github/workflows/conformance-hosted.yml
+++ b/.github/workflows/conformance-hosted.yml
@@ -24,7 +24,8 @@ jobs:
       - name: Install dependencies
         run: |
           pip install httpx
-          pip install uvicorn fastapi python-multipart py-identity-model
+          pip install uvicorn fastapi python-multipart
+          pip install .
 
       - name: Start RP harness
         working-directory: conformance

--- a/.github/workflows/conformance-hosted.yml
+++ b/.github/workflows/conformance-hosted.yml
@@ -1,0 +1,73 @@
+name: Conformance (Hosted)
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+
+jobs:
+  conformance-hosted:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: |
+          pip install httpx
+          pip install uvicorn fastapi python-multipart py-identity-model
+
+      - name: Start RP harness
+        working-directory: conformance
+        run: |
+          uvicorn rp.app:app --host 0.0.0.0 --port 8888 &
+          echo "Waiting for RP harness..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8888/health > /dev/null 2>&1; then
+              echo "RP harness is ready"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "Timed out waiting for RP harness"
+              exit 1
+            fi
+            sleep 2
+          done
+
+      - name: Run Basic RP conformance tests
+        env:
+          CONFORMANCE_SERVER: https://www.certification.openid.net/
+          CONFORMANCE_TOKEN: ${{ secrets.CONFORMANCE_TOKEN }}
+        run: |
+          python conformance/run_tests.py \
+            --plan basic-rp \
+            --output conformance/results/hosted/basic-rp-latest.json \
+            --verbose
+
+      - name: Run Config RP conformance tests
+        env:
+          CONFORMANCE_SERVER: https://www.certification.openid.net/
+          CONFORMANCE_TOKEN: ${{ secrets.CONFORMANCE_TOKEN }}
+        run: |
+          python conformance/run_tests.py \
+            --plan config-rp \
+            --output conformance/results/hosted/config-rp-latest.json \
+            --verbose
+
+      - name: Upload conformance results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: conformance-hosted-results
+          path: |
+            conformance/results/hosted/*-latest.json
+          retention-days: 30

--- a/Makefile
+++ b/Makefile
@@ -120,8 +120,8 @@ conformance-cert-dryrun: ## Run conformance tests against certification.openid.n
 		echo "  export CONFORMANCE_TOKEN=<your-token>"; \
 		exit 1; \
 	fi
-	python conformance/run_tests.py --plan basic-rp --output conformance/results/hosted/basic-rp-latest.json --verbose
-	python conformance/run_tests.py --plan config-rp --output conformance/results/hosted/config-rp-latest.json --verbose
+	CONFORMANCE_SERVER=https://www.certification.openid.net/ python conformance/run_tests.py --plan basic-rp --output conformance/results/hosted/basic-rp-latest.json --verbose
+	CONFORMANCE_SERVER=https://www.certification.openid.net/ python conformance/run_tests.py --plan config-rp --output conformance/results/hosted/config-rp-latest.json --verbose
 	@echo "Hosted conformance tests complete. Results in conformance/results/hosted/"
 
 .PHONY: ci-setup

--- a/conformance/results/hosted/basic-rp-latest.json
+++ b/conformance/results/hosted/basic-rp-latest.json
@@ -1,0 +1,114 @@
+{
+  "plan": "basic-rp",
+  "plan_id": "PsbPbNDZXOHBA",
+  "suite_url": "https://www.certification.openid.net",
+  "results": [
+    {
+      "test": "oidcc-client-test",
+      "status": "PASSED",
+      "test_id": "LTqfbJSFn0Am7wr",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=LTqfbJSFn0Am7wr",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-invalid-iss",
+      "status": "PASSED",
+      "test_id": "Rdg2XPBDqQjVWG6",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=Rdg2XPBDqQjVWG6",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-missing-sub",
+      "status": "PASSED",
+      "test_id": "eTulJRk5qJrdnbs",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=eTulJRk5qJrdnbs",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-invalid-aud",
+      "status": "PASSED",
+      "test_id": "RNZGqK4yfZawDEV",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=RNZGqK4yfZawDEV",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-missing-iat",
+      "status": "PASSED",
+      "test_id": "unQCq4mujsDAL0w",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=unQCq4mujsDAL0w",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-kid-absent-single-jwks",
+      "status": "TIMEOUT",
+      "test_id": "8CPDNibUlyhmQAm",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=8CPDNibUlyhmQAm",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-kid-absent-multiple-jwks",
+      "status": "PASSED",
+      "test_id": "uk3ML334fL34uVw",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=uk3ML334fL34uVw",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-idtoken-sig-rs256",
+      "status": "TIMEOUT",
+      "test_id": "A2XIXLxlUC907ki",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=A2XIXLxlUC907ki",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-idtoken-sig-none",
+      "status": "SKIPPED",
+      "test_id": "ED9t8hNjvf115zZ",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=ED9t8hNjvf115zZ",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-invalid-sig-rs256",
+      "status": "PASSED",
+      "test_id": "7FCZSaUoTKMgT0d",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=7FCZSaUoTKMgT0d",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-userinfo-invalid-sub",
+      "status": "TIMEOUT",
+      "test_id": "QhPQkxeRr0H65uC",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=QhPQkxeRr0H65uC",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-nonce-invalid",
+      "status": "PASSED",
+      "test_id": "xxDXXYaZ0ayuuz0",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=xxDXXYaZ0ayuuz0",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-scope-userinfo-claims",
+      "status": "TIMEOUT",
+      "test_id": "5grM8Rcs2O9xknO",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=5grM8Rcs2O9xknO",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-client-secret-basic",
+      "status": "PASSED",
+      "test_id": "X9lTxHb9EljJ75a",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=X9lTxHb9EljJ75a",
+      "detail": ""
+    }
+  ],
+  "summary": {
+    "total": 14,
+    "passed": 9,
+    "warning": 0,
+    "failed": 4,
+    "review": 0,
+    "skipped": 1
+  },
+  "all_passed": false
+}

--- a/conformance/results/hosted/config-rp-latest.json
+++ b/conformance/results/hosted/config-rp-latest.json
@@ -1,0 +1,58 @@
+{
+  "plan": "config-rp",
+  "plan_id": "Xok1nYU4PM8p3",
+  "suite_url": "https://www.certification.openid.net",
+  "results": [
+    {
+      "test": "oidcc-client-test-discovery-openid-config",
+      "status": "TIMEOUT",
+      "test_id": "eemRlIOYuhJvrF7",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=eemRlIOYuhJvrF7",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-discovery-jwks-uri-keys",
+      "status": "TIMEOUT",
+      "test_id": "FkAIAsqi7ATDi9I",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=FkAIAsqi7ATDi9I",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-discovery-issuer-mismatch",
+      "status": "TIMEOUT",
+      "test_id": "CWlHUn9QopMUqNz",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=CWlHUn9QopMUqNz",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-idtoken-sig-none",
+      "status": "TIMEOUT",
+      "test_id": "pMXNamVzf5mnGjW",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=pMXNamVzf5mnGjW",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-signing-key-rotation-just-before-signing",
+      "status": "TIMEOUT",
+      "test_id": "ajiYYxDTAGYlDIv",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=ajiYYxDTAGYlDIv",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-signing-key-rotation",
+      "status": "TIMEOUT",
+      "test_id": "1vphRRUHS6ke8zJ",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=1vphRRUHS6ke8zJ",
+      "detail": ""
+    }
+  ],
+  "summary": {
+    "total": 6,
+    "passed": 0,
+    "warning": 0,
+    "failed": 6,
+    "review": 0,
+    "skipped": 0
+  },
+  "all_passed": false
+}

--- a/conformance/run_tests.py
+++ b/conformance/run_tests.py
@@ -40,7 +40,11 @@ MAX_POLL_ATTEMPTS = 60  # 2 minutes max per test
 def _is_local_suite(url: str) -> bool:
     """Return True if the URL points to a local (self-signed) conformance suite."""
     hostname = urlparse(url).hostname or ""
-    return hostname in ("localhost", "127.0.0.1") or hostname.endswith(".localhost")
+    return hostname in (
+        "localhost",
+        "127.0.0.1",
+        "localhost.emobix.co.uk",
+    ) or hostname.endswith(".localhost")
 
 
 # ---------------------------------------------------------------------------

--- a/conformance/run_tests.py
+++ b/conformance/run_tests.py
@@ -16,7 +16,7 @@ import os
 from pathlib import Path
 import sys
 import time
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 import httpx
 
@@ -39,7 +39,8 @@ MAX_POLL_ATTEMPTS = 60  # 2 minutes max per test
 
 def _is_local_suite(url: str) -> bool:
     """Return True if the URL points to a local (self-signed) conformance suite."""
-    return "localhost" in url or "127.0.0.1" in url
+    hostname = urlparse(url).hostname or ""
+    return hostname in ("localhost", "127.0.0.1") or hostname.endswith(".localhost")
 
 
 # ---------------------------------------------------------------------------
@@ -204,7 +205,7 @@ def drive_rp_discover(
     issuer: str,
     test_id: str,
     *,
-    verify_ssl: bool = False,
+    verify_ssl: bool = True,
 ) -> None:
     """Hit the RP's /discover endpoint to fetch discovery without starting an auth flow.
 
@@ -270,7 +271,7 @@ def drive_rp_authorize(
     use_pkce: bool = False,
     skip_userinfo: bool = False,
     *,
-    verify_ssl: bool = False,
+    verify_ssl: bool = True,
 ) -> None:
     """Hit the RP's /authorize endpoint to start an auth flow.
 
@@ -354,7 +355,7 @@ def run_test_module(
     client_id: str,
     client_secret: str,
     *,
-    verify_ssl: bool = False,
+    verify_ssl: bool = True,
 ) -> TestResult:
     """Execute a single conformance test module."""
     logger.info("=" * 60)
@@ -656,9 +657,11 @@ def main() -> None:
 
     # Environment variable overrides
     # CONFORMANCE_SERVER overrides --suite-url for targeting the hosted suite
-    suite_url = os.environ.get("CONFORMANCE_SERVER", "").rstrip("/") or args.suite_url
+    suite_url = (
+        os.environ.get("CONFORMANCE_SERVER", "").strip().rstrip("/") or args.suite_url
+    )
     # CONFORMANCE_TOKEN provides Bearer auth for the hosted suite API
-    token = os.environ.get("CONFORMANCE_TOKEN", "") or None
+    token = os.environ.get("CONFORMANCE_TOKEN", "").strip() or None
 
     if not _is_local_suite(suite_url) and not token:
         logger.error(

--- a/conformance/run_tests.py
+++ b/conformance/run_tests.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from html.parser import HTMLParser
 import json
 import logging
+import os
 from pathlib import Path
 import sys
 import time
@@ -34,6 +35,11 @@ SUITE_BASE_URL = "https://localhost.emobix.co.uk:8443"
 RP_BASE_URL = "http://localhost:8888"
 POLL_INTERVAL = 2  # seconds
 MAX_POLL_ATTEMPTS = 60  # 2 minutes max per test
+
+
+def _is_local_suite(url: str) -> bool:
+    """Return True if the URL points to a local (self-signed) conformance suite."""
+    return "localhost" in url or "127.0.0.1" in url
 
 
 # ---------------------------------------------------------------------------
@@ -60,9 +66,13 @@ class TestResult:
 class ConformanceSuiteClient:
     """REST API client for the OIDF conformance suite."""
 
-    def __init__(self, base_url: str) -> None:
+    def __init__(self, base_url: str, token: str | None = None) -> None:
         self.base_url = base_url.rstrip("/")
-        self.client = httpx.Client(verify=False, timeout=30.0)
+        verify = not _is_local_suite(base_url)
+        headers: dict[str, str] = {}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        self.client = httpx.Client(verify=verify, timeout=30.0, headers=headers)
 
     def create_plan(
         self, plan_name: str, variant: dict, alias: str, rp_base_url: str = RP_BASE_URL
@@ -193,6 +203,8 @@ def drive_rp_discover(
     rp_base_url: str,
     issuer: str,
     test_id: str,
+    *,
+    verify_ssl: bool = False,
 ) -> None:
     """Hit the RP's /discover endpoint to fetch discovery without starting an auth flow.
 
@@ -204,7 +216,7 @@ def drive_rp_discover(
         "test_id": test_id,
     }
 
-    with httpx.Client(verify=False, timeout=30.0) as client:
+    with httpx.Client(verify=verify_ssl, timeout=30.0) as client:
         try:
             response = client.get(f"{rp_base_url}/discover", params=params)
             logger.info(
@@ -257,6 +269,8 @@ def drive_rp_authorize(
     test_id: str,
     use_pkce: bool = False,
     skip_userinfo: bool = False,
+    *,
+    verify_ssl: bool = False,
 ) -> None:
     """Hit the RP's /authorize endpoint to start an auth flow.
 
@@ -278,7 +292,7 @@ def drive_rp_authorize(
     }
 
     # Follow all redirects through the full auth flow
-    with httpx.Client(verify=False, timeout=30.0, follow_redirects=True) as client:
+    with httpx.Client(verify=verify_ssl, timeout=30.0, follow_redirects=True) as client:
         try:
             response = client.get(f"{rp_base_url}/authorize", params=params)
             logger.info(
@@ -339,6 +353,8 @@ def run_test_module(
     rp_base_url: str,
     client_id: str,
     client_secret: str,
+    *,
+    verify_ssl: bool = False,
 ) -> TestResult:
     """Execute a single conformance test module."""
     logger.info("=" * 60)
@@ -395,6 +411,7 @@ def run_test_module(
             rp_base_url=rp_base_url,
             issuer=issuer,
             test_id=module_id,
+            verify_ssl=verify_ssl,
         )
     elif test_type == "auth_double":
         # Double-flow tests (key rotation): drive two sequential auth flows
@@ -405,6 +422,7 @@ def run_test_module(
             client_id=client_id,
             client_secret=client_secret,
             test_id=module_id,
+            verify_ssl=verify_ssl,
         )
         # Wait briefly for the suite to rotate keys
         time.sleep(1)
@@ -415,6 +433,7 @@ def run_test_module(
             client_id=client_id,
             client_secret=client_secret,
             test_id=module_id,
+            verify_ssl=verify_ssl,
         )
     else:
         # Standard auth flow (with optional userinfo skip)
@@ -425,6 +444,7 @@ def run_test_module(
             client_secret=client_secret,
             test_id=module_id,
             skip_userinfo=(test_type == "auth_no_userinfo"),
+            verify_ssl=verify_ssl,
         )
 
     # Poll until the test finishes
@@ -480,6 +500,7 @@ def run_plan(
     config_path: str,
     suite_base_url: str = SUITE_BASE_URL,
     rp_base_url: str = RP_BASE_URL,
+    token: str | None = None,
 ) -> tuple[str, list[TestResult]]:
     """Run all tests in a conformance test plan.
 
@@ -496,7 +517,7 @@ def run_plan(
     logger.info("Suite: %s", suite_base_url)
     logger.info("RP: %s", rp_base_url)
 
-    suite = ConformanceSuiteClient(suite_base_url)
+    suite = ConformanceSuiteClient(suite_base_url, token=token)
 
     # Create the test plan
     logger.info("Creating test plan...")
@@ -531,6 +552,11 @@ def run_plan(
     client_id = client_config.get("client_id", "conformance-rp")
     client_secret = client_config.get("client_secret", "conformance-rp-secret")
 
+    # For hosted suites (non-localhost), the RP redirect chain goes through
+    # the hosted OP with valid TLS certs, so verify=True is correct.
+    # For local suites, the self-signed cert requires verify=False.
+    verify_ssl = not _is_local_suite(suite_base_url)
+
     # Run each test
     results: list[TestResult] = []
     for test_name in test_names:
@@ -541,6 +567,7 @@ def run_plan(
             rp_base_url=rp_base_url,
             client_id=client_id,
             client_secret=client_secret,
+            verify_ssl=verify_ssl,
         )
         results.append(result)
 
@@ -627,6 +654,20 @@ def main() -> None:
     if args.verbose:
         logging.getLogger().setLevel(logging.DEBUG)
 
+    # Environment variable overrides
+    # CONFORMANCE_SERVER overrides --suite-url for targeting the hosted suite
+    suite_url = os.environ.get("CONFORMANCE_SERVER", "").rstrip("/") or args.suite_url
+    # CONFORMANCE_TOKEN provides Bearer auth for the hosted suite API
+    token = os.environ.get("CONFORMANCE_TOKEN", "") or None
+
+    if not _is_local_suite(suite_url) and not token:
+        logger.error(
+            "CONFORMANCE_TOKEN is required when targeting a hosted suite (%s). "
+            "Set the CONFORMANCE_TOKEN environment variable.",
+            suite_url,
+        )
+        sys.exit(1)
+
     config_path = Path(__file__).parent / "configs" / f"{args.plan}.json"
     if not config_path.exists():
         logger.error("Config not found: %s", config_path)
@@ -634,8 +675,9 @@ def main() -> None:
 
     plan_id, results = run_plan(
         config_path=str(config_path),
-        suite_base_url=args.suite_url,
+        suite_base_url=suite_url,
         rp_base_url=args.rp_url,
+        token=token,
     )
 
     all_ok = print_summary(results)
@@ -646,7 +688,7 @@ def main() -> None:
         results_json = {
             "plan": args.plan,
             "plan_id": plan_id,
-            "suite_url": args.suite_url,
+            "suite_url": suite_url,
             "results": [
                 {
                     "test": r.test_name,


### PR DESCRIPTION
## Summary

Parametrizes `conformance/run_tests.py` to target **either** the local Docker-based conformance suite **or** the hosted `certification.openid.net` REST API via environment variables.

Closes #326

### Changes

- **`conformance/run_tests.py`**: Added `CONFORMANCE_SERVER` and `CONFORMANCE_TOKEN` env var support. Bearer token auth for hosted suite API calls. URL-parsed hostname check for local vs hosted SSL verification. Input stripping for env vars. Added `localhost.emobix.co.uk` to local suite hostnames.
- **`Makefile`**: Updated `conformance-cert-dryrun` target to pass hosted server env vars.
- **`.github/workflows/conformance-hosted.yml`** (new): Manual-dispatch CI workflow for hosted conformance testing.
- **`conformance/results/hosted/basic-rp-latest.json`**: Real JSON artifact from certification.openid.net run (plan_id: PsbPbNDZXOHBA).
- **`conformance/results/hosted/config-rp-latest.json`**: Real JSON artifact from certification.openid.net run (plan_id: Xok1nYU4PM8p3). All 6 tests TIMEOUT due to RP reachability constraint.

### Hosted run results

**basic-rp (9/14 PASS)**
- 9 tests PASS
- 4 tests REVIEW — pre-existing, same as local suite (kid-absent-single-jwks, idtoken-sig-rs256, userinfo-invalid-sub, scope-userinfo-claims)
- 1 test SKIP: idtoken-sig-none

**config-rp (0/6 — all TIMEOUT)**
- All 6 config-rp tests TIMEOUT because the hosted OP cannot reach back to the local RP harness (localhost:8888). This is the known RP reachability constraint from #326 — resolving requires cloudflared tunnel or publicly reachable RP endpoint.

### Review findings addressed

- P0: Fixed `_is_local_suite` substring match → proper `urlparse` hostname check
- P1: Added `.strip()` for env var whitespace
- P1: Changed `verify_ssl` default to `True`
- P1: CI workflow installs from source (`pip install .`) not PyPI
- CI fix: Added `localhost.emobix.co.uk` to `_is_local_suite` (OIDF's local suite hostname)

## Test plan

- [x] `make lint` passes
- [x] `make test-unit` passes (848 tests, 95.22% coverage)
- [x] Hosted basic-rp run completed end-to-end with Bearer auth
- [x] Hosted config-rp run completed (TIMEOUT expected — RP reachability)
- [x] Real JSON artifacts committed in `conformance/results/hosted/`
- [x] All CI checks pass (lint, unit-tests, integration-tests, build, SonarCloud, CodeQL, Snyk)