### PR TITLE
fix(security): enforce key type / algorithm consistency to prevent algorithm confusion

### DIFF
--- a/src/py_identity_model/core/parsers.py
+++ b/src/py_identity_model/core/parsers.py
@@ -28,6 +28,40 @@ _ALG_TO_KTY: dict[str, str] = {
 }
 
 
+def _validate_key_alg_consistency(
+    key: JsonWebKey,
+    jwt_alg: str | None,
+) -> None:
+    """Validate that a JWK's key type is consistent with the JWT algorithm.
+
+    Prevents algorithm confusion attacks where an attacker substitutes
+    a key of one type (e.g. EC) to verify a token signed with a different
+    algorithm family (e.g. RS256).
+
+    Raises:
+        TokenValidationException: If the key type does not match the algorithm.
+    """
+    if not jwt_alg:
+        return
+
+    expected_kty = _ALG_TO_KTY.get(jwt_alg)
+    if expected_kty and key.kty != expected_kty:
+        raise TokenValidationException(
+            f"Key type '{key.kty}' is incompatible with algorithm '{jwt_alg}' "
+            f"(expected key type '{expected_kty}')",
+            token_part="header",
+            details={"kid": key.kid, "kty": key.kty, "alg": jwt_alg},
+        )
+
+    # If the key declares an alg, it must match the JWT header exactly
+    if key.alg and key.alg != jwt_alg:
+        raise TokenValidationException(
+            f"Key algorithm '{key.alg}' does not match JWT algorithm '{jwt_alg}'",
+            token_part="header",
+            details={"kid": key.kid, "key_alg": key.alg, "jwt_alg": jwt_alg},
+        )
+
+
 def extract_kid_from_jwt(jwt: str) -> str | None:
     """
     Extract the 'kid' (key ID) from a JWT header without verification.
@@ -151,6 +185,7 @@ def find_key_by_kid(
                 "JWT has no kid header; using the single signing key from JWKS"
             )
             public_key = signing_keys[0]
+            _validate_key_alg_consistency(public_key, jwt_alg)
             alg = public_key.alg if public_key.alg else (jwt_alg or "RS256")
             return public_key.as_dict(), alg
         raise TokenValidationException(
@@ -173,6 +208,7 @@ def find_key_by_kid(
         )
 
     public_key = filtered_keys[0]
+    _validate_key_alg_consistency(public_key, jwt_alg)
     alg = public_key.alg if public_key.alg else "RS256"
     return public_key.as_dict(), alg
 
@@ -218,8 +254,9 @@ def get_public_key_from_jwk(jwt: str, keys: list[JsonWebKey]) -> JsonWebKey:
                 "JWT has no kid header; using the single signing key from JWKS"
             )
             key = signing_keys[0]
+            _validate_key_alg_consistency(key, jwt_alg)
             if not key.alg:
-                key.alg = headers.get("alg")
+                key.alg = jwt_alg
             return key
         raise TokenValidationException(
             "JWT has no kid header and JWKS contains multiple signing keys; "
@@ -244,8 +281,10 @@ def get_public_key_from_jwk(jwt: str, keys: list[JsonWebKey]) -> JsonWebKey:
         )
 
     key = filtered_keys[0]
+    jwt_alg = headers.get("alg")
+    _validate_key_alg_consistency(key, jwt_alg)
     if not key.alg:
-        key.alg = headers["alg"]
+        key.alg = jwt_alg
 
     logger.debug(f"Found matching key with kid: {kid}, alg: {key.alg}")
     return key

--- a/src/tests/unit/test_algorithm_confusion.py
+++ b/src/tests/unit/test_algorithm_confusion.py
@@ -1,0 +1,139 @@
+"""Tests for algorithm confusion prevention (Batch 4, #349).
+
+Validates that key type / algorithm consistency is enforced to prevent
+algorithm confusion attacks.
+"""
+
+# Minimal JWT headers for testing (base64-encoded, no signature needed)
+import base64
+import json
+
+import pytest
+
+from py_identity_model.core.models import JsonWebKey
+from py_identity_model.core.parsers import (
+    _validate_key_alg_consistency,
+    find_key_by_kid,
+    get_public_key_from_jwk,
+)
+from py_identity_model.exceptions import TokenValidationException
+
+
+def _make_jwt(kid: str | None = "k1", alg: str = "RS256") -> str:
+    """Build a minimal unsigned JWT with given header fields."""
+    header: dict = {"typ": "JWT", "alg": alg}
+    if kid is not None:
+        header["kid"] = kid
+    h = base64.urlsafe_b64encode(json.dumps(header).encode()).rstrip(b"=").decode()
+    p = base64.urlsafe_b64encode(b'{"sub":"test"}').rstrip(b"=").decode()
+    return f"{h}.{p}.fake_sig"
+
+
+class TestValidateKeyAlgConsistency:
+    """Direct tests for _validate_key_alg_consistency."""
+
+    def test_rsa_key_with_rs256(self):
+        key = JsonWebKey(kty="RSA", kid="k1", n="n", e="e")
+        _validate_key_alg_consistency(key, "RS256")  # should not raise
+
+    def test_rsa_key_with_ps256(self):
+        key = JsonWebKey(kty="RSA", kid="k1", n="n", e="e")
+        _validate_key_alg_consistency(key, "PS256")  # should not raise
+
+    def test_ec_key_with_es256(self):
+        key = JsonWebKey(kty="EC", kid="k1", crv="P-256", x="x", y="y")
+        _validate_key_alg_consistency(key, "ES256")  # should not raise
+
+    def test_rsa_key_rejects_es256(self):
+        key = JsonWebKey(kty="RSA", kid="k1", n="n", e="e")
+        with pytest.raises(TokenValidationException, match="incompatible"):
+            _validate_key_alg_consistency(key, "ES256")
+
+    def test_ec_key_rejects_rs256(self):
+        key = JsonWebKey(kty="EC", kid="k1", crv="P-256", x="x", y="y")
+        with pytest.raises(TokenValidationException, match="incompatible"):
+            _validate_key_alg_consistency(key, "RS256")
+
+    def test_key_alg_mismatch(self):
+        key = JsonWebKey(kty="RSA", kid="k1", alg="RS256", n="n", e="e")
+        with pytest.raises(TokenValidationException, match="does not match"):
+            _validate_key_alg_consistency(key, "RS384")
+
+    def test_key_alg_matches(self):
+        key = JsonWebKey(kty="RSA", kid="k1", alg="RS256", n="n", e="e")
+        _validate_key_alg_consistency(key, "RS256")  # should not raise
+
+    def test_no_jwt_alg_skips_validation(self):
+        key = JsonWebKey(kty="RSA", kid="k1", n="n", e="e")
+        _validate_key_alg_consistency(key, None)  # should not raise
+
+    def test_unknown_alg_skips_kty_check(self):
+        """Unknown algorithms skip kty check but still check key.alg."""
+        key = JsonWebKey(kty="RSA", kid="k1", n="n", e="e")
+        _validate_key_alg_consistency(key, "CUSTOM")  # should not raise
+
+    def test_okp_key_with_eddsa(self):
+        key = JsonWebKey(kty="OKP", kid="k1", crv="Ed25519", x="x")
+        _validate_key_alg_consistency(key, "EdDSA")  # should not raise
+
+    def test_okp_key_rejects_rs256(self):
+        key = JsonWebKey(kty="OKP", kid="k1", crv="Ed25519", x="x")
+        with pytest.raises(TokenValidationException, match="incompatible"):
+            _validate_key_alg_consistency(key, "RS256")
+
+
+class TestFindKeyByKidAlgorithmEnforcement:
+    """Test that find_key_by_kid enforces key/algorithm consistency."""
+
+    def test_rejects_ec_key_with_rs256_jwt(self):
+        keys = [JsonWebKey(kty="EC", kid="k1", crv="P-256", x="x", y="y")]
+        with pytest.raises(TokenValidationException, match="incompatible"):
+            find_key_by_kid("k1", keys, jwt_alg="RS256")
+
+    def test_rejects_rsa_key_with_es256_jwt(self):
+        keys = [JsonWebKey(kty="RSA", kid="k1", n="n", e="e")]
+        with pytest.raises(TokenValidationException, match="incompatible"):
+            find_key_by_kid("k1", keys, jwt_alg="ES256")
+
+    def test_allows_rsa_key_with_rs256_jwt(self):
+        keys = [JsonWebKey(kty="RSA", kid="k1", n="n", e="e")]
+        key_dict, _alg = find_key_by_kid("k1", keys, jwt_alg="RS256")
+        assert key_dict["kid"] == "k1"
+
+    def test_rejects_key_alg_mismatch(self):
+        keys = [JsonWebKey(kty="RSA", kid="k1", alg="RS256", n="n", e="e")]
+        with pytest.raises(TokenValidationException, match="does not match"):
+            find_key_by_kid("k1", keys, jwt_alg="RS384")
+
+    def test_no_kid_single_key_validates(self):
+        keys = [JsonWebKey(kty="EC", kid="k1", crv="P-256", x="x", y="y")]
+        with pytest.raises(TokenValidationException, match="incompatible"):
+            find_key_by_kid(None, keys, jwt_alg="RS256")
+
+
+class TestGetPublicKeyFromJwkAlgorithmEnforcement:
+    """Test that get_public_key_from_jwk enforces key/algorithm consistency."""
+
+    def test_rejects_ec_key_with_rs256_jwt(self):
+        jwt = _make_jwt(kid="k1", alg="RS256")
+        keys = [JsonWebKey(kty="EC", kid="k1", crv="P-256", x="x", y="y")]
+        with pytest.raises(TokenValidationException, match="incompatible"):
+            get_public_key_from_jwk(jwt, keys)
+
+    def test_allows_matching_key(self):
+        jwt = _make_jwt(kid="k1", alg="RS256")
+        keys = [JsonWebKey(kty="RSA", kid="k1", n="n", e="e")]
+        key = get_public_key_from_jwk(jwt, keys)
+        assert key.kid == "k1"
+
+    def test_rejects_key_alg_mismatch(self):
+        jwt = _make_jwt(kid="k1", alg="RS384")
+        keys = [JsonWebKey(kty="RSA", kid="k1", alg="RS256", n="n", e="e")]
+        with pytest.raises(TokenValidationException, match="does not match"):
+            get_public_key_from_jwk(jwt, keys)
+
+    def test_no_kid_single_key_validates(self):
+        jwt = _make_jwt(kid=None, alg="RS256")
+        keys = [JsonWebKey(kty="EC", crv="P-256", x="x", y="y")]
+        with pytest.raises(TokenValidationException, match="incompatible"):
+            get_public_key_from_jwk(jwt, keys)

--- a/src/tests/unit/test_parsers.py
+++ b/src/tests/unit/test_parsers.py
@@ -354,8 +354,8 @@ class TestGetPublicKeyFromJwk:
         assert key.kid == "ec-key"
         assert key.alg == "ES256"
 
-    def test_get_public_key_no_kid_fallback_to_all_keys(self):
-        """When all keys have use=enc, fall back to all keys."""
+    def test_get_public_key_no_kid_fallback_to_all_keys_rejects_alg_mismatch(self):
+        """When all keys have use=enc and alg doesn't match JWT, reject."""
         jwt = _create_jwt_without_kid()
         keys = [
             JsonWebKey(
@@ -363,9 +363,8 @@ class TestGetPublicKeyFromJwk:
             ),
         ]
 
-        key = get_public_key_from_jwk(jwt, keys)
-
-        assert key.kid == "enc-key"
+        with pytest.raises(TokenValidationException, match="does not match"):
+            get_public_key_from_jwk(jwt, keys)
 
 
 class TestJwksFromDict:


### PR DESCRIPTION
## Summary

- Adds `_validate_key_alg_consistency()` that enforces key type matches JWT algorithm family:
  - RSA keys → RS/PS algorithms only
  - EC keys → ES algorithms only
  - OKP keys → EdDSA/Ed25519/Ed448 only
- Verifies key's declared `alg` field matches JWT header `alg` exactly
- Applied on all code paths in `find_key_by_kid` and `get_public_key_from_jwk` (kid match + no-kid single key)
- Updated existing test that expected encryption key (`RSA-OAEP`) to be used for signing (`RS256`) — this was the exact attack vector

20 new tests.

Closes #349

## Test plan

- [x] 931 unit tests pass
- [x] Pre-commit hooks pass (ruff, pyrefly, coverage)
- [ ] CI integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)