### PR TITLE
fix(security): deprecate get_public_key_from_jwk to prevent cached key mutation

### DIFF
--- a/src/py_identity_model/core/__init__.py
+++ b/src/py_identity_model/core/__init__.py
@@ -32,7 +32,10 @@ from .models import (
     JwksResponse,
     TokenValidationConfig,
 )
-from .parsers import get_public_key_from_jwk, jwks_from_dict
+from .parsers import (
+    get_public_key_from_jwk as get_public_key_from_jwk,
+)
+from .parsers import jwks_from_dict
 from .pkce import (
     generate_code_challenge,
     generate_code_verifier,
@@ -86,7 +89,6 @@ __all__ = [
     "generate_code_verifier",
     "generate_pkce_pair",
     # From parsers
-    "get_public_key_from_jwk",
     "jwks_from_dict",
     "parse_authorize_callback_response",
     "validate_authorize_callback_state",

--- a/src/py_identity_model/core/parsers.py
+++ b/src/py_identity_model/core/parsers.py
@@ -264,7 +264,7 @@ def get_public_key_from_jwk(jwt: str, keys: list[JsonWebKey]) -> JsonWebKey:
             logger.warning(
                 "JWT has no kid header; using the single signing key from JWKS"
             )
-            key = copy.copy(signing_keys[0])
+            key = copy.deepcopy(signing_keys[0])
             _validate_key_alg_consistency(key, jwt_alg)
             if not key.alg:
                 key.alg = jwt_alg
@@ -291,7 +291,7 @@ def get_public_key_from_jwk(jwt: str, keys: list[JsonWebKey]) -> JsonWebKey:
             details={"kid": kid, "available_kids": available_kids},
         )
 
-    key = copy.copy(filtered_keys[0])
+    key = copy.deepcopy(filtered_keys[0])
     jwt_alg = headers.get("alg")
     _validate_key_alg_consistency(key, jwt_alg)
     if not key.alg:

--- a/src/py_identity_model/core/parsers.py
+++ b/src/py_identity_model/core/parsers.py
@@ -4,6 +4,9 @@ Parsing functions for py-identity-model.
 This module contains parsing logic used by both sync and async implementations.
 """
 
+import copy
+import warnings
+
 from jwt import get_unverified_header
 
 from ..exceptions import TokenValidationException
@@ -230,6 +233,14 @@ def get_public_key_from_jwk(jwt: str, keys: list[JsonWebKey]) -> JsonWebKey:
     Raises:
         TokenValidationException: If no matching key is found
     """
+    warnings.warn(
+        "get_public_key_from_jwk is deprecated and will be removed in a future "
+        "version. Use find_key_by_kid() instead, which returns (key_dict, alg) "
+        "without mutating the original key.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     headers = get_unverified_header(jwt)
     kid = headers.get("kid")
     logger.debug(f"Looking for key with kid: {kid}")
@@ -253,7 +264,7 @@ def get_public_key_from_jwk(jwt: str, keys: list[JsonWebKey]) -> JsonWebKey:
             logger.warning(
                 "JWT has no kid header; using the single signing key from JWKS"
             )
-            key = signing_keys[0]
+            key = copy.copy(signing_keys[0])
             _validate_key_alg_consistency(key, jwt_alg)
             if not key.alg:
                 key.alg = jwt_alg
@@ -280,7 +291,7 @@ def get_public_key_from_jwk(jwt: str, keys: list[JsonWebKey]) -> JsonWebKey:
             details={"kid": kid, "available_kids": available_kids},
         )
 
-    key = filtered_keys[0]
+    key = copy.copy(filtered_keys[0])
     jwt_alg = headers.get("alg")
     _validate_key_alg_consistency(key, jwt_alg)
     if not key.alg:
@@ -294,6 +305,5 @@ __all__ = [
     "extract_jwt_header_fields",
     "extract_kid_from_jwt",
     "find_key_by_kid",
-    "get_public_key_from_jwk",
     "jwks_from_dict",
 ]

--- a/src/tests/unit/test_parsers.py
+++ b/src/tests/unit/test_parsers.py
@@ -6,7 +6,9 @@ import logging
 
 import pytest
 
+import py_identity_model.core as core_mod
 from py_identity_model.core.models import JsonWebKey
+import py_identity_model.core.parsers as parsers_mod
 from py_identity_model.core.parsers import (
     extract_jwt_header_fields,
     extract_kid_from_jwt,
@@ -365,6 +367,79 @@ class TestGetPublicKeyFromJwk:
 
         with pytest.raises(TokenValidationException, match="does not match"):
             get_public_key_from_jwk(jwt, keys)
+
+
+class TestGetPublicKeyFromJwkSecurityFixes:
+    """Security tests for get_public_key_from_jwk (T200 / #375).
+
+    Validates that the deprecation + copy-on-use fix blocks the cached key
+    mutation exploit where an attacker's JWT header could permanently alter
+    the alg field on a cached JsonWebKey.
+    """
+
+    def test_key_mutation_via_jwt_header_blocked(self):
+        """Exploit scenario: JWT with alg=HS256 must not mutate cached key's alg."""
+        original_key = JsonWebKey(kty="RSA", kid="key1", alg=None, n="abc", e="def")
+        jwt = _create_jwt_with_kid("key1", alg="RS256")
+
+        with pytest.warns(DeprecationWarning, match="deprecated"):
+            returned_key = get_public_key_from_jwk(jwt, [original_key])
+
+        # Returned key should have the alg set
+        assert returned_key.alg == "RS256"
+        # Original key must NOT be mutated
+        assert original_key.alg is None
+
+    def test_kid_path_no_mutation(self):
+        """Kid-matched path must also not mutate the original key."""
+        original_key = JsonWebKey(kty="RSA", kid="target", alg=None, n="abc", e="def")
+        jwt = _create_jwt_with_kid("target", alg="RS384")
+
+        with pytest.warns(DeprecationWarning, match="deprecated"):
+            returned_key = get_public_key_from_jwk(jwt, [original_key])
+
+        assert returned_key.alg == "RS384"
+        assert original_key.alg is None
+
+    def test_no_kid_path_no_mutation(self):
+        """No-kid single-key fallback path must not mutate the original key."""
+        original_key = JsonWebKey(kty="RSA", kid="only-key", alg=None, n="abc", e="def")
+        jwt = _create_jwt_without_kid(alg="RS256")
+
+        with pytest.warns(DeprecationWarning, match="deprecated"):
+            returned_key = get_public_key_from_jwk(jwt, [original_key])
+
+        assert returned_key.alg == "RS256"
+        assert original_key.alg is None
+
+    def test_deprecation_warning_emitted(self):
+        """Calling get_public_key_from_jwk must emit DeprecationWarning."""
+        jwt = _create_jwt_with_kid("key1", alg="RS256")
+        keys = [JsonWebKey(kty="RSA", kid="key1", alg="RS256", n="abc", e="def")]
+
+        with pytest.warns(DeprecationWarning, match="deprecated"):
+            get_public_key_from_jwk(jwt, keys)
+
+    def test_returned_key_has_correct_alg_when_key_already_has_alg(self):
+        """When key already has alg set, returned copy preserves it."""
+        original_key = JsonWebKey(kty="RSA", kid="key1", alg="RS256", n="abc", e="def")
+        jwt = _create_jwt_with_kid("key1", alg="RS256")
+
+        with pytest.warns(DeprecationWarning, match="deprecated"):
+            returned_key = get_public_key_from_jwk(jwt, [original_key])
+
+        assert returned_key.alg == "RS256"
+        # Original still untouched (was already RS256, but verify identity differs)
+        assert returned_key is not original_key
+
+    def test_not_in_core_all(self):
+        """get_public_key_from_jwk must not be in core.__all__ (removed from public API)."""
+        assert "get_public_key_from_jwk" not in core_mod.__all__
+        assert "get_public_key_from_jwk" not in parsers_mod.__all__
+
+    def test_still_importable_for_backwards_compat(self):
+        """Function is still importable even though removed from __all__."""
+        assert callable(get_public_key_from_jwk)
 
 
 class TestJwksFromDict:


### PR DESCRIPTION
## Summary

- Deprecate `get_public_key_from_jwk()` with `DeprecationWarning` — `find_key_by_kid()` is the safe replacement
- Use `copy.deepcopy()` on matched keys before mutating `.alg`, preventing permanent corruption of cached JWKS keys
- Remove `get_public_key_from_jwk` from `core.__all__` to discourage new usage

Closes #375

## Exploit Scenario Blocked

1. JWKS cached with keys where `alg` is `None` (common — many IdPs omit `alg`)
2. Attacker sends JWT with `alg: HS256`, calls `get_public_key_from_jwk(jwt, cached_keys)`
3. `key.alg` is permanently mutated to `HS256` on the cached `JsonWebKey` object
4. All subsequent validation using that cached key sees `alg: HS256` instead of correct algorithm

The fix uses `deepcopy()` so mutations only affect the returned copy, never the cached original.

## Review Findings Addressed

- **5 reviewers** (Blind Hunter, Edge Case Hunter, Acceptance Auditor, Sentinel, Viper): all PASS
- **1 P1 resolved**: upgraded `copy.copy()` → `copy.deepcopy()` to close mutable list field leakage (flagged by Blind Hunter, Edge Case Hunter, Viper)
- **4/4 acceptance criteria**: PASS
- **0 blocking findings**

## Test plan
- [x] Unit tests pass (`test_key_mutation_via_jwt_header_blocked`, `test_deprecation_warning_emitted`, `test_returned_key_has_correct_alg`, `test_kid_path_no_mutation`, `test_not_in_core_all`)
- [x] Lint passes
- [x] Independent review agents passed
- [ ] CI passes