### PR TITLE
fix(security): add JWKS size limit and fix async cleanup lock race

### DIFF
--- a/src/py_identity_model/aio/http_client.py
+++ b/src/py_identity_model/aio/http_client.py
@@ -36,13 +36,16 @@ class _AsyncClientState(TypedDict):
     """Module-level mutable state container (avoids `global` statements)."""
 
     client: httpx.AsyncClient | None
-    cleanup_lock: asyncio.Lock | None
 
 
 _state: _AsyncClientState = {
     "client": None,
-    "cleanup_lock": None,
 }
+
+# Dedicated cleanup lock — created eagerly to avoid initialization races.
+# asyncio.Lock() is safe to create outside an event loop; it binds to the
+# running loop on first acquire.
+_cleanup_lock = asyncio.Lock()
 
 
 def _log_retry(message: str, delay: float, attempt: int, retries: int) -> None:
@@ -186,12 +189,8 @@ async def close_async_http_client() -> None:
         This function uses asyncio.Lock for proper async cleanup without
         blocking the event loop.
     """
-    # Initialize the async cleanup lock if needed (lazy initialization)
-    if _state["cleanup_lock"] is None:
-        _state["cleanup_lock"] = asyncio.Lock()
-
     if _state["client"] is not None:
-        async with _state["cleanup_lock"]:
+        async with _cleanup_lock:
             if _state["client"] is not None:
                 await _state["client"].aclose()
                 _state["client"] = None
@@ -210,7 +209,6 @@ def _reset_async_http_client() -> None:
     """
     with _async_client_creation_lock:
         _state["client"] = None
-        _state["cleanup_lock"] = None
 
 
 __all__ = [

--- a/src/py_identity_model/core/http_utils.py
+++ b/src/py_identity_model/core/http_utils.py
@@ -20,6 +20,7 @@ from ..exceptions import NetworkException
 DEFAULT_HTTP_TIMEOUT = 30.0
 DEFAULT_RETRY_MAX_ATTEMPTS = 3
 DEFAULT_RETRY_BASE_DELAY = 1.0
+DEFAULT_MAX_JWKS_SIZE = 512 * 1024  # 512 KB
 
 # HTTP status codes for retry logic
 HTTP_TOO_MANY_REQUESTS = 429
@@ -103,8 +104,18 @@ def check_no_redirect(response: httpx.Response) -> None:
         )
 
 
+def get_max_jwks_size() -> int:
+    """Get maximum JWKS response size from environment variable.
+
+    Returns:
+        int: Maximum response size in bytes.
+    """
+    return int(os.getenv("MAX_JWKS_SIZE", str(DEFAULT_MAX_JWKS_SIZE)))
+
+
 __all__ = [
     "DEFAULT_HTTP_TIMEOUT",
+    "DEFAULT_MAX_JWKS_SIZE",
     "DEFAULT_RETRY_BASE_DELAY",
     "DEFAULT_RETRY_MAX_ATTEMPTS",
     "HTTP_INTERNAL_SERVER_ERROR",
@@ -113,6 +124,7 @@ __all__ = [
     "HTTP_TOO_MANY_REQUESTS",
     "calculate_delay",
     "check_no_redirect",
+    "get_max_jwks_size",
     "get_retry_config",
     "get_timeout",
     "should_retry_response",

--- a/src/py_identity_model/core/response_processors.py
+++ b/src/py_identity_model/core/response_processors.py
@@ -13,6 +13,7 @@ from urllib.parse import urlparse
 from ..exceptions import DiscoveryException
 from ..logging_config import logger
 from .discovery_policy import DiscoveryPolicy
+from .http_utils import get_max_jwks_size
 from .models import (
     AuthorizationCodeTokenResponse,
     ClientCredentialsTokenResponse,
@@ -295,6 +296,27 @@ def parse_jwks_response(response: httpx.Response) -> JwksResponse:
         JwksResponse: Parsed JWKS response with keys
     """
     if response.is_success:
+        # Check response size before parsing
+        max_size = get_max_jwks_size()
+        content_length = response.headers.get("Content-Length")
+        if content_length and int(content_length) > max_size:
+            return JwksResponse(
+                is_successful=False,
+                error=(
+                    f"JWKS response too large: Content-Length {content_length} "
+                    f"exceeds limit of {max_size} bytes"
+                ),
+            )
+        body_size = len(response.content)
+        if body_size > max_size:
+            return JwksResponse(
+                is_successful=False,
+                error=(
+                    f"JWKS response too large: {body_size} bytes "
+                    f"exceeds limit of {max_size} bytes"
+                ),
+            )
+
         content_type_header = response.headers.get("Content-Type", "")
         media_type = content_type_header.split(";")[0].strip().lower()
         if not media_type:

--- a/src/tests/unit/test_resource_limits.py
+++ b/src/tests/unit/test_resource_limits.py
@@ -1,0 +1,132 @@
+"""Tests for resource limits and concurrency fixes (Batch 5).
+
+Covers:
+- #353: JWKS response size limit
+- #357: Async cleanup lock race
+"""
+
+import asyncio
+import json
+from typing import ClassVar
+
+import httpx
+import pytest
+
+from py_identity_model.aio.http_client import (
+    _cleanup_lock,
+    _reset_async_http_client,
+    close_async_http_client,
+    get_async_http_client,
+)
+from py_identity_model.core.http_utils import DEFAULT_MAX_JWKS_SIZE
+from py_identity_model.core.response_processors import parse_jwks_response
+
+
+# ============================================================================
+# #353 — JWKS response size limit
+# ============================================================================
+
+
+class TestJwksSizeLimit:
+    """Verify JWKS responses are rejected when too large."""
+
+    _SMALL_JWKS: ClassVar[dict] = {
+        "keys": [{"kty": "RSA", "kid": "k1", "n": "n", "e": "AQAB"}]
+    }
+
+    def test_accepts_small_response(self):
+        response = httpx.Response(
+            200,
+            json=self._SMALL_JWKS,
+            headers={"Content-Type": "application/json"},
+        )
+        result = parse_jwks_response(response)
+        assert result.is_successful is True
+
+    def test_rejects_large_content_length(self):
+        response = httpx.Response(
+            200,
+            content=b'{"keys": []}',
+            headers={
+                "Content-Type": "application/json",
+                "Content-Length": str(DEFAULT_MAX_JWKS_SIZE + 1),
+            },
+        )
+        result = parse_jwks_response(response)
+        assert result.is_successful is False
+        assert result.error is not None
+        assert "too large" in result.error
+
+    def test_rejects_large_body(self, monkeypatch):
+        """Body larger than limit is rejected even without Content-Length."""
+        monkeypatch.setenv("MAX_JWKS_SIZE", "100")
+        big_body = json.dumps({"keys": [{"kty": "RSA", "n": "x" * 200, "e": "AQAB"}]})
+        response = httpx.Response(
+            200,
+            content=big_body.encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        result = parse_jwks_response(response)
+        assert result.is_successful is False
+        assert result.error is not None
+        assert "too large" in result.error
+
+    def test_respects_env_var_override(self, monkeypatch):
+        monkeypatch.setenv("MAX_JWKS_SIZE", "50")
+        response = httpx.Response(
+            200,
+            content=b'{"keys": [{"kty": "RSA", "n": "long_value", "e": "AQAB"}]}',
+            headers={"Content-Type": "application/json"},
+        )
+        result = parse_jwks_response(response)
+        assert result.is_successful is False
+        assert result.error is not None
+        assert "too large" in result.error
+
+    def test_non_success_skips_size_check(self):
+        """Non-2xx responses report HTTP error, not size."""
+        response = httpx.Response(
+            500,
+            content=b"x" * (DEFAULT_MAX_JWKS_SIZE + 1),
+        )
+        result = parse_jwks_response(response)
+        assert result.is_successful is False
+        assert result.error is not None
+        assert "500" in result.error
+
+
+# ============================================================================
+# #357 — Async cleanup lock race
+# ============================================================================
+
+
+class TestAsyncCleanupLock:
+    """Verify the async cleanup lock is eagerly initialized."""
+
+    def test_cleanup_lock_is_module_level(self):
+        """The cleanup lock should exist at module level, not lazily created."""
+        assert isinstance(_cleanup_lock, asyncio.Lock)
+
+    @pytest.mark.asyncio
+    async def test_concurrent_close_does_not_race(self):
+        """Multiple concurrent close calls should not raise."""
+        _reset_async_http_client()
+        _ = get_async_http_client()
+
+        # Close concurrently from multiple coroutines
+        await asyncio.gather(
+            close_async_http_client(),
+            close_async_http_client(),
+            close_async_http_client(),
+        )
+        # No error = no race
+
+    @pytest.mark.asyncio
+    async def test_close_then_recreate(self):
+        """Client can be recreated after closing."""
+        _reset_async_http_client()
+        client1 = get_async_http_client()
+        await close_async_http_client()
+        client2 = get_async_http_client()
+        assert client2 is not client1
+        _reset_async_http_client()


### PR DESCRIPTION
## Summary

- **#353 — JWKS size limit**: Rejects JWKS responses exceeding 512KB (configurable via `MAX_JWKS_SIZE` env var). Checks both `Content-Length` header and actual body size before parsing.
- **#357 — Async cleanup lock race**: Replaced lazily-initialized `cleanup_lock` with an eagerly-created module-level `asyncio.Lock()`. Prevents race condition when multiple coroutines call `close_async_http_client()` concurrently.

8 new tests.

Closes #353, closes #357

## Test plan

- [x] 939 unit tests pass
- [x] Pre-commit hooks pass
- [ ] CI integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)