### PR TITLE
chore(conformance): consolidate Makefile targets and add token guard (#342)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,12 +110,12 @@ conformance-down: ## Tear down conformance suite
 .PHONY: conformance-test
 conformance-test: $(if $(HOSTED),,conformance-up) ## Run conformance tests (HOSTED=1 for hosted suite)
 ifdef HOSTED
-	python conformance/run_tests.py --plan basic-rp --suite-url $(CONFORMANCE_SERVER) --output conformance/results/hosted/basic-rp-latest.json --verbose
-	python conformance/run_tests.py --plan config-rp --suite-url $(CONFORMANCE_SERVER) --output conformance/results/hosted/config-rp-latest.json --verbose
+	uv run python conformance/run_tests.py --plan basic-rp --suite-url "$(CONFORMANCE_SERVER)" --output conformance/results/hosted/basic-rp-latest.json --verbose
+	uv run python conformance/run_tests.py --plan config-rp --suite-url "$(CONFORMANCE_SERVER)" --output conformance/results/hosted/config-rp-latest.json --verbose
 	@echo "Hosted conformance tests complete. Results in conformance/results/hosted/"
 else
-	python conformance/run_tests.py --plan basic-rp --output conformance/results/basic-rp-latest.json --verbose
-	python conformance/run_tests.py --plan config-rp --output conformance/results/config-rp-latest.json --verbose
+	uv run python conformance/run_tests.py --plan basic-rp --output conformance/results/basic-rp-latest.json --verbose
+	uv run python conformance/run_tests.py --plan config-rp --output conformance/results/config-rp-latest.json --verbose
 	@echo "Conformance tests complete. Results in conformance/results/"
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -1,34 +1,46 @@
+# py-identity-model Makefile
+# Run `make help` to see all available targets.
+
+CONFORMANCE_SERVER ?= https://www.certification.openid.net/
+ACTION ?= create
+
+# ── Build ────────────────────────────────────────────────────────────
+
 .PHONY: build-dist
-build-dist:
+build-dist: ## Build wheel and sdist
 	uv sync
 	uv build
 
 .PHONY: upload-dist
-upload-dist:
+upload-dist: ## Publish package to PyPI
 	uv publish
 
+# ── Lint ─────────────────────────────────────────────────────────────
+
 .PHONY: lint
-lint:
+lint: ## Run all pre-commit hooks (ruff, pyrefly, coverage)
 	uv run pre-commit run -a
 
+# ── Tests ────────────────────────────────────────────────────────────
+
 .PHONY: test
-test:
+test: ## Run all tests (unit + integration)
 	uv run pytest src/tests -v -n auto --cov=src/py_identity_model --cov-report=term-missing --cov-report=html --cov-fail-under=80 --ignore=src/tests/benchmarks -p no:benchmark
 
 .PHONY: test-unit
-test-unit:
+test-unit: ## Run unit tests only
 	uv run pytest src/tests -m unit -v -n auto --cov=src/py_identity_model --cov-report=term-missing --cov-report=html --cov-fail-under=80 --ignore=src/tests/benchmarks -p no:benchmark
 
 .PHONY: test-integration-local
-test-integration-local:
+test-integration-local: ## Run integration tests against local provider
 	uv run pytest src/tests -m integration --env-file=.env.local -v -n auto -p no:benchmark
 
 .PHONY: test-integration-ory
-test-integration-ory:
+test-integration-ory: ## Run integration tests against Ory
 	uv run pytest src/tests -m integration -v -n auto -p no:benchmark
 
 .PHONY: test-integration-descope
-test-integration-descope:
+test-integration-descope: ## Run integration tests against Descope
 	@echo "Running integration tests against Descope..."
 	uv run pytest src/tests -m integration $(if $(wildcard .env.descope),--env-file=.env.descope) -v -n auto -p no:benchmark
 
@@ -41,33 +53,47 @@ test-integration-node-oidc: ## Run integration tests against node-oidc-provider
 		(docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml down && exit 1)
 	docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml down
 
+.PHONY: test-benchmark
+test-benchmark: ## Run benchmarks
+	uv run pytest src/tests/benchmarks -v --benchmark-only --benchmark-sort=name
+
+.PHONY: test-examples
+test-examples: ## Run example integration tests (Docker)
+	@echo "Running example integration tests..."
+	cd examples && ./run-tests.sh
+
+.PHONY: test-all
+test-all: test test-examples ## Run all tests including examples
+
+# ── Docs ─────────────────────────────────────────────────────────────
+
+.PHONY: docs-serve
+docs-serve: ## Serve mkdocs documentation locally
+	uv run --group docs mkdocs serve
+
+.PHONY: docs-build
+docs-build: ## Build mkdocs documentation
+	uv run --group docs mkdocs build --strict
+
+# ── Utilities ────────────────────────────────────────────────────────
+
 .PHONY: provider-matrix
 provider-matrix: ## Show provider capability matrix from discovery documents
 	uv run python src/tests/integration/provider_matrix.py
 
 .PHONY: generate-token
-generate-token:
+generate-token: ## Generate a sample JWT token
 	uv run python examples/generate_token.py
 
-.PHONY: test-benchmark
-test-benchmark:
-	uv run pytest src/tests/benchmarks -v --benchmark-only --benchmark-sort=name
+.PHONY: ci-setup
+ci-setup: ## CI environment setup
+	python -m pip install --upgrade pip
+	pip install pipx
+	pipx install uv
+	uv venv
+	uv sync --all-packages
 
-.PHONY: test-examples
-test-examples:
-	@echo "Running example integration tests..."
-	cd examples && ./run-tests.sh
-
-.PHONY: test-all
-test-all: test test-examples
-
-.PHONY: docs-serve
-docs-serve:
-	uv run --group docs mkdocs serve
-
-.PHONY: docs-build
-docs-build:
-	uv run --group docs mkdocs build --strict
+# ── Conformance ──────────────────────────────────────────────────────
 
 .PHONY: conformance-build
 conformance-build: ## Build conformance suite containers
@@ -82,52 +108,39 @@ conformance-down: ## Tear down conformance suite
 	docker compose -f conformance/docker-compose.yml down -v
 
 .PHONY: conformance-test
-conformance-test: conformance-up ## Run all conformance profiles against local suite
+conformance-test: $(if $(HOSTED),,conformance-up) ## Run conformance tests (HOSTED=1 for hosted suite)
+ifdef HOSTED
+	python conformance/run_tests.py --plan basic-rp --suite-url $(CONFORMANCE_SERVER) --output conformance/results/hosted/basic-rp-latest.json --verbose
+	python conformance/run_tests.py --plan config-rp --suite-url $(CONFORMANCE_SERVER) --output conformance/results/hosted/config-rp-latest.json --verbose
+	@echo "Hosted conformance tests complete. Results in conformance/results/hosted/"
+else
 	python conformance/run_tests.py --plan basic-rp --output conformance/results/basic-rp-latest.json --verbose
 	python conformance/run_tests.py --plan config-rp --output conformance/results/config-rp-latest.json --verbose
 	@echo "Conformance tests complete. Results in conformance/results/"
+endif
 
 .PHONY: conformance-test-harness
 conformance-test-harness: ## Run conformance harness unit tests (parser + callback)
 	uv run --with fastapi --with httpx --with python-multipart pytest conformance/tests/ -v
 
 .PHONY: conformance-token
-conformance-token: ## Create OIDF API token via Playwright and push to HCP Vault Secrets
+conformance-token: ## Manage OIDF API token (ACTION=create|show|env)
+ifeq ($(ACTION),show)
+	uv run conformance/scripts/rotate_conformance_token.py --dry-run --show-token
+else ifeq ($(ACTION),env)
+	@echo "export CONFORMANCE_TOKEN=$$(hcp vault-secrets secrets open CONFORMANCE_TOKEN --app py-identity-model --format json | jq -r '.static_version.value')"
+	@echo "# Run the above command, or: eval \$$(make conformance-token ACTION=env)"
+else
 	@echo "Launching browser for certification.openid.net login..."
 	@echo "First run: sign in via Google/GitLab in the browser window."
 	@echo "Subsequent runs: session is cached in ~/.cache/py-identity-model/playwright-profile/"
 	uv run conformance/scripts/rotate_conformance_token.py
+endif
 
-.PHONY: conformance-token-show
-conformance-token-show: ## Create token and print to stderr (dry run, no Vault push)
-	uv run conformance/scripts/rotate_conformance_token.py --dry-run --show-token
+# ── Help ─────────────────────────────────────────────────────────────
 
-.PHONY: conformance-token-env
-conformance-token-env: ## Pull CONFORMANCE_TOKEN from HCP Vault and print export command
-	@echo "export CONFORMANCE_TOKEN=$$(hcp vault-secrets secrets open CONFORMANCE_TOKEN --app py-identity-model --format json | jq -r '.static_version.value')"
-	@echo "# Run the above command, or: eval \$$(make conformance-token-env)"
+.DEFAULT_GOAL := help
 
-.PHONY: conformance-cert-dryrun
-conformance-cert-dryrun: ## Run conformance tests against certification.openid.net (requires CONFORMANCE_TOKEN)
-	@if [ -z "$$CONFORMANCE_TOKEN" ]; then \
-		echo "Error: CONFORMANCE_TOKEN is not set."; \
-		echo ""; \
-		echo "To get a token:"; \
-		echo "  make conformance-token        # creates token + pushes to HCP Vault"; \
-		echo "  eval \$$(make conformance-token-env)  # pulls from HCP into shell"; \
-		echo ""; \
-		echo "Or set it manually:"; \
-		echo "  export CONFORMANCE_TOKEN=<your-token>"; \
-		exit 1; \
-	fi
-	python conformance/run_tests.py --plan basic-rp --output conformance/results/hosted/basic-rp-latest.json --verbose
-	python conformance/run_tests.py --plan config-rp --output conformance/results/hosted/config-rp-latest.json --verbose
-	@echo "Hosted conformance tests complete. Results in conformance/results/hosted/"
-
-.PHONY: ci-setup
-ci-setup:
-	python -m pip install --upgrade pip
-	pip install pipx
-	pipx install uv
-	uv venv
-	uv sync --all-packages
+.PHONY: help
+help: ## Show available targets
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/conformance/run_tests.py
+++ b/conformance/run_tests.py
@@ -617,7 +617,7 @@ def print_summary(results: list[TestResult]) -> bool:
 def main() -> None:
     # Environment variable overrides
     env_server = os.environ.get("CONFORMANCE_SERVER", "")
-    env_token = os.environ.get("CONFORMANCE_TOKEN", "")
+    env_token = os.environ.get("CONFORMANCE_TOKEN", "").strip()
 
     parser = argparse.ArgumentParser(
         description="Run OIDF conformance tests against py-identity-model"

--- a/conformance/run_tests.py
+++ b/conformance/run_tests.py
@@ -12,10 +12,11 @@ from dataclasses import dataclass
 from html.parser import HTMLParser
 import json
 import logging
+import os
 from pathlib import Path
 import sys
 import time
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 import httpx
 
@@ -34,6 +35,21 @@ SUITE_BASE_URL = "https://localhost.emobix.co.uk:8443"
 RP_BASE_URL = "http://localhost:8888"
 POLL_INTERVAL = 2  # seconds
 MAX_POLL_ATTEMPTS = 60  # 2 minutes max per test
+
+LOCAL_HOSTNAMES = frozenset(
+    {
+        "localhost",
+        "127.0.0.1",
+        "::1",
+        "localhost.emobix.co.uk",
+    }
+)
+
+
+def _is_local_suite(url: str) -> bool:
+    """Check if the suite URL points to a local conformance instance."""
+    hostname = urlparse(url).hostname or ""
+    return hostname in LOCAL_HOSTNAMES
 
 
 # ---------------------------------------------------------------------------
@@ -60,9 +76,16 @@ class TestResult:
 class ConformanceSuiteClient:
     """REST API client for the OIDF conformance suite."""
 
-    def __init__(self, base_url: str) -> None:
+    def __init__(self, base_url: str, token: str | None = None) -> None:
         self.base_url = base_url.rstrip("/")
-        self.client = httpx.Client(verify=False, timeout=30.0)
+        headers: dict[str, str] = {}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        self.client = httpx.Client(
+            verify=not _is_local_suite(base_url),
+            timeout=30.0,
+            headers=headers,
+        )
 
     def create_plan(
         self, plan_name: str, variant: dict, alias: str, rp_base_url: str = RP_BASE_URL
@@ -480,6 +503,7 @@ def run_plan(
     config_path: str,
     suite_base_url: str = SUITE_BASE_URL,
     rp_base_url: str = RP_BASE_URL,
+    token: str | None = None,
 ) -> tuple[str, list[TestResult]]:
     """Run all tests in a conformance test plan.
 
@@ -496,7 +520,7 @@ def run_plan(
     logger.info("Suite: %s", suite_base_url)
     logger.info("RP: %s", rp_base_url)
 
-    suite = ConformanceSuiteClient(suite_base_url)
+    suite = ConformanceSuiteClient(suite_base_url, token=token)
 
     # Create the test plan
     logger.info("Creating test plan...")
@@ -591,6 +615,10 @@ def print_summary(results: list[TestResult]) -> bool:
 
 
 def main() -> None:
+    # Environment variable overrides
+    env_server = os.environ.get("CONFORMANCE_SERVER", "")
+    env_token = os.environ.get("CONFORMANCE_TOKEN", "")
+
     parser = argparse.ArgumentParser(
         description="Run OIDF conformance tests against py-identity-model"
     )
@@ -602,8 +630,8 @@ def main() -> None:
     )
     parser.add_argument(
         "--suite-url",
-        default=SUITE_BASE_URL,
-        help=f"Conformance suite base URL (default: {SUITE_BASE_URL})",
+        default=env_server or SUITE_BASE_URL,
+        help=f"Conformance suite base URL (env: CONFORMANCE_SERVER, default: {SUITE_BASE_URL})",
     )
     parser.add_argument(
         "--rp-url",
@@ -627,6 +655,19 @@ def main() -> None:
     if args.verbose:
         logging.getLogger().setLevel(logging.DEBUG)
 
+    # Token guard: require CONFORMANCE_TOKEN for non-local suites
+    if not _is_local_suite(args.suite_url) and not env_token:
+        logger.error(
+            "CONFORMANCE_TOKEN is required when targeting a hosted suite (%s).\n\n"
+            "To get a token:\n"
+            "  make conformance-token              # create + push to HCP Vault\n"
+            "  eval $(make conformance-token ACTION=env)  # pull from HCP into shell\n\n"
+            "Or set it manually:\n"
+            "  export CONFORMANCE_TOKEN=<your-token>",
+            args.suite_url,
+        )
+        sys.exit(1)
+
     config_path = Path(__file__).parent / "configs" / f"{args.plan}.json"
     if not config_path.exists():
         logger.error("Config not found: %s", config_path)
@@ -636,6 +677,7 @@ def main() -> None:
         config_path=str(config_path),
         suite_base_url=args.suite_url,
         rp_base_url=args.rp_url,
+        token=env_token or None,
     )
 
     all_ok = print_summary(results)


### PR DESCRIPTION
## Summary

Closes #342

- **Token targets consolidated**: `conformance-token`, `conformance-token-show`, `conformance-token-env` → single `make conformance-token [ACTION=create|show|env]` (default: create)
- **Test targets unified**: `conformance-test` and `conformance-cert-dryrun` → `make conformance-test [HOSTED=1]`. `HOSTED=1` targets the hosted suite with token auth and writes to `conformance/results/hosted/`
- **Token guard moved to `run_tests.py`**: When `--suite-url` points to a non-local server, fails early with actionable message if `CONFORMANCE_TOKEN` is missing
- **`make help`** target added — lists all targets with descriptions; set as default goal
- Shell injection fix: quoted `$(CONFORMANCE_SERVER)` in Makefile
- Consistency: `uv run python` instead of bare `python` for conformance targets
- Robustness: `.strip()` on `CONFORMANCE_TOKEN` to catch whitespace-only values

## Test plan

- [x] `make lint` — all hooks pass
- [x] `make test-unit` — 848 passed, 95.22% coverage
- [x] `make help` — lists all 24 targets with descriptions
- [x] `make -n conformance-test` — dry-run local mode correct
- [x] `make -n conformance-test HOSTED=1` — dry-run hosted mode correct
- [x] `make -n conformance-token` — dry-run default (create) correct
- [x] `make -n conformance-token ACTION=show` — dry-run show correct
- [x] `make -n conformance-token ACTION=env` — dry-run env correct