### PR TITLE
fix(security): add JWKS max key count limit and KeyError guard

### DIFF
--- a/src/py_identity_model/core/http_utils.py
+++ b/src/py_identity_model/core/http_utils.py
@@ -21,6 +21,7 @@ DEFAULT_HTTP_TIMEOUT = 30.0
 DEFAULT_RETRY_MAX_ATTEMPTS = 3
 DEFAULT_RETRY_BASE_DELAY = 1.0
 DEFAULT_MAX_JWKS_SIZE = 512 * 1024  # 512 KB
+DEFAULT_MAX_JWKS_KEYS = 100
 
 # HTTP status codes for retry logic
 HTTP_TOO_MANY_REQUESTS = 429
@@ -113,8 +114,18 @@ def get_max_jwks_size() -> int:
     return int(os.getenv("MAX_JWKS_SIZE", str(DEFAULT_MAX_JWKS_SIZE)))
 
 
+def get_max_jwks_keys() -> int:
+    """Get maximum number of keys allowed in a JWKS response.
+
+    Returns:
+        int: Maximum number of keys.
+    """
+    return int(os.getenv("MAX_JWKS_KEYS", str(DEFAULT_MAX_JWKS_KEYS)))
+
+
 __all__ = [
     "DEFAULT_HTTP_TIMEOUT",
+    "DEFAULT_MAX_JWKS_KEYS",
     "DEFAULT_MAX_JWKS_SIZE",
     "DEFAULT_RETRY_BASE_DELAY",
     "DEFAULT_RETRY_MAX_ATTEMPTS",
@@ -124,6 +135,7 @@ __all__ = [
     "HTTP_TOO_MANY_REQUESTS",
     "calculate_delay",
     "check_no_redirect",
+    "get_max_jwks_keys",
     "get_max_jwks_size",
     "get_retry_config",
     "get_timeout",

--- a/src/py_identity_model/core/http_utils.py
+++ b/src/py_identity_model/core/http_utils.py
@@ -118,9 +118,9 @@ def get_max_jwks_keys() -> int:
     """Get maximum number of keys allowed in a JWKS response.
 
     Returns:
-        int: Maximum number of keys.
+        int: Maximum number of keys (always >= 1).
     """
-    return int(os.getenv("MAX_JWKS_KEYS", str(DEFAULT_MAX_JWKS_KEYS)))
+    return max(1, int(os.getenv("MAX_JWKS_KEYS", str(DEFAULT_MAX_JWKS_KEYS))))
 
 
 __all__ = [

--- a/src/py_identity_model/core/response_processors.py
+++ b/src/py_identity_model/core/response_processors.py
@@ -13,7 +13,7 @@ from urllib.parse import urlparse
 from ..exceptions import DiscoveryException
 from ..logging_config import logger
 from .discovery_policy import DiscoveryPolicy
-from .http_utils import get_max_jwks_size
+from .http_utils import get_max_jwks_keys, get_max_jwks_size
 from .models import (
     AuthorizationCodeTokenResponse,
     ClientCredentialsTokenResponse,
@@ -299,20 +299,18 @@ def parse_jwks_response(response: httpx.Response) -> JwksResponse:
         # Check response size before parsing
         max_size = get_max_jwks_size()
         content_length = response.headers.get("Content-Length")
-        if content_length and int(content_length) > max_size:
-            return JwksResponse(
-                is_successful=False,
-                error=(
-                    f"JWKS response too large: Content-Length {content_length} "
-                    f"exceeds limit of {max_size} bytes"
-                ),
-            )
         body_size = len(response.content)
-        if body_size > max_size:
+        if content_length and int(content_length) > max_size:
+            size_desc = f"Content-Length {content_length}"
+        elif body_size > max_size:
+            size_desc = f"{body_size} bytes"
+        else:
+            size_desc = None
+        if size_desc:
             return JwksResponse(
                 is_successful=False,
                 error=(
-                    f"JWKS response too large: {body_size} bytes "
+                    f"JWKS response too large: {size_desc} "
                     f"exceeds limit of {max_size} bytes"
                 ),
             )
@@ -331,7 +329,25 @@ def parse_jwks_response(response: httpx.Response) -> JwksResponse:
             )
 
         response_json = response.json()
-        keys = [jwks_from_dict(key) for key in response_json["keys"]]
+        try:
+            raw_keys = response_json["keys"]
+        except KeyError:
+            return JwksResponse(
+                is_successful=False,
+                error="Invalid JWKS response: missing required 'keys' field",
+            )
+
+        max_keys = get_max_jwks_keys()
+        if len(raw_keys) > max_keys:
+            return JwksResponse(
+                is_successful=False,
+                error=(
+                    f"JWKS response contains too many keys: {len(raw_keys)} "
+                    f"exceeds limit of {max_keys}"
+                ),
+            )
+
+        keys = [jwks_from_dict(key) for key in raw_keys]
         cache_control = response.headers.get("cache-control")
         return JwksResponse(is_successful=True, keys=keys, cache_control=cache_control)
 

--- a/src/py_identity_model/core/response_processors.py
+++ b/src/py_identity_model/core/response_processors.py
@@ -286,13 +286,19 @@ _VALID_JWKS_CONTENT_TYPES = frozenset({"application/json", "application/jwk-set+
 
 
 def _extract_jwks_keys(
-    response_json: dict,
+    response_json: object,
 ) -> tuple[list[dict], str | None]:
     """Extract and validate the 'keys' array from a parsed JWKS response.
 
     Returns:
         Tuple of (raw_keys_list, error_string). On success error_string is None.
     """
+    if not isinstance(response_json, dict):
+        return [], (
+            "Invalid JWKS response: expected a JSON object, "
+            f"got {type(response_json).__name__}"
+        )
+
     try:
         raw_keys = response_json["keys"]
     except KeyError:
@@ -311,6 +317,14 @@ def _extract_jwks_keys(
             f"exceeds limit of {max_keys}"
         )
 
+    # Validate each element is a dict before downstream processing
+    for i, key in enumerate(raw_keys):
+        if not isinstance(key, dict):
+            return [], (
+                f"Invalid JWKS response: key at index {i} is not a JSON object, "
+                f"got {type(key).__name__}"
+            )
+
     return raw_keys, None
 
 
@@ -325,14 +339,18 @@ def parse_jwks_response(response: httpx.Response) -> JwksResponse:
         JwksResponse: Parsed JWKS response with keys
     """
     if response.is_success:
-        # Check response size before parsing
+        # Check response size before parsing — Content-Length first to
+        # avoid materialising the body for obviously-oversized responses.
         max_size = get_max_jwks_size()
         content_length = response.headers.get("Content-Length")
-        body_size = len(response.content)
-        if content_length and int(content_length) > max_size:
+        try:
+            cl_too_large = content_length is not None and int(content_length) > max_size
+        except (ValueError, TypeError):
+            cl_too_large = False
+        if cl_too_large:
             size_desc = f"Content-Length {content_length}"
-        elif body_size > max_size:
-            size_desc = f"{body_size} bytes"
+        elif len(response.content) > max_size:
+            size_desc = f"{len(response.content)} bytes"
         else:
             size_desc = None
         if size_desc:

--- a/src/py_identity_model/core/response_processors.py
+++ b/src/py_identity_model/core/response_processors.py
@@ -285,6 +285,35 @@ def build_discovery_response(
 _VALID_JWKS_CONTENT_TYPES = frozenset({"application/json", "application/jwk-set+json"})
 
 
+def _extract_jwks_keys(
+    response_json: dict,
+) -> tuple[list[dict], str | None]:
+    """Extract and validate the 'keys' array from a parsed JWKS response.
+
+    Returns:
+        Tuple of (raw_keys_list, error_string). On success error_string is None.
+    """
+    try:
+        raw_keys = response_json["keys"]
+    except KeyError:
+        return [], "Invalid JWKS response: missing required 'keys' field"
+
+    if not isinstance(raw_keys, list):
+        return [], (
+            "Invalid JWKS response: 'keys' field must be a JSON array, "
+            f"got {type(raw_keys).__name__}"
+        )
+
+    max_keys = get_max_jwks_keys()
+    if len(raw_keys) > max_keys:
+        return [], (
+            f"JWKS response contains too many keys: {len(raw_keys)} "
+            f"exceeds limit of {max_keys}"
+        )
+
+    return raw_keys, None
+
+
 def parse_jwks_response(response: httpx.Response) -> JwksResponse:
     """
     Parse JWKS HTTP response.
@@ -329,23 +358,9 @@ def parse_jwks_response(response: httpx.Response) -> JwksResponse:
             )
 
         response_json = response.json()
-        try:
-            raw_keys = response_json["keys"]
-        except KeyError:
-            return JwksResponse(
-                is_successful=False,
-                error="Invalid JWKS response: missing required 'keys' field",
-            )
-
-        max_keys = get_max_jwks_keys()
-        if len(raw_keys) > max_keys:
-            return JwksResponse(
-                is_successful=False,
-                error=(
-                    f"JWKS response contains too many keys: {len(raw_keys)} "
-                    f"exceeds limit of {max_keys}"
-                ),
-            )
+        raw_keys, keys_error = _extract_jwks_keys(response_json)
+        if keys_error:
+            return JwksResponse(is_successful=False, error=keys_error)
 
         keys = [jwks_from_dict(key) for key in raw_keys]
         cache_control = response.headers.get("cache-control")

--- a/src/py_identity_model/core/response_processors.py
+++ b/src/py_identity_model/core/response_processors.py
@@ -346,6 +346,7 @@ def parse_jwks_response(response: httpx.Response) -> JwksResponse:
         try:
             cl_too_large = content_length is not None and int(content_length) > max_size
         except (ValueError, TypeError):
+            logger.warning("Malformed Content-Length header: %s", content_length)
             cl_too_large = False
         if cl_too_large:
             size_desc = f"Content-Length {content_length}"

--- a/src/tests/unit/test_resource_limits.py
+++ b/src/tests/unit/test_resource_limits.py
@@ -3,6 +3,7 @@
 Covers:
 - #353: JWKS response size limit
 - #357: Async cleanup lock race
+- #376: JWKS max key count limit and KeyError guard
 """
 
 import asyncio
@@ -18,7 +19,10 @@ from py_identity_model.aio.http_client import (
     close_async_http_client,
     get_async_http_client,
 )
-from py_identity_model.core.http_utils import DEFAULT_MAX_JWKS_SIZE
+from py_identity_model.core.http_utils import (
+    DEFAULT_MAX_JWKS_KEYS,
+    DEFAULT_MAX_JWKS_SIZE,
+)
 from py_identity_model.core.response_processors import parse_jwks_response
 
 
@@ -93,6 +97,135 @@ class TestJwksSizeLimit:
         assert result.is_successful is False
         assert result.error is not None
         assert "500" in result.error
+
+
+# ============================================================================
+# #376 — JWKS max key count limit and missing "keys" guard
+# ============================================================================
+
+
+class TestJwksKeyCountLimit:
+    """Verify JWKS responses are rejected when they contain too many keys.
+
+    Attack scenario: An attacker controlling a JWKS endpoint returns a
+    response with thousands of minimal keys that stays under the 512 KB body
+    size limit. Each key triggers expensive cryptographic processing (modulus
+    calculation), causing CPU/memory exhaustion.
+    """
+
+    @staticmethod
+    def _make_keys(n: int) -> list[dict]:
+        """Generate n minimal RSA JWK dicts."""
+        return [{"kty": "RSA", "kid": f"k{i}", "n": "n", "e": "AQAB"} for i in range(n)]
+
+    def test_cpu_exhaustion_via_many_keys_blocked(self):
+        """JWKS with 1000+ keys is rejected before any key processing."""
+        keys = self._make_keys(1001)
+        response = httpx.Response(
+            200,
+            json={"keys": keys},
+            headers={"Content-Type": "application/json"},
+        )
+        result = parse_jwks_response(response)
+        assert result.is_successful is False
+        assert result.error is not None
+        assert "too many keys" in result.error
+        assert "1001" in result.error
+
+    def test_rejects_keys_over_default_limit(self):
+        """JWKS with 101 keys exceeds default limit of 100."""
+        keys = self._make_keys(DEFAULT_MAX_JWKS_KEYS + 1)
+        response = httpx.Response(
+            200,
+            json={"keys": keys},
+            headers={"Content-Type": "application/json"},
+        )
+        result = parse_jwks_response(response)
+        assert result.is_successful is False
+        assert result.error is not None
+        assert "too many keys" in result.error
+
+    def test_accepts_keys_at_limit(self):
+        """JWKS with exactly 100 keys (the default limit) is accepted."""
+        keys = self._make_keys(DEFAULT_MAX_JWKS_KEYS)
+        response = httpx.Response(
+            200,
+            json={"keys": keys},
+            headers={"Content-Type": "application/json"},
+        )
+        result = parse_jwks_response(response)
+        assert result.is_successful is True
+
+    def test_accepts_empty_keys_list(self):
+        """JWKS with empty keys list is valid (0 < limit)."""
+        response = httpx.Response(
+            200,
+            json={"keys": []},
+            headers={"Content-Type": "application/json"},
+        )
+        result = parse_jwks_response(response)
+        assert result.is_successful is True
+
+    def test_max_keys_env_var_override(self, monkeypatch):
+        """MAX_JWKS_KEYS env var overrides the default limit."""
+        monkeypatch.setenv("MAX_JWKS_KEYS", "5")
+        keys = self._make_keys(6)
+        response = httpx.Response(
+            200,
+            json={"keys": keys},
+            headers={"Content-Type": "application/json"},
+        )
+        result = parse_jwks_response(response)
+        assert result.is_successful is False
+        assert result.error is not None
+        assert "too many keys" in result.error
+        assert "6" in result.error
+        assert "5" in result.error
+
+
+class TestJwksMissingKeysField:
+    """Verify missing 'keys' field returns a descriptive error, not a raw KeyError.
+
+    Attack scenario: Attacker returns a valid JSON object without the
+    expected 'keys' field, causing a raw KeyError that may leak stack traces
+    or crash the application.
+    """
+
+    def test_missing_keys_field_blocked(self):
+        """JWKS response without 'keys' field returns descriptive error."""
+        response = httpx.Response(
+            200,
+            json={"not_keys": []},
+            headers={"Content-Type": "application/json"},
+        )
+        result = parse_jwks_response(response)
+        assert result.is_successful is False
+        assert result.error is not None
+        assert "missing required 'keys' field" in result.error
+
+    def test_empty_object_missing_keys(self):
+        """Empty JSON object (no 'keys') returns descriptive error."""
+        response = httpx.Response(
+            200,
+            json={},
+            headers={"Content-Type": "application/json"},
+        )
+        result = parse_jwks_response(response)
+        assert result.is_successful is False
+        assert result.error is not None
+        assert "missing required 'keys' field" in result.error
+
+    def test_keys_field_null_handled_gracefully(self):
+        """'keys': null returns descriptive error, not a raw TypeError."""
+        response = httpx.Response(
+            200,
+            json={"keys": None},
+            headers={"Content-Type": "application/json"},
+        )
+        result = parse_jwks_response(response)
+        assert result.is_successful is False
+        assert result.error is not None
+        assert "keys" in result.error.lower()
 
 
 # ============================================================================

--- a/src/tests/unit/test_resource_limits.py
+++ b/src/tests/unit/test_resource_limits.py
@@ -227,6 +227,66 @@ class TestJwksMissingKeysField:
         assert result.error is not None
         assert "keys" in result.error.lower()
 
+    def test_response_json_is_list_blocked(self):
+        """JWKS response that is a JSON array (not object) is rejected."""
+        response = httpx.Response(
+            200,
+            json=[{"kty": "RSA", "kid": "k1", "n": "n", "e": "AQAB"}],
+            headers={"Content-Type": "application/json"},
+        )
+        result = parse_jwks_response(response)
+        assert result.is_successful is False
+        assert result.error is not None
+        assert "expected a JSON object" in result.error
+
+    def test_non_dict_key_element_blocked(self):
+        """JWKS response with non-dict key elements is rejected."""
+        response = httpx.Response(
+            200,
+            json={"keys": ["not-a-dict", 42]},
+            headers={"Content-Type": "application/json"},
+        )
+        result = parse_jwks_response(response)
+        assert result.is_successful is False
+        assert result.error is not None
+        assert "not a JSON object" in result.error
+
+    def test_malformed_content_length_ignored(self):
+        """Malformed Content-Length header doesn't crash parsing."""
+        response = httpx.Response(
+            200,
+            json={"keys": []},
+            headers={
+                "Content-Type": "application/json",
+                "Content-Length": "invalid",
+            },
+        )
+        result = parse_jwks_response(response)
+        assert result.is_successful is True
+
+    def test_zero_max_keys_env_var_clamped(self, monkeypatch):
+        """MAX_JWKS_KEYS=0 is clamped to 1, not zero (which would reject everything)."""
+        monkeypatch.setenv("MAX_JWKS_KEYS", "0")
+        response = httpx.Response(
+            200,
+            json={"keys": [{"kty": "RSA", "kid": "k1", "n": "n", "e": "AQAB"}]},
+            headers={"Content-Type": "application/json"},
+        )
+        # With clamp to 1, a single key should be accepted
+        result = parse_jwks_response(response)
+        assert result.is_successful is True
+
+    def test_negative_max_keys_env_var_clamped(self, monkeypatch):
+        """MAX_JWKS_KEYS=-5 is clamped to 1."""
+        monkeypatch.setenv("MAX_JWKS_KEYS", "-5")
+        response = httpx.Response(
+            200,
+            json={"keys": [{"kty": "RSA", "kid": "k1", "n": "n", "e": "AQAB"}]},
+            headers={"Content-Type": "application/json"},
+        )
+        result = parse_jwks_response(response)
+        assert result.is_successful is True
+
 
 # ============================================================================
 # #357 — Async cleanup lock race


### PR DESCRIPTION
## Summary

- Add max key count limit (default 100, configurable via `MAX_JWKS_KEYS` env var) to `parse_jwks_response()` to prevent CPU/memory exhaustion from oversized JWKS responses
- Guard `response_json["keys"]` access with proper KeyError handling instead of letting raw KeyError propagate
- Add TypeError guard for non-dict JWKS responses (e.g., JSON arrays)
- Validate individual key entries are dicts before processing
- Handle malformed Content-Length headers gracefully with warning log

Closes #376

## Exploit Scenario Blocked

An attacker controlling a JWKS endpoint returns a large JWKS JSON with 1000+ keys that stays under the 512KB body size limit. Each key triggers `jwks_from_dict()` → `_validate_key_parameters()` → CPU exhaustion on modulus calculation. The new key count limit (default 100) rejects such responses before processing any keys.

Additionally, a response missing the `"keys"` field entirely no longer raises a raw `KeyError` — it returns a descriptive error response.

## Review Findings Addressed

5-reviewer security review completed (Blind Hunter, Edge Case Hunter, Acceptance Auditor, Sentinel, Viper):
- **3 P0 fixes**: Content-Length pre-check ordering, TypeError guard for non-dict responses, MAX_JWKS_KEYS clamped to min 1
- **3 P1 fixes**: Malformed Content-Length handling, per-element dict validation, warning logging
- **P2 deferred**: env var ValueError (consistent with existing codebase patterns)
- All 5 acceptance criteria passed
- Delta re-review confirmed all fixes correct, no new issues

## Test plan
- [x] Unit tests pass (`make test-unit`)
- [x] Lint passes (`make lint`)
- [x] Independent review agents passed (5/5)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)