### PR TITLE
fix(conformance): make UserInfo sub mismatch fatal and display claims

### DIFF
--- a/.github/workflows/conformance-hosted.yml
+++ b/.github/workflows/conformance-hosted.yml
@@ -1,0 +1,74 @@
+name: Conformance (Hosted)
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+
+jobs:
+  conformance-hosted:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: |
+          pip install httpx
+          pip install uvicorn fastapi python-multipart
+          pip install .
+
+      - name: Start RP harness
+        working-directory: conformance
+        run: |
+          uvicorn app:app --host 0.0.0.0 --port 8888 &
+          echo "Waiting for RP harness..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8888/health > /dev/null 2>&1; then
+              echo "RP harness is ready"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "Timed out waiting for RP harness"
+              exit 1
+            fi
+            sleep 2
+          done
+
+      - name: Run Basic RP conformance tests
+        env:
+          CONFORMANCE_SERVER: https://www.certification.openid.net/
+          CONFORMANCE_TOKEN: ${{ secrets.CONFORMANCE_TOKEN }}
+        run: |
+          python conformance/run_tests.py \
+            --plan basic-rp \
+            --output conformance/results/hosted/basic-rp-latest.json \
+            --verbose
+
+      - name: Run Config RP conformance tests
+        env:
+          CONFORMANCE_SERVER: https://www.certification.openid.net/
+          CONFORMANCE_TOKEN: ${{ secrets.CONFORMANCE_TOKEN }}
+        run: |
+          python conformance/run_tests.py \
+            --plan config-rp \
+            --output conformance/results/hosted/config-rp-latest.json \
+            --verbose
+
+      - name: Upload conformance results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: conformance-hosted-results
+          path: |
+            conformance/results/hosted/*-latest.json
+          retention-days: 30

--- a/conformance/app.py
+++ b/conformance/app.py
@@ -564,9 +564,18 @@ def _handle_callback(request_url: str) -> HTMLResponse | JSONResponse:
             if userinfo_response.is_successful:
                 userinfo_claims = userinfo_response.claims or {}
             else:
-                # UserInfo errors should be reported but may not be fatal
-                logger.warning("UserInfo error: %s", userinfo_response.error)
-                session.result["userinfo_error"] = userinfo_response.error
+                # OIDC Core 1.0 §5.3.4: sub mismatch is a fatal error.
+                # The RP MUST reject the UserInfo response if sub differs
+                # from the ID token sub.
+                error_msg = userinfo_response.error
+                logger.error("UserInfo validation failed: %s", error_msg)
+                session.result["status"] = "error"
+                session.result["error"] = f"userinfo_validation: {error_msg}"
+                _store_test_result(session)
+                return HTMLResponse(
+                    content=f"<h1>UserInfo Validation Failed</h1><p>{error_msg}</p>",
+                    status_code=400,
+                )
         except PyIdentityModelException as exc:
             logger.warning("UserInfo exception: %s", exc)
             session.result["userinfo_error"] = str(exc)
@@ -582,12 +591,19 @@ def _handle_callback(request_url: str) -> HTMLResponse | JSONResponse:
         "Callback successful for issuer=%s, sub=%s", session.issuer, claims.get("sub")
     )
 
+    # Build response body with ID token and UserInfo claims so the conformance
+    # suite can verify the RP fetched and displayed them.
+    claim_lines = [
+        f"<p>Subject: {claims.get('sub', 'N/A')}</p>",
+        f"<p>Issuer: {claims.get('iss', 'N/A')}</p>",
+    ]
+    if userinfo_claims:
+        claim_lines.append("<h2>UserInfo Claims</h2>")
+        for key, value in userinfo_claims.items():
+            claim_lines.append(f"<p>{key}: {value}</p>")
+
     return HTMLResponse(
-        content=(
-            "<h1>Authentication Successful</h1>"
-            f"<p>Subject: {claims.get('sub', 'N/A')}</p>"
-            f"<p>Issuer: {claims.get('iss', 'N/A')}</p>"
-        ),
+        content="<h1>Authentication Successful</h1>" + "\n".join(claim_lines),
         status_code=200,
     )
 


### PR DESCRIPTION
## Summary

- **UserInfo sub mismatch is now fatal**: Per OIDC Core 1.0 §5.3.4, the RP MUST reject UserInfo responses where `sub` differs from the ID token. Previously treated as a non-fatal warning, now returns 400 — fixing `oidcc-client-test-userinfo-invalid-sub`.
- **UserInfo claims displayed in response**: The success HTML now renders all UserInfo claims, allowing the conformance suite to verify the RP fetched them — fixing `oidcc-client-test-scope-userinfo-claims`.
- **Hosted conformance workflow**: Adds `conformance-hosted.yml` for `workflow_dispatch` runs against `certification.openid.net`.

Combined with the SSL cert sharing (#343) and cache clearing (#343) already on main, this should bring the Basic RP conformance results from 7/14 → 13/14 (only `idtoken-sig-none` intentionally skipped).

Supersedes #359 — close that PR after merging this one.

## Test plan

- [ ] Verify lint + unit tests pass in CI
- [ ] Verify integration tests pass in CI
- [ ] Verify local conformance suite: `make conformance-test` shows no `[????]` results
- [ ] Verify hosted conformance via `conformance-hosted.yml` workflow dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)