### PR TITLE
fix(jwt): remove lru_cache from JWT decode to prevent stale expired tokens

### DIFF
--- a/src/py_identity_model/core/jwt_helpers.py
+++ b/src/py_identity_model/core/jwt_helpers.py
@@ -46,51 +46,45 @@ def _get_pyjwk(key_json: str, algorithm: str | None) -> PyJWK:
     return PyJWK(json.loads(key_json), algorithm)
 
 
-@lru_cache(maxsize=256)
-def _decode_jwt_cached(  # noqa: PLR0913  # @lru_cache requires individual hashable params
-    jwt: str,
-    key_json: str,
-    algorithms_tuple: tuple[str, ...],
+def _decode_jwt(  # noqa: PLR0913  # JWT validation requires these params per RFC 7519
+    jwt_token: str,
+    key: dict,
+    algorithms: list[str],
     audience: str | None,
-    issuer: str | tuple[str, ...] | None,
-    options_json: str | None,
+    issuer: str | list[str] | None,
+    options: dict | None,
     leeway: float | None = None,
 ) -> dict:
     """
-    Internal cached JWT decoding.
+    Internal JWT decoding.
 
-    Caches decoded tokens to avoid redundant signature verification when
-    the same JWT is validated multiple times.
+    Decodes and validates a JWT token using PyJWT. The PyJWK construction
+    is cached via ``_get_pyjwk`` to avoid redundant cryptographic key loading.
 
     Args:
-        jwt: The JWT token
-        key_json: Serialized key
-        algorithms_tuple: Algorithms as tuple (hashable)
+        jwt_token: The JWT token
+        key: Public key as a dict
+        algorithms: Allowed algorithms
         audience: Expected audience
-        issuer: Expected issuer (string or tuple for multi-issuer)
-        options_json: Serialized options
+        issuer: Expected issuer (string or list for multi-issuer)
+        options: Additional validation options
         leeway: Clock skew tolerance in seconds
 
     Returns:
         Decoded claims
     """
-    pyjwk = _get_pyjwk(key_json, algorithms_tuple[0] if algorithms_tuple else None)
-    options = json.loads(options_json) if options_json else None
-
-    # PyJWT accepts issuer as str or sequence
-    issuer_param: str | list[str] | None = (
-        list(issuer) if isinstance(issuer, tuple) else issuer
-    )
+    key_json = json.dumps(key, sort_keys=True)
+    pyjwk = _get_pyjwk(key_json, algorithms[0] if algorithms else None)
 
     kwargs: dict = {
         "audience": audience,
-        "algorithms": list(algorithms_tuple),
-        "issuer": issuer_param,
+        "algorithms": algorithms,
+        "issuer": issuer,
         "options": options,
         "leeway": leeway if leeway is not None else 0,
     }
 
-    return decode(jwt, pyjwk, **kwargs)
+    return decode(jwt_token, pyjwk, **kwargs)
 
 
 def decode_and_validate_jwt(  # noqa: PLR0913  # RFC 7519 §7.2 validation requires these params
@@ -137,30 +131,15 @@ def decode_and_validate_jwt(  # noqa: PLR0913  # RFC 7519 §7.2 validation requi
                 "issuer must not be an empty list; omit or set to None to skip issuer validation"
             )
 
-        # Convert to hashable types for caching
-        key_json = json.dumps(key, sort_keys=True)
-        algorithms_tuple = tuple(algorithms)
-        options_json = json.dumps(options, sort_keys=True) if options else None
-
-        # Convert issuer list to tuple for hashability
-        issuer_hashable: str | tuple[str, ...] | None = (
-            tuple(issuer) if isinstance(issuer, list) else issuer
-        )
-
-        decoded = _decode_jwt_cached(
+        decoded = _decode_jwt(
             jwt,
-            key_json,
-            algorithms_tuple,
+            key,
+            algorithms,
             audience,
-            issuer_hashable,
-            options_json,
+            issuer,
+            options,
             leeway=leeway,
         )
-
-        # Return a shallow copy to prevent cache aliasing —
-        # lru_cache returns the same dict reference on cache hits,
-        # so callers mutating the returned dict would corrupt the cache.
-        decoded = decoded.copy()
 
         # Validate subject claim (PyJWT doesn't do this natively)
         if subject is not None and decoded.get("sub") != subject:

--- a/src/tests/unit/test_aio_token_validation.py
+++ b/src/tests/unit/test_aio_token_validation.py
@@ -19,7 +19,6 @@ from py_identity_model.aio.token_validation import (
     clear_jwks_cache,
     validate_token,
 )
-from py_identity_model.core.jwt_helpers import _decode_jwt_cached
 from py_identity_model.core.models import TokenValidationConfig
 from py_identity_model.exceptions import (
     ConfigurationException,
@@ -50,11 +49,9 @@ def _clear_caches():
     """Clear all caches between tests."""
     _get_disco_response.cache_clear()
     clear_jwks_cache()
-    _decode_jwt_cached.cache_clear()
     yield
     _get_disco_response.cache_clear()
     clear_jwks_cache()
-    _decode_jwt_cached.cache_clear()
 
 
 class TestAsyncTokenValidation:
@@ -184,8 +181,6 @@ class TestAsyncJwksCacheTTL:
         )
         assert jwks_route.call_count == 1
 
-        _decode_jwt_cached.cache_clear()
-
         # Second call — should use cached JWKS
         await validate_token(
             jwt=token,
@@ -225,8 +220,6 @@ class TestAsyncJwksCacheTTL:
             disco_doc_address="https://example.com/.well-known/openid-configuration",
         )
         assert jwks_route.call_count == 1
-
-        _decode_jwt_cached.cache_clear()
 
         # Simulate TTL expiry
         with patch("py_identity_model.core.jwks_cache.time") as mock_time:

--- a/src/tests/unit/test_enhanced_token_validation.py
+++ b/src/tests/unit/test_enhanced_token_validation.py
@@ -8,10 +8,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 import jwt as pyjwt
 import pytest
 
-from py_identity_model.core.jwt_helpers import (
-    _decode_jwt_cached,
-    decode_and_validate_jwt,
-)
+from py_identity_model.core.jwt_helpers import decode_and_validate_jwt
 from py_identity_model.exceptions import (
     ConfigurationException,
     InvalidIssuerException,
@@ -57,14 +54,6 @@ def rsa_keypair():
 def _sign_jwt(pem: bytes, claims: dict, headers: dict | None = None) -> str:
     """Sign a JWT with the given private key."""
     return pyjwt.encode(claims, pem, algorithm="RS256", headers=headers)
-
-
-@pytest.fixture(autouse=True)
-def _clear_jwt_cache():
-    """Clear JWT decode cache between tests."""
-    _decode_jwt_cached.cache_clear()
-    yield
-    _decode_jwt_cached.cache_clear()
 
 
 @pytest.mark.unit

--- a/src/tests/unit/test_jwt_helpers.py
+++ b/src/tests/unit/test_jwt_helpers.py
@@ -31,10 +31,10 @@ class TestDecodeAndValidateJWT:
         def mock_decode(*_args, **_kwargs):
             raise InvalidAudienceError("Invalid audience")
 
-        # Mock the internal _decode_jwt_cached function
+        # Mock the internal _decode_jwt function
         monkeypatch.setattr(
             py_identity_model.core.jwt_helpers,
-            "_decode_jwt_cached",
+            "_decode_jwt",
             mock_decode,
         )
 
@@ -56,7 +56,7 @@ class TestDecodeAndValidateJWT:
 
         monkeypatch.setattr(
             py_identity_model.core.jwt_helpers,
-            "_decode_jwt_cached",
+            "_decode_jwt",
             mock_decode,
         )
 
@@ -78,7 +78,7 @@ class TestDecodeAndValidateJWT:
 
         monkeypatch.setattr(
             py_identity_model.core.jwt_helpers,
-            "_decode_jwt_cached",
+            "_decode_jwt",
             mock_decode,
         )
 
@@ -100,7 +100,7 @@ class TestDecodeAndValidateJWT:
 
         monkeypatch.setattr(
             py_identity_model.core.jwt_helpers,
-            "_decode_jwt_cached",
+            "_decode_jwt",
             mock_decode,
         )
 

--- a/src/tests/unit/test_sync_token_validation.py
+++ b/src/tests/unit/test_sync_token_validation.py
@@ -12,7 +12,6 @@ import httpx
 import pytest
 import respx
 
-from py_identity_model.core.jwt_helpers import _decode_jwt_cached
 from py_identity_model.core.models import TokenValidationConfig
 from py_identity_model.exceptions import (
     ConfigurationException,
@@ -47,11 +46,9 @@ def _clear_caches():
     """Clear all caches between tests."""
     _get_disco_response.cache_clear()
     clear_jwks_cache()
-    _decode_jwt_cached.cache_clear()
     yield
     _get_disco_response.cache_clear()
     clear_jwks_cache()
-    _decode_jwt_cached.cache_clear()
 
 
 class TestSyncTokenValidation:
@@ -195,9 +192,6 @@ class TestSyncJwksCacheTTL:
         )
         assert jwks_route.call_count == 1
 
-        # Clear JWT decode cache so second call re-decodes
-        _decode_jwt_cached.cache_clear()
-
         # Second call — should use cached JWKS (no additional fetch)
         validate_token(
             jwt=token,
@@ -236,8 +230,6 @@ class TestSyncJwksCacheTTL:
             disco_doc_address="https://example.com/.well-known/openid-configuration",
         )
         assert jwks_route.call_count == 1
-
-        _decode_jwt_cached.cache_clear()
 
         # Simulate TTL expiry by shifting cached_at into the past
         with patch("py_identity_model.core.jwks_cache.time") as mock_time:


### PR DESCRIPTION
## Summary

- **Remove `@lru_cache(maxsize=256)` from `_decode_jwt_cached`** to fix a security issue where expired JWT tokens could be returned from cache instead of being re-validated on each call
- **Rename `_decode_jwt_cached` to `_decode_jwt`** and simplify its signature to accept native types (list, dict) directly instead of hashable conversions (tuple, JSON string)
- **Remove the `.copy()` call** on the decoded dict return value — the cache aliasing concern only existed because `lru_cache` returns the same dict reference on cache hits
- **Keep `_get_pyjwk` lru_cache (maxsize=128)** — PyJWK construction is genuinely expensive (cryptographic key parsing) and keys don't expire

## Security Impact

The `lru_cache` on JWT decode meant that once a token was decoded and cached, subsequent validations of the same token would return the cached result without re-checking expiration. This allowed expired tokens to pass validation if they had been successfully validated before expiring. Removing the cache ensures every token validation performs a fresh decode with full expiration checking.

## Test plan

- [x] Updated mock targets in `test_jwt_helpers.py` from `_decode_jwt_cached` to `_decode_jwt`
- [x] Removed `_decode_jwt_cached.cache_clear()` calls from fixtures in `test_aio_token_validation.py`, `test_sync_token_validation.py`, and `test_enhanced_token_validation.py`
- [x] Removed `_decode_jwt_cached` import from `test_enhanced_token_validation.py`
- [x] All 848 unit tests pass with 95.21% coverage
- [x] `make lint` passes (ruff, ruff format, pyrefly, coverage)

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)