### PR TITLE
ci: add pre-push hook enforcing integration, conformance, and example tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,11 @@ repos:
         types: [python]
         pass_filenames: false
         require_serial: true
+      - id: pre-push-validation
+        name: pre-push validation (integration + conformance + examples)
+        entry: make pre-push
+        language: system
+        pass_filenames: false
+        require_serial: true
+        stages: [pre-push]
+        always_run: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,13 +31,11 @@ py-identity-model is a production-grade OIDC/OAuth2.0 helper library for Python 
    make lint                    # Run BEFORE every commit
    ```
 
-3. **Always run ALL test suites before pushing** — unit tests alone are not sufficient. Run the full local validation sequence:
+3. **Always run `make pre-push` before pushing** — unit tests alone are not sufficient. This is enforced by a pre-push git hook, but you must also run it explicitly when working in agents or automated workflows:
    ```bash
-   make lint                           # Pre-commit hooks
-   make test-unit                      # Unit tests (fast, no deps)
-   make test-integration-node-oidc     # Integration tests against local fixture (Docker)
+   make pre-push    # Runs: lint + node-oidc integration + conformance harness + examples
    ```
-   The node-oidc integration tests catch client config mismatches, protocol bugs, and grant type issues that unit tests cannot. If you only have credentials for Ory or Descope, also run `make test-integration-ory` or `make test-integration-descope` respectively.
+   This target runs the full local validation sequence: `make lint`, `make test-integration-node-oidc` (Docker), `make conformance-test-harness`, and `make test-examples` (Docker). Do NOT push without passing all of these. If you only have credentials for Ory or Descope, also run `make test-integration-ory` or `make test-integration-descope` respectively.
 
 4. **Use conventional commits** — commit messages must follow the Angular convention (see Git Workflow section below). Commits to `main` trigger semantic-release version bumps.
 

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,11 @@ test-examples: ## Run example integration tests (Docker)
 .PHONY: test-all
 test-all: test test-examples ## Run all tests including examples
 
+# ── Pre-push ────────────────────────────────────────────────────────
+
+.PHONY: pre-push
+pre-push: lint test-integration-node-oidc conformance-test-harness test-examples ## Full local validation before push
+
 # ── Docs ─────────────────────────────────────────────────────────────
 
 .PHONY: docs-serve


### PR DESCRIPTION
## Summary

- Add `make pre-push` Makefile target that runs the full local validation suite before push
- Register it as a pre-commit framework `pre-push` hook so pushes are blocked if any step fails
- Update CLAUDE.md workflow rules to reference `make pre-push`

### What `make pre-push` runs

1. `make lint` — ruff, ruff format, pyrefly, unit tests with coverage
2. `make test-integration-node-oidc` — Docker-based integration tests against node-oidc-provider
3. `make conformance-test-harness` — conformance harness unit tests
4. `make test-examples` — Docker-based example integration tests

### Setup

After merging, run once to install the pre-push hook:
```bash
pre-commit install --hook-type pre-push
```

## Test plan
- [x] `make pre-push` passes locally (all 4 stages)
- [x] Port conflict scenario verified and resolved
- [ ] CI pipeline validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)