### PR TITLE
fix(security): prevent cache stampede on TTL expiry

### DIFF
--- a/src/py_identity_model/aio/token_validation.py
+++ b/src/py_identity_model/aio/token_validation.py
@@ -71,18 +71,16 @@ async def _get_disco_response(
         if entry is not None and not is_cache_expired(entry):
             return entry.response
 
-    # Fetch outside the lock
-    policy = DiscoveryPolicy(require_https=require_https)
-    response = await get_discovery_document(
-        DiscoveryDocumentRequest(address=disco_doc_address, policy=policy),
-    )
-    ttl = resolve_disco_ttl(response.cache_control)
-
-    async with _disco_cache_lock:
+        # Fetch under lock to prevent cache stampede (single-flight refresh)
+        policy = DiscoveryPolicy(require_https=require_https)
+        response = await get_discovery_document(
+            DiscoveryDocumentRequest(address=disco_doc_address, policy=policy),
+        )
+        ttl = resolve_disco_ttl(response.cache_control)
         _disco_cache[cache_key] = DiscoCacheEntry(
             response=response, cached_at=time.time(), ttl=ttl
         )
-    return response
+        return response
 
 
 def clear_discovery_cache() -> None:
@@ -105,27 +103,25 @@ async def _get_cached_jwks(jwks_uri: str) -> JwksResponse:
         if entry is not None and not is_cache_expired(entry):
             return entry.response
 
-    # Fetch outside the lock to avoid blocking other coroutines
-    response = await get_jwks(JwksRequest(address=jwks_uri))
-    ttl = resolve_ttl(response.cache_control)
-
-    async with _jwks_cache_lock:
+        # Fetch under lock to prevent cache stampede (single-flight refresh)
+        response = await get_jwks(JwksRequest(address=jwks_uri))
+        ttl = resolve_ttl(response.cache_control)
         _jwks_cache[jwks_uri] = JwksCacheEntry(
             response=response, cached_at=time.time(), ttl=ttl
         )
-    return response
+        return response
 
 
 async def _refresh_jwks(jwks_uri: str) -> JwksResponse:
     """Force re-fetch JWKS and update cache (key rotation)."""
-    logger.info("Forcing JWKS refresh for %s (possible key rotation)", jwks_uri)
-    response = await get_jwks(JwksRequest(address=jwks_uri))
-    ttl = resolve_ttl(response.cache_control)
     async with _jwks_cache_lock:
+        logger.info("Forcing JWKS refresh for %s (possible key rotation)", jwks_uri)
+        response = await get_jwks(JwksRequest(address=jwks_uri))
+        ttl = resolve_ttl(response.cache_control)
         _jwks_cache[jwks_uri] = JwksCacheEntry(
             response=response, cached_at=time.time(), ttl=ttl
         )
-    return response
+        return response
 
 
 def clear_jwks_cache() -> None:

--- a/src/py_identity_model/aio/token_validation.py
+++ b/src/py_identity_model/aio/token_validation.py
@@ -114,7 +114,14 @@ async def _get_cached_jwks(jwks_uri: str) -> JwksResponse:
 
 async def _refresh_jwks(jwks_uri: str) -> JwksResponse:
     """Force re-fetch JWKS and update cache (key rotation)."""
+    request_time = time.time()
     async with _jwks_cache_lock:
+        # If another coroutine already refreshed while we waited on the lock,
+        # return the fresh entry to avoid redundant sequential fetches
+        entry = _jwks_cache.get(jwks_uri)
+        if entry is not None and entry.cached_at >= request_time:
+            return entry.response
+
         logger.info("Forcing JWKS refresh for %s (possible key rotation)", jwks_uri)
         response = await get_jwks(JwksRequest(address=jwks_uri))
         ttl = resolve_ttl(response.cache_control)

--- a/src/py_identity_model/sync/token_validation.py
+++ b/src/py_identity_model/sync/token_validation.py
@@ -113,7 +113,14 @@ def _get_cached_jwks(jwks_uri: str) -> JwksResponse:
 
 def _refresh_jwks(jwks_uri: str) -> JwksResponse:
     """Force re-fetch JWKS and update cache (key rotation)."""
+    request_time = time.time()
     with _jwks_cache_lock:
+        # If another thread already refreshed while we waited on the lock,
+        # return the fresh entry to avoid redundant sequential fetches
+        entry = _jwks_cache.get(jwks_uri)
+        if entry is not None and entry.cached_at >= request_time:
+            return entry.response
+
         logger.info("Forcing JWKS refresh for %s (possible key rotation)", jwks_uri)
         response = get_jwks(JwksRequest(address=jwks_uri))
         ttl = resolve_ttl(response.cache_control)

--- a/src/py_identity_model/sync/token_validation.py
+++ b/src/py_identity_model/sync/token_validation.py
@@ -70,18 +70,16 @@ def _get_disco_response(
         if entry is not None and not is_cache_expired(entry):
             return entry.response
 
-    # Fetch outside the lock
-    policy = DiscoveryPolicy(require_https=require_https)
-    response = get_discovery_document(
-        DiscoveryDocumentRequest(address=disco_doc_address, policy=policy)
-    )
-    ttl = resolve_disco_ttl(response.cache_control)
-
-    with _disco_cache_lock:
+        # Fetch under lock to prevent cache stampede (single-flight refresh)
+        policy = DiscoveryPolicy(require_https=require_https)
+        response = get_discovery_document(
+            DiscoveryDocumentRequest(address=disco_doc_address, policy=policy)
+        )
+        ttl = resolve_disco_ttl(response.cache_control)
         _disco_cache[cache_key] = DiscoCacheEntry(
             response=response, cached_at=time.time(), ttl=ttl
         )
-    return response
+        return response
 
 
 def clear_discovery_cache() -> None:
@@ -104,27 +102,25 @@ def _get_cached_jwks(jwks_uri: str) -> JwksResponse:
         if entry is not None and not is_cache_expired(entry):
             return entry.response
 
-    # Fetch outside the lock to avoid blocking other threads
-    response = get_jwks(JwksRequest(address=jwks_uri))
-    ttl = resolve_ttl(response.cache_control)
-
-    with _jwks_cache_lock:
+        # Fetch under lock to prevent cache stampede (single-flight refresh)
+        response = get_jwks(JwksRequest(address=jwks_uri))
+        ttl = resolve_ttl(response.cache_control)
         _jwks_cache[jwks_uri] = JwksCacheEntry(
             response=response, cached_at=time.time(), ttl=ttl
         )
-    return response
+        return response
 
 
 def _refresh_jwks(jwks_uri: str) -> JwksResponse:
     """Force re-fetch JWKS and update cache (key rotation)."""
-    logger.info("Forcing JWKS refresh for %s (possible key rotation)", jwks_uri)
-    response = get_jwks(JwksRequest(address=jwks_uri))
-    ttl = resolve_ttl(response.cache_control)
     with _jwks_cache_lock:
+        logger.info("Forcing JWKS refresh for %s (possible key rotation)", jwks_uri)
+        response = get_jwks(JwksRequest(address=jwks_uri))
+        ttl = resolve_ttl(response.cache_control)
         _jwks_cache[jwks_uri] = JwksCacheEntry(
             response=response, cached_at=time.time(), ttl=ttl
         )
-    return response
+        return response
 
 
 def clear_jwks_cache() -> None:

--- a/src/tests/unit/test_cache_stampede.py
+++ b/src/tests/unit/test_cache_stampede.py
@@ -21,6 +21,9 @@ from py_identity_model.aio.token_validation import (
     _get_disco_response as async_get_disco_response,
 )
 from py_identity_model.aio.token_validation import (
+    _refresh_jwks as async_refresh_jwks,
+)
+from py_identity_model.aio.token_validation import (
     clear_discovery_cache as async_clear_discovery_cache,
 )
 from py_identity_model.aio.token_validation import (
@@ -31,6 +34,7 @@ from py_identity_model.sync import token_validation as sync_tv
 from py_identity_model.sync.token_validation import (
     _get_cached_jwks,
     _get_disco_response,
+    _refresh_jwks,
     clear_discovery_cache,
     clear_jwks_cache,
 )
@@ -188,8 +192,9 @@ class TestSyncStampedeAfterExpiry:
         _get_disco_response(DISCO_URL)
         assert disco_route.call_count == 1
 
-        sync_tv._disco_cache[DISCO_URL] = DiscoCacheEntry(
-            response=sync_tv._disco_cache[DISCO_URL].response,
+        cache_key = (DISCO_URL, True)
+        sync_tv._disco_cache[cache_key] = DiscoCacheEntry(
+            response=sync_tv._disco_cache[cache_key].response,
             cached_at=time.time() - 3601,
             ttl=3600.0,
         )
@@ -299,8 +304,9 @@ class TestAsyncStampedeAfterExpiry:
         assert disco_route.call_count == 1
 
         # Expire the entry
-        aio_tv._disco_cache[DISCO_URL] = DiscoCacheEntry(
-            response=aio_tv._disco_cache[DISCO_URL].response,
+        cache_key = (DISCO_URL, True)
+        aio_tv._disco_cache[cache_key] = DiscoCacheEntry(
+            response=aio_tv._disco_cache[cache_key].response,
             cached_at=time.time() - 3601,
             ttl=3600.0,
         )
@@ -311,3 +317,96 @@ class TestAsyncStampedeAfterExpiry:
 
         assert all(r is not None for r in results)
         assert disco_route.call_count == FETCH_AFTER_EXPIRY
+
+
+class TestSyncRefreshJwksFreshnessGuard:
+    """Verify _refresh_jwks skips fetch when another thread already refreshed."""
+
+    @respx.mock
+    def test_refresh_skips_fetch_when_already_fresh(self):
+        """If cache was refreshed while waiting on lock, return cached entry."""
+        key_dict, _ = generate_rsa_keypair()
+        jwks_route = respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(200, json={"keys": [key_dict]})
+        )
+
+        # Prime the cache
+        _get_cached_jwks(JWKS_URL)
+        assert jwks_route.call_count == 1
+
+        # Manually set cached_at to a future time to simulate another thread
+        # having just refreshed the cache
+        entry = sync_tv._jwks_cache[JWKS_URL]
+        sync_tv._jwks_cache[JWKS_URL] = JwksCacheEntry(
+            response=entry.response,
+            cached_at=time.time() + 100,
+            ttl=entry.ttl,
+        )
+
+        # _refresh_jwks should see the fresh entry and skip the HTTP fetch
+        result = _refresh_jwks(JWKS_URL)
+        assert result is not None
+        # No new fetch — still just the 1 from priming
+        assert jwks_route.call_count == 1
+
+    @respx.mock
+    def test_refresh_fetches_when_cache_stale(self):
+        """Normal refresh path: fetch when cache is stale."""
+        key_dict, _ = generate_rsa_keypair()
+        jwks_route = respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(200, json={"keys": [key_dict]})
+        )
+
+        # Prime the cache
+        _get_cached_jwks(JWKS_URL)
+        assert jwks_route.call_count == 1
+
+        # Call _refresh_jwks — cached_at is in the past relative to request_time
+        result = _refresh_jwks(JWKS_URL)
+        assert result is not None
+        assert jwks_route.call_count == FETCH_AFTER_EXPIRY
+
+
+class TestAsyncRefreshJwksFreshnessGuard:
+    """Verify async _refresh_jwks skips fetch when another coroutine already refreshed."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_refresh_skips_fetch_when_already_fresh_async(self):
+        """If cache was refreshed while waiting on lock, return cached entry."""
+        key_dict, _ = generate_rsa_keypair()
+        jwks_route = respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(200, json={"keys": [key_dict]})
+        )
+
+        # Prime the cache
+        await async_get_cached_jwks(JWKS_URL)
+        assert jwks_route.call_count == 1
+
+        # Set cached_at to future time to simulate another coroutine refresh
+        entry = aio_tv._jwks_cache[JWKS_URL]
+        aio_tv._jwks_cache[JWKS_URL] = JwksCacheEntry(
+            response=entry.response,
+            cached_at=time.time() + 100,
+            ttl=entry.ttl,
+        )
+
+        result = await async_refresh_jwks(JWKS_URL)
+        assert result is not None
+        assert jwks_route.call_count == 1
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_refresh_fetches_when_cache_stale_async(self):
+        """Normal refresh path: fetch when cache is stale."""
+        key_dict, _ = generate_rsa_keypair()
+        jwks_route = respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(200, json={"keys": [key_dict]})
+        )
+
+        await async_get_cached_jwks(JWKS_URL)
+        assert jwks_route.call_count == 1
+
+        result = await async_refresh_jwks(JWKS_URL)
+        assert result is not None
+        assert jwks_route.call_count == FETCH_AFTER_EXPIRY

--- a/src/tests/unit/test_cache_stampede.py
+++ b/src/tests/unit/test_cache_stampede.py
@@ -1,0 +1,313 @@
+"""
+Security tests for cache stampede prevention (#378).
+
+Verifies that concurrent cache misses (TTL expiry) result in a single HTTP
+fetch rather than N parallel fetches (thundering herd).
+"""
+
+import asyncio
+import threading
+import time
+
+import httpx
+import pytest
+import respx
+
+from py_identity_model.aio import token_validation as aio_tv
+from py_identity_model.aio.token_validation import (
+    _get_cached_jwks as async_get_cached_jwks,
+)
+from py_identity_model.aio.token_validation import (
+    _get_disco_response as async_get_disco_response,
+)
+from py_identity_model.aio.token_validation import (
+    clear_discovery_cache as async_clear_discovery_cache,
+)
+from py_identity_model.aio.token_validation import (
+    clear_jwks_cache as async_clear_jwks_cache,
+)
+from py_identity_model.core.jwks_cache import DiscoCacheEntry, JwksCacheEntry
+from py_identity_model.sync import token_validation as sync_tv
+from py_identity_model.sync.token_validation import (
+    _get_cached_jwks,
+    _get_disco_response,
+    clear_discovery_cache,
+    clear_jwks_cache,
+)
+
+from .token_validation_helpers import (
+    DISCO_RESPONSE_WITH_JWKS,
+    generate_rsa_keypair,
+)
+
+
+DISCO_URL = "https://example.com/.well-known/openid-configuration"
+JWKS_URL = "https://example.com/jwks"
+
+# Expected fetch counts: 1 initial prime + 1 single-flight refresh after expiry
+FETCH_AFTER_EXPIRY = 2
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    """Clear all caches between tests."""
+    clear_discovery_cache()
+    clear_jwks_cache()
+    async_clear_discovery_cache()
+    async_clear_jwks_cache()
+    yield
+    clear_discovery_cache()
+    clear_jwks_cache()
+    async_clear_discovery_cache()
+    async_clear_jwks_cache()
+
+
+class TestSyncDiscoCacheStampede:
+    """Verify sync discovery cache prevents thundering herd on TTL expiry."""
+
+    @respx.mock
+    def test_disco_cache_stampede_blocked(self):
+        """Multiple threads hitting expired cache produce only 1 HTTP fetch."""
+        disco_route = respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+
+        barrier = threading.Barrier(5, timeout=5)
+        results: list[object] = [None] * 5
+        errors: list[Exception | None] = [None] * 5
+
+        def worker(idx: int) -> None:
+            try:
+                barrier.wait()
+                results[idx] = _get_disco_response(DISCO_URL)
+            except Exception as exc:
+                errors[idx] = exc
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        for err in errors:
+            assert err is None, f"Thread raised: {err}"
+
+        # All 5 threads should have gotten a result
+        assert all(r is not None for r in results)
+        # Only 1 HTTP fetch should have occurred (single-flight)
+        assert disco_route.call_count == 1
+
+
+class TestSyncJwksCacheStampede:
+    """Verify sync JWKS cache prevents thundering herd on TTL expiry."""
+
+    @respx.mock
+    def test_jwks_cache_stampede_blocked(self):
+        """Multiple threads hitting expired JWKS cache produce only 1 HTTP fetch."""
+        key_dict, _ = generate_rsa_keypair()
+        jwks_route = respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(200, json={"keys": [key_dict]})
+        )
+
+        barrier = threading.Barrier(5, timeout=5)
+        results: list[object] = [None] * 5
+        errors: list[Exception | None] = [None] * 5
+
+        def worker(idx: int) -> None:
+            try:
+                barrier.wait()
+                results[idx] = _get_cached_jwks(JWKS_URL)
+            except Exception as exc:
+                errors[idx] = exc
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        for err in errors:
+            assert err is None, f"Thread raised: {err}"
+
+        assert all(r is not None for r in results)
+        assert jwks_route.call_count == 1
+
+
+class TestSyncStampedeAfterExpiry:
+    """Verify stampede prevention after TTL expiry."""
+
+    @respx.mock
+    def test_jwks_stampede_after_expiry_blocked(self):
+        """After TTL expires, concurrent fetches produce only 1 new HTTP request."""
+        key_dict, _ = generate_rsa_keypair()
+        jwks_route = respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(200, json={"keys": [key_dict]})
+        )
+
+        # Prime cache, then expire it by backdating cached_at
+        _get_cached_jwks(JWKS_URL)
+        assert jwks_route.call_count == 1
+
+        # Expire the entry by setting cached_at far in the past
+        sync_tv._jwks_cache[JWKS_URL] = JwksCacheEntry(
+            response=sync_tv._jwks_cache[JWKS_URL].response,
+            cached_at=time.time() - 86401,
+            ttl=86400.0,
+        )
+
+        barrier = threading.Barrier(5, timeout=5)
+        errors: list[Exception | None] = [None] * 5
+
+        def worker(idx: int) -> None:
+            try:
+                barrier.wait()
+                _get_cached_jwks(JWKS_URL)
+            except Exception as exc:
+                errors[idx] = exc
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        for err in errors:
+            assert err is None, f"Thread raised: {err}"
+
+        # 1 initial + 1 refresh (NOT 1 + 5)
+        assert jwks_route.call_count == FETCH_AFTER_EXPIRY
+
+    @respx.mock
+    def test_disco_stampede_after_expiry_blocked(self):
+        """After disco TTL expires, concurrent fetches produce only 1 new request."""
+        disco_route = respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+
+        # Prime cache, then expire it
+        _get_disco_response(DISCO_URL)
+        assert disco_route.call_count == 1
+
+        sync_tv._disco_cache[DISCO_URL] = DiscoCacheEntry(
+            response=sync_tv._disco_cache[DISCO_URL].response,
+            cached_at=time.time() - 3601,
+            ttl=3600.0,
+        )
+
+        barrier = threading.Barrier(5, timeout=5)
+        errors: list[Exception | None] = [None] * 5
+
+        def worker(idx: int) -> None:
+            try:
+                barrier.wait()
+                _get_disco_response(DISCO_URL)
+            except Exception as exc:
+                errors[idx] = exc
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        for err in errors:
+            assert err is None, f"Thread raised: {err}"
+
+        assert disco_route.call_count == FETCH_AFTER_EXPIRY
+
+
+class TestAsyncDiscoCacheStampede:
+    """Verify async discovery cache prevents thundering herd on TTL expiry."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_disco_cache_stampede_blocked_async(self):
+        """Multiple coroutines hitting expired cache produce only 1 HTTP fetch."""
+        disco_route = respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+
+        results = await asyncio.gather(
+            *[async_get_disco_response(DISCO_URL) for _ in range(5)]
+        )
+
+        assert all(r is not None for r in results)
+        assert disco_route.call_count == 1
+
+
+class TestAsyncJwksCacheStampede:
+    """Verify async JWKS cache prevents thundering herd on TTL expiry."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_jwks_cache_stampede_blocked_async(self):
+        """Multiple coroutines hitting expired JWKS cache produce only 1 HTTP fetch."""
+        key_dict, _ = generate_rsa_keypair()
+        jwks_route = respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(200, json={"keys": [key_dict]})
+        )
+
+        results = await asyncio.gather(
+            *[async_get_cached_jwks(JWKS_URL) for _ in range(5)]
+        )
+
+        assert all(r is not None for r in results)
+        assert jwks_route.call_count == 1
+
+
+class TestAsyncStampedeAfterExpiry:
+    """Verify async stampede prevention after TTL expiry."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_jwks_stampede_after_expiry_blocked_async(self):
+        """After TTL expires, concurrent async fetches produce only 1 new request."""
+        key_dict, _ = generate_rsa_keypair()
+        jwks_route = respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(200, json={"keys": [key_dict]})
+        )
+
+        # Prime cache
+        await async_get_cached_jwks(JWKS_URL)
+        assert jwks_route.call_count == 1
+
+        # Expire the entry
+        aio_tv._jwks_cache[JWKS_URL] = JwksCacheEntry(
+            response=aio_tv._jwks_cache[JWKS_URL].response,
+            cached_at=time.time() - 86401,
+            ttl=86400.0,
+        )
+
+        results = await asyncio.gather(
+            *[async_get_cached_jwks(JWKS_URL) for _ in range(5)]
+        )
+
+        assert all(r is not None for r in results)
+        # 1 initial + 1 refresh (NOT 1 + 5)
+        assert jwks_route.call_count == FETCH_AFTER_EXPIRY
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_disco_stampede_after_expiry_blocked_async(self):
+        """After disco TTL expires, concurrent async fetches produce only 1 new request."""
+        disco_route = respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+
+        # Prime cache
+        await async_get_disco_response(DISCO_URL)
+        assert disco_route.call_count == 1
+
+        # Expire the entry
+        aio_tv._disco_cache[DISCO_URL] = DiscoCacheEntry(
+            response=aio_tv._disco_cache[DISCO_URL].response,
+            cached_at=time.time() - 3601,
+            ttl=3600.0,
+        )
+
+        results = await asyncio.gather(
+            *[async_get_disco_response(DISCO_URL) for _ in range(5)]
+        )
+
+        assert all(r is not None for r in results)
+        assert disco_route.call_count == FETCH_AFTER_EXPIRY


### PR DESCRIPTION
## Summary

- Implements fetch-under-lock pattern in all 6 cache functions (sync + async × discovery + JWKS + refresh) to prevent thundering herd on TTL expiry
- Only one thread/task refreshes while others wait on the lock, eliminating N simultaneous HTTP requests to the IdP
- Adds timestamp-based freshness guard in `_refresh_jwks` to prevent redundant sequential fetches

Closes #378

## Exploit Scenario Blocked

When a discovery or JWKS cache entry expires, all concurrent threads/tasks previously saw the stale entry simultaneously, released the lock, and made parallel HTTP requests to the IdP. With N threads, N requests fired at once — triggering rate limiting (429), amplifying DoS conditions, and causing N simultaneous JWKS fetches during key rotation. The fix ensures only one thread performs the refresh while others wait on the result.

## Review Findings Addressed

Five independent review agents assessed the implementation:

- **Blind Hunter**: 2 MUST FIX (lock held during I/O — accepted as the design pattern recommended by the issue), 4 SHOULD FIX, 2 NITPICK
- **Edge Case Hunter**: 6 findings (0 critical), redundant `_refresh_jwks` fetches FIXED (commit a73a026)
- **Acceptance Auditor**: 7/7 acceptance criteria PASS
- **Sentinel**: 0 BLOCK, 1 WARN, 2 INFO — overall PASS
- **Viper**: 0 critical, 0 high, 1 medium, 2 low — overall PASS

Key trade-off: fetch-under-lock adds latency for waiting threads (convoy effect) but is the simplest correct solution. Per-URI locks or stale-while-revalidate can be added as a future enhancement if needed.

## Test plan
- [x] Unit tests pass (8 new tests covering sync + async, cold start + expiry scenarios)
- [x] Lint passes (`make lint`)
- [x] Independent review agents passed (5/5)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)