### PR TITLE
fix(security): wire require_https config field through to DiscoveryPolicy

### DIFF
--- a/src/py_identity_model/aio/token_validation.py
+++ b/src/py_identity_model/aio/token_validation.py
@@ -50,7 +50,8 @@ from .managed_client import AsyncHTTPClient
 # Discovery TTL cache
 # ============================================================================
 
-_disco_cache: dict[str, DiscoCacheEntry] = {}
+# Discovery TTL cache — keyed by (address, require_https) to prevent policy bypass
+_disco_cache: dict[tuple[str, bool], DiscoCacheEntry] = {}
 _disco_cache_lock = asyncio.Lock()
 
 
@@ -64,8 +65,9 @@ async def _get_disco_response(
             "disco_doc_address is required when perform_disco is True"
         )
 
+    cache_key = (disco_doc_address, require_https)
     async with _disco_cache_lock:
-        entry = _disco_cache.get(disco_doc_address)
+        entry = _disco_cache.get(cache_key)
         if entry is not None and not is_cache_expired(entry):
             return entry.response
 
@@ -77,7 +79,7 @@ async def _get_disco_response(
     ttl = resolve_disco_ttl(response.cache_control)
 
     async with _disco_cache_lock:
-        _disco_cache[disco_doc_address] = DiscoCacheEntry(
+        _disco_cache[cache_key] = DiscoCacheEntry(
             response=response, cached_at=time.time(), ttl=ttl
         )
     return response

--- a/src/py_identity_model/aio/token_validation.py
+++ b/src/py_identity_model/aio/token_validation.py
@@ -8,6 +8,7 @@ with automatic cache expiry and forced JWKS refresh on key rotation.
 import asyncio
 import time
 
+from ..core.discovery_policy import DiscoveryPolicy
 from ..core.jwks_cache import (
     DiscoCacheEntry,
     JwksCacheEntry,
@@ -55,6 +56,7 @@ _disco_cache_lock = asyncio.Lock()
 
 async def _get_disco_response(
     disco_doc_address: str | None,
+    require_https: bool = True,
 ) -> DiscoveryDocumentResponse:
     """Cached async discovery document fetching with TTL."""
     if disco_doc_address is None:
@@ -68,8 +70,9 @@ async def _get_disco_response(
             return entry.response
 
     # Fetch outside the lock
+    policy = DiscoveryPolicy(require_https=require_https)
     response = await get_discovery_document(
-        DiscoveryDocumentRequest(address=disco_doc_address),
+        DiscoveryDocumentRequest(address=disco_doc_address, policy=policy),
     )
     ttl = resolve_disco_ttl(response.cache_control)
 
@@ -137,6 +140,7 @@ async def _discover_and_resolve_key(
     jwt: str,
     disco_doc_address: str | None,
     http_client: AsyncHTTPClient | None,
+    require_https: bool = True,
 ) -> tuple[dict, str, DiscoveryDocumentResponse, bool]:
     """Fetch discovery + JWKS and resolve the signing key.
 
@@ -147,8 +151,9 @@ async def _discover_and_resolve_key(
             raise ConfigurationException(
                 "disco_doc_address is required when perform_disco is True"
             )
+        policy = DiscoveryPolicy(require_https=require_https)
         disco_doc_response = await get_discovery_document(
-            DiscoveryDocumentRequest(address=disco_doc_address),
+            DiscoveryDocumentRequest(address=disco_doc_address, policy=policy),
             http_client=http_client,
         )
         validate_disco_response(disco_doc_response)
@@ -162,7 +167,7 @@ async def _discover_and_resolve_key(
         return key_dict, alg, disco_doc_response, False
 
     # Cached path with TTL
-    disco_doc_response = await _get_disco_response(disco_doc_address)
+    disco_doc_response = await _get_disco_response(disco_doc_address, require_https)
     validate_disco_response(disco_doc_response)
     jwks_uri = validate_jwks_uri(disco_doc_response)
     jwks_response = await _get_cached_jwks(jwks_uri)
@@ -223,7 +228,7 @@ async def validate_token(
 
     if token_validation_config.perform_disco:
         key_dict, alg, disco_doc_response, _is_cached = await _discover_and_resolve_key(
-            jwt, disco_doc_address, http_client
+            jwt, disco_doc_address, http_client, token_validation_config.require_https
         )
         resolved_config = build_resolved_config(token_validation_config, key_dict, alg)
 

--- a/src/py_identity_model/core/token_validation_logic.py
+++ b/src/py_identity_model/core/token_validation_logic.py
@@ -227,6 +227,7 @@ def build_resolved_config(
         subject=original_config.subject,
         options=original_config.options,
         claims_validator=original_config.claims_validator,
+        require_https=original_config.require_https,
         leeway=original_config.leeway,
     )
 

--- a/src/py_identity_model/sync/token_validation.py
+++ b/src/py_identity_model/sync/token_validation.py
@@ -49,8 +49,8 @@ from .jwks import get_jwks
 from .managed_client import HTTPClient
 
 
-# Discovery TTL cache
-_disco_cache: dict[str, DiscoCacheEntry] = {}
+# Discovery TTL cache — keyed by (address, require_https) to prevent policy bypass
+_disco_cache: dict[tuple[str, bool], DiscoCacheEntry] = {}
 _disco_cache_lock = threading.Lock()
 
 
@@ -64,8 +64,9 @@ def _get_disco_response(
             "disco_doc_address is required when perform_disco is True"
         )
 
+    cache_key = (disco_doc_address, require_https)
     with _disco_cache_lock:
-        entry = _disco_cache.get(disco_doc_address)
+        entry = _disco_cache.get(cache_key)
         if entry is not None and not is_cache_expired(entry):
             return entry.response
 
@@ -77,7 +78,7 @@ def _get_disco_response(
     ttl = resolve_disco_ttl(response.cache_control)
 
     with _disco_cache_lock:
-        _disco_cache[disco_doc_address] = DiscoCacheEntry(
+        _disco_cache[cache_key] = DiscoCacheEntry(
             response=response, cached_at=time.time(), ttl=ttl
         )
     return response

--- a/src/py_identity_model/sync/token_validation.py
+++ b/src/py_identity_model/sync/token_validation.py
@@ -11,6 +11,7 @@ with automatic cache expiry and forced JWKS refresh on key rotation.
 import threading
 import time
 
+from ..core.discovery_policy import DiscoveryPolicy
 from ..core.jwks_cache import (
     DiscoCacheEntry,
     JwksCacheEntry,
@@ -55,6 +56,7 @@ _disco_cache_lock = threading.Lock()
 
 def _get_disco_response(
     disco_doc_address: str | None,
+    require_https: bool = True,
 ) -> DiscoveryDocumentResponse:
     """Cached discovery document fetching with TTL."""
     if disco_doc_address is None:
@@ -68,8 +70,9 @@ def _get_disco_response(
             return entry.response
 
     # Fetch outside the lock
+    policy = DiscoveryPolicy(require_https=require_https)
     response = get_discovery_document(
-        DiscoveryDocumentRequest(address=disco_doc_address)
+        DiscoveryDocumentRequest(address=disco_doc_address, policy=policy)
     )
     ttl = resolve_disco_ttl(response.cache_control)
 
@@ -137,6 +140,7 @@ def _discover_and_resolve_key(
     jwt: str,
     disco_doc_address: str | None,
     http_client: HTTPClient | None,
+    require_https: bool = True,
 ) -> tuple[dict, str, DiscoveryDocumentResponse, bool]:
     """Fetch discovery + JWKS and resolve the signing key.
 
@@ -147,8 +151,9 @@ def _discover_and_resolve_key(
             raise ConfigurationException(
                 "disco_doc_address is required when perform_disco is True"
             )
+        policy = DiscoveryPolicy(require_https=require_https)
         disco_doc_response = get_discovery_document(
-            DiscoveryDocumentRequest(address=disco_doc_address),
+            DiscoveryDocumentRequest(address=disco_doc_address, policy=policy),
             http_client=http_client,
         )
         validate_disco_response(disco_doc_response)
@@ -160,7 +165,7 @@ def _discover_and_resolve_key(
         return key_dict, alg, disco_doc_response, False
 
     # Cached path with TTL
-    disco_doc_response = _get_disco_response(disco_doc_address)
+    disco_doc_response = _get_disco_response(disco_doc_address, require_https)
     validate_disco_response(disco_doc_response)
     jwks_uri = validate_jwks_uri(disco_doc_response)
     jwks_response = _get_cached_jwks(jwks_uri)
@@ -219,7 +224,7 @@ def validate_token(
 
     if token_validation_config.perform_disco:
         key_dict, alg, disco_doc_response, _is_cached = _discover_and_resolve_key(
-            jwt, disco_doc_address, http_client
+            jwt, disco_doc_address, http_client, token_validation_config.require_https
         )
         resolved_config = build_resolved_config(token_validation_config, key_dict, alg)
 

--- a/src/tests/unit/test_require_https_wiring.py
+++ b/src/tests/unit/test_require_https_wiring.py
@@ -24,6 +24,7 @@ from py_identity_model.aio.token_validation import (
     validate_token as async_validate_token,
 )
 from py_identity_model.core.models import TokenValidationConfig
+from py_identity_model.core.token_validation_logic import build_resolved_config
 from py_identity_model.exceptions import TokenValidationException
 from py_identity_model.sync.managed_client import HTTPClient
 from py_identity_model.sync.token_validation import (
@@ -219,6 +220,68 @@ class TestSyncRequireHttpsWiring:
         )
         assert decoded["sub"] == "user1"
 
+    @respx.mock
+    def test_cache_poisoning_blocked_require_https_in_cache_key(self, rsa_keypair):
+        """Cache with require_https=False must not bypass require_https=True.
+
+        Exploit scenario: attacker triggers a require_https=False call first,
+        poisoning the cache. A subsequent require_https=True call to the same
+        address must NOT hit the poisoned cache — it must enforce HTTPS.
+
+        Uses a non-loopback address since DiscoveryPolicy allows HTTP on
+        loopback by default.
+        """
+        key_dict, pem = rsa_keypair
+
+        disco_response_http = {
+            "issuer": "http://external.example.com",
+            "authorization_endpoint": "http://external.example.com/authorize",
+            "token_endpoint": "http://external.example.com/token",
+            "jwks_uri": "http://external.example.com/jwks",
+            "response_types_supported": ["code"],
+            "subject_types_supported": ["public"],
+            "id_token_signing_alg_values_supported": ["RS256"],
+        }
+        token = sign_jwt(
+            pem,
+            {"sub": "user1", "iss": "http://external.example.com"},
+            headers={"kid": "test-key-1"},
+        )
+
+        respx.get("http://external.example.com/.well-known/openid-configuration").mock(
+            return_value=httpx.Response(200, json=disco_response_http)
+        )
+        respx.get("http://external.example.com/jwks").mock(
+            return_value=httpx.Response(200, json={"keys": [key_dict]})
+        )
+
+        # Step 1: Populate cache with require_https=False
+        config_permissive = TokenValidationConfig(
+            perform_disco=True,
+            audience=None,
+            issuer="http://external.example.com",
+            require_https=False,
+        )
+        decoded = sync_validate_token(
+            jwt=token,
+            token_validation_config=config_permissive,
+            disco_doc_address="http://external.example.com/.well-known/openid-configuration",
+        )
+        assert decoded["sub"] == "user1"
+
+        # Step 2: require_https=True must still reject the HTTP address
+        config_strict = TokenValidationConfig(
+            perform_disco=True,
+            audience="test-audience",
+            require_https=True,
+        )
+        with pytest.raises(TokenValidationException, match="HTTPS is required"):
+            sync_validate_token(
+                jwt="fake.jwt.token",
+                token_validation_config=config_strict,
+                disco_doc_address="http://external.example.com/.well-known/openid-configuration",
+            )
+
 
 class TestAsyncRequireHttpsWiring:
     """Test require_https propagation in async token validation."""
@@ -361,3 +424,88 @@ class TestAsyncRequireHttpsWiring:
             disco_doc_address="https://example.com/.well-known/openid-configuration",
         )
         assert decoded["sub"] == "user1"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_cache_poisoning_blocked_require_https_in_cache_key(
+        self, rsa_keypair
+    ):
+        """Cache with require_https=False must not bypass require_https=True.
+
+        Uses a non-loopback address since DiscoveryPolicy allows HTTP on
+        loopback by default.
+        """
+        key_dict, pem = rsa_keypair
+
+        disco_response_http = {
+            "issuer": "http://external.example.com",
+            "authorization_endpoint": "http://external.example.com/authorize",
+            "token_endpoint": "http://external.example.com/token",
+            "jwks_uri": "http://external.example.com/jwks",
+            "response_types_supported": ["code"],
+            "subject_types_supported": ["public"],
+            "id_token_signing_alg_values_supported": ["RS256"],
+        }
+        token = sign_jwt(
+            pem,
+            {"sub": "user1", "iss": "http://external.example.com"},
+            headers={"kid": "test-key-1"},
+        )
+
+        respx.get("http://external.example.com/.well-known/openid-configuration").mock(
+            return_value=httpx.Response(200, json=disco_response_http)
+        )
+        respx.get("http://external.example.com/jwks").mock(
+            return_value=httpx.Response(200, json={"keys": [key_dict]})
+        )
+
+        # Step 1: Populate cache with require_https=False
+        config_permissive = TokenValidationConfig(
+            perform_disco=True,
+            audience=None,
+            issuer="http://external.example.com",
+            require_https=False,
+        )
+        decoded = await async_validate_token(
+            jwt=token,
+            token_validation_config=config_permissive,
+            disco_doc_address="http://external.example.com/.well-known/openid-configuration",
+        )
+        assert decoded["sub"] == "user1"
+
+        # Step 2: require_https=True must still reject the HTTP address
+        config_strict = TokenValidationConfig(
+            perform_disco=True,
+            audience="test-audience",
+            require_https=True,
+        )
+        with pytest.raises(TokenValidationException, match="HTTPS is required"):
+            await async_validate_token(
+                jwt="fake.jwt.token",
+                token_validation_config=config_strict,
+                disco_doc_address="http://external.example.com/.well-known/openid-configuration",
+            )
+
+
+class TestBuildResolvedConfigPreservesRequireHttps:
+    """Verify build_resolved_config propagates require_https."""
+
+    def test_require_https_false_preserved(self):
+        """build_resolved_config must copy require_https from original config."""
+        original = TokenValidationConfig(
+            perform_disco=True,
+            audience="aud",
+            require_https=False,
+        )
+        resolved = build_resolved_config(original, {"kty": "RSA"}, "RS256")
+        assert resolved.require_https is False
+
+    def test_require_https_true_preserved(self):
+        """build_resolved_config must copy require_https=True (default)."""
+        original = TokenValidationConfig(
+            perform_disco=True,
+            audience="aud",
+            require_https=True,
+        )
+        resolved = build_resolved_config(original, {"kty": "RSA"}, "RS256")
+        assert resolved.require_https is True

--- a/src/tests/unit/test_require_https_wiring.py
+++ b/src/tests/unit/test_require_https_wiring.py
@@ -1,0 +1,363 @@
+"""
+Unit tests for require_https wiring in token validation.
+
+These tests verify that TokenValidationConfig.require_https is properly
+propagated to DiscoveryPolicy in both sync and async token validation,
+blocking the exploit scenario where an attacker downgrades discovery
+to plaintext HTTP to intercept or tamper with OIDC metadata.
+
+Security fix for: #377
+"""
+
+import httpx
+import pytest
+import respx
+
+from py_identity_model.aio.managed_client import AsyncHTTPClient
+from py_identity_model.aio.token_validation import (
+    clear_discovery_cache as async_clear_discovery_cache,
+)
+from py_identity_model.aio.token_validation import (
+    clear_jwks_cache as async_clear_jwks_cache,
+)
+from py_identity_model.aio.token_validation import (
+    validate_token as async_validate_token,
+)
+from py_identity_model.core.models import TokenValidationConfig
+from py_identity_model.exceptions import TokenValidationException
+from py_identity_model.sync.managed_client import HTTPClient
+from py_identity_model.sync.token_validation import (
+    clear_discovery_cache as sync_clear_discovery_cache,
+)
+from py_identity_model.sync.token_validation import (
+    clear_jwks_cache as sync_clear_jwks_cache,
+)
+from py_identity_model.sync.token_validation import (
+    validate_token as sync_validate_token,
+)
+
+from .token_validation_helpers import (
+    DISCO_RESPONSE_WITH_JWKS,
+    generate_rsa_keypair,
+    sign_jwt,
+)
+
+
+# HTTP discovery response — same as HTTPS but with http:// URLs
+DISCO_RESPONSE_HTTP = {
+    "issuer": "http://localhost:8080",
+    "authorization_endpoint": "http://localhost:8080/authorize",
+    "token_endpoint": "http://localhost:8080/token",
+    "jwks_uri": "http://localhost:8080/jwks",
+    "response_types_supported": ["code"],
+    "subject_types_supported": ["public"],
+    "id_token_signing_alg_values_supported": ["RS256"],
+}
+
+
+@pytest.fixture
+def rsa_keypair():
+    """Generate a fresh RSA key pair for testing."""
+    return generate_rsa_keypair()
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    """Clear all caches between tests."""
+    sync_clear_discovery_cache()
+    sync_clear_jwks_cache()
+    async_clear_discovery_cache()
+    async_clear_jwks_cache()
+    yield
+    sync_clear_discovery_cache()
+    sync_clear_jwks_cache()
+    async_clear_discovery_cache()
+    async_clear_jwks_cache()
+
+
+class TestSyncRequireHttpsWiring:
+    """Test require_https propagation in sync token validation."""
+
+    @respx.mock
+    def test_require_https_default_blocks_http_discovery_cached_path(self):
+        """Default require_https=True blocks HTTP discovery URL (cached path).
+
+        Exploit scenario: attacker provides http:// discovery address to
+        intercept OIDC metadata in transit and inject malicious JWKS URI.
+        """
+        config = TokenValidationConfig(
+            perform_disco=True,
+            audience="test-audience",
+            # require_https defaults to True
+        )
+
+        with pytest.raises(TokenValidationException, match="HTTPS is required"):
+            sync_validate_token(
+                jwt="fake.jwt.token",
+                token_validation_config=config,
+                disco_doc_address="http://evil.example.com/.well-known/openid-configuration",
+            )
+
+    @respx.mock
+    def test_require_https_true_blocks_http_discovery_di_path(self):
+        """require_https=True blocks HTTP discovery URL (DI path).
+
+        The injected http_client path must also enforce HTTPS policy.
+        """
+        config = TokenValidationConfig(
+            perform_disco=True,
+            audience="test-audience",
+            require_https=True,
+        )
+
+        with (
+            HTTPClient() as client,
+            pytest.raises(TokenValidationException, match="HTTPS is required"),
+        ):
+            sync_validate_token(
+                jwt="fake.jwt.token",
+                token_validation_config=config,
+                disco_doc_address="http://evil.example.com/.well-known/openid-configuration",
+                http_client=client,
+            )
+
+    @respx.mock
+    def test_require_https_false_allows_http_discovery_cached_path(self, rsa_keypair):
+        """require_https=False allows HTTP discovery URL (cached path).
+
+        Legitimate use case: local development with http://localhost.
+        """
+        key_dict, pem = rsa_keypair
+        token = sign_jwt(
+            pem,
+            {"sub": "user1", "iss": "http://localhost:8080"},
+            headers={"kid": "test-key-1"},
+        )
+
+        respx.get("http://localhost:8080/.well-known/openid-configuration").mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_HTTP)
+        )
+        respx.get("http://localhost:8080/jwks").mock(
+            return_value=httpx.Response(200, json={"keys": [key_dict]})
+        )
+
+        config = TokenValidationConfig(
+            perform_disco=True,
+            audience=None,
+            issuer="http://localhost:8080",
+            require_https=False,
+        )
+
+        decoded = sync_validate_token(
+            jwt=token,
+            token_validation_config=config,
+            disco_doc_address="http://localhost:8080/.well-known/openid-configuration",
+        )
+        assert decoded["sub"] == "user1"
+
+    @respx.mock
+    def test_require_https_false_allows_http_discovery_di_path(self, rsa_keypair):
+        """require_https=False allows HTTP discovery URL (DI path)."""
+        key_dict, pem = rsa_keypair
+        token = sign_jwt(
+            pem,
+            {"sub": "user1", "iss": "http://localhost:8080"},
+            headers={"kid": "test-key-1"},
+        )
+
+        respx.get("http://localhost:8080/.well-known/openid-configuration").mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_HTTP)
+        )
+        respx.get("http://localhost:8080/jwks").mock(
+            return_value=httpx.Response(200, json={"keys": [key_dict]})
+        )
+
+        config = TokenValidationConfig(
+            perform_disco=True,
+            audience=None,
+            issuer="http://localhost:8080",
+            require_https=False,
+        )
+
+        with HTTPClient() as client:
+            decoded = sync_validate_token(
+                jwt=token,
+                token_validation_config=config,
+                disco_doc_address="http://localhost:8080/.well-known/openid-configuration",
+                http_client=client,
+            )
+        assert decoded["sub"] == "user1"
+
+    @respx.mock
+    def test_https_always_works_regardless_of_require_https(self, rsa_keypair):
+        """HTTPS URLs work whether require_https is True or False."""
+        key_dict, pem = rsa_keypair
+        token = sign_jwt(
+            pem,
+            {"sub": "user1", "iss": "https://example.com"},
+            headers={"kid": "test-key-1"},
+        )
+
+        respx.get("https://example.com/.well-known/openid-configuration").mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+        respx.get("https://example.com/jwks").mock(
+            return_value=httpx.Response(200, json={"keys": [key_dict]})
+        )
+
+        config = TokenValidationConfig(
+            perform_disco=True,
+            audience=None,
+            issuer="https://example.com",
+            require_https=True,
+        )
+
+        decoded = sync_validate_token(
+            jwt=token,
+            token_validation_config=config,
+            disco_doc_address="https://example.com/.well-known/openid-configuration",
+        )
+        assert decoded["sub"] == "user1"
+
+
+class TestAsyncRequireHttpsWiring:
+    """Test require_https propagation in async token validation."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_require_https_default_blocks_http_discovery_cached_path(self):
+        """Default require_https=True blocks HTTP discovery URL (cached path).
+
+        Exploit scenario: attacker provides http:// discovery address to
+        intercept OIDC metadata in transit and inject malicious JWKS URI.
+        """
+        config = TokenValidationConfig(
+            perform_disco=True,
+            audience="test-audience",
+        )
+
+        with pytest.raises(TokenValidationException, match="HTTPS is required"):
+            await async_validate_token(
+                jwt="fake.jwt.token",
+                token_validation_config=config,
+                disco_doc_address="http://evil.example.com/.well-known/openid-configuration",
+            )
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_require_https_true_blocks_http_discovery_di_path(self):
+        """require_https=True blocks HTTP discovery URL (DI path)."""
+        config = TokenValidationConfig(
+            perform_disco=True,
+            audience="test-audience",
+            require_https=True,
+        )
+
+        async with AsyncHTTPClient() as client:
+            with pytest.raises(TokenValidationException, match="HTTPS is required"):
+                await async_validate_token(
+                    jwt="fake.jwt.token",
+                    token_validation_config=config,
+                    disco_doc_address="http://evil.example.com/.well-known/openid-configuration",
+                    http_client=client,
+                )
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_require_https_false_allows_http_discovery_cached_path(
+        self, rsa_keypair
+    ):
+        """require_https=False allows HTTP discovery URL (cached path)."""
+        key_dict, pem = rsa_keypair
+        token = sign_jwt(
+            pem,
+            {"sub": "user1", "iss": "http://localhost:8080"},
+            headers={"kid": "test-key-1"},
+        )
+
+        respx.get("http://localhost:8080/.well-known/openid-configuration").mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_HTTP)
+        )
+        respx.get("http://localhost:8080/jwks").mock(
+            return_value=httpx.Response(200, json={"keys": [key_dict]})
+        )
+
+        config = TokenValidationConfig(
+            perform_disco=True,
+            audience=None,
+            issuer="http://localhost:8080",
+            require_https=False,
+        )
+
+        decoded = await async_validate_token(
+            jwt=token,
+            token_validation_config=config,
+            disco_doc_address="http://localhost:8080/.well-known/openid-configuration",
+        )
+        assert decoded["sub"] == "user1"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_require_https_false_allows_http_discovery_di_path(self, rsa_keypair):
+        """require_https=False allows HTTP discovery URL (DI path)."""
+        key_dict, pem = rsa_keypair
+        token = sign_jwt(
+            pem,
+            {"sub": "user1", "iss": "http://localhost:8080"},
+            headers={"kid": "test-key-1"},
+        )
+
+        respx.get("http://localhost:8080/.well-known/openid-configuration").mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_HTTP)
+        )
+        respx.get("http://localhost:8080/jwks").mock(
+            return_value=httpx.Response(200, json={"keys": [key_dict]})
+        )
+
+        config = TokenValidationConfig(
+            perform_disco=True,
+            audience=None,
+            issuer="http://localhost:8080",
+            require_https=False,
+        )
+
+        async with AsyncHTTPClient() as client:
+            decoded = await async_validate_token(
+                jwt=token,
+                token_validation_config=config,
+                disco_doc_address="http://localhost:8080/.well-known/openid-configuration",
+                http_client=client,
+            )
+        assert decoded["sub"] == "user1"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_https_always_works_regardless_of_require_https(self, rsa_keypair):
+        """HTTPS URLs work whether require_https is True or False."""
+        key_dict, pem = rsa_keypair
+        token = sign_jwt(
+            pem,
+            {"sub": "user1", "iss": "https://example.com"},
+            headers={"kid": "test-key-1"},
+        )
+
+        respx.get("https://example.com/.well-known/openid-configuration").mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+        respx.get("https://example.com/jwks").mock(
+            return_value=httpx.Response(200, json={"keys": [key_dict]})
+        )
+
+        config = TokenValidationConfig(
+            perform_disco=True,
+            audience=None,
+            issuer="https://example.com",
+            require_https=True,
+        )
+
+        decoded = await async_validate_token(
+            jwt=token,
+            token_validation_config=config,
+            disco_doc_address="https://example.com/.well-known/openid-configuration",
+        )
+        assert decoded["sub"] == "user1"


### PR DESCRIPTION
## Summary

- Wire `TokenValidationConfig.require_https` through to `DiscoveryPolicy` in both sync and async `_discover_and_resolve_key` paths, fixing a dead-code field that silently ignored user configuration
- Fix `build_resolved_config()` in `token_validation_logic.py` to propagate `require_https` from the original config
- Use `(address, require_https)` tuple as cache key for `_get_disco_response` to prevent cache poisoning between different `require_https` settings

Closes #377

## Exploit Scenario Blocked

`TokenValidationConfig.require_https` was dead code — the field was never read by the token validation pipeline. Users setting `require_https=False` believed they had configured HTTP support, but discovery always enforced `require_https=True` (the `DiscoveryPolicy` default). While the safe default prevented exploitation, this was a misleading API that could cause silent misconfiguration.

Additionally, without the cache key fix, a `require_https=False` call would poison the discovery cache for subsequent `require_https=True` calls to the same address, potentially allowing an HTTP discovery document to be served to a caller expecting HTTPS enforcement.

## Review Findings Addressed

- **5 reviewers**: Blind Hunter, Edge Case Hunter, Acceptance Auditor, Sentinel, Viper
- **2 findings fixed**:
  - P0 (Blind Hunter + Edge Case Hunter): Cache poisoning — discovery cache now uses `(address, require_https)` tuple key
  - P1 (Viper): `build_resolved_config()` now propagates `require_https`
- **All reviewers PASS** on delta re-review

## Test plan
- [x] Unit tests pass (`make test-unit`)
- [x] Lint passes (`make lint`)
- [x] Independent review agents passed (5/5)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)