### PR TITLE
fix(security): reject JWKS responses with missing Content-Type

### DIFF
--- a/src/py_identity_model/core/response_processors.py
+++ b/src/py_identity_model/core/response_processors.py
@@ -366,8 +366,11 @@ def parse_jwks_response(response: httpx.Response) -> JwksResponse:
         content_type_header = response.headers.get("Content-Type", "")
         media_type = content_type_header.split(";")[0].strip().lower()
         if not media_type:
-            logger.warning("JWKS response missing Content-Type header")
-        elif media_type not in _VALID_JWKS_CONTENT_TYPES:
+            return JwksResponse(
+                is_successful=False,
+                error="JWKS response missing Content-Type header",
+            )
+        if media_type not in _VALID_JWKS_CONTENT_TYPES:
             return JwksResponse(
                 is_successful=False,
                 error=(

--- a/src/tests/unit/test_http_security_hardening.py
+++ b/src/tests/unit/test_http_security_hardening.py
@@ -8,7 +8,6 @@ Covers:
 """
 
 import json
-import logging
 from typing import ClassVar
 from unittest.mock import MagicMock
 
@@ -282,16 +281,16 @@ class TestJwksContentTypeValidation:
         assert result.error is not None
         assert "text/plain" in result.error
 
-    def test_warns_on_missing_content_type(self, caplog):
+    def test_rejects_missing_content_type(self):
         response = httpx.Response(
             200,
             content=json.dumps(self._VALID_JWKS_JSON).encode(),
             # No Content-Type header
         )
-        with caplog.at_level(logging.WARNING, logger="py_identity_model"):
-            result = parse_jwks_response(response)
-        assert result.is_successful is True
-        assert "missing Content-Type" in caplog.text
+        result = parse_jwks_response(response)
+        assert result.is_successful is False
+        assert result.error is not None
+        assert "missing Content-Type" in result.error
 
     def test_rejects_application_xml(self):
         response = httpx.Response(

--- a/src/tests/unit/test_jwks.py
+++ b/src/tests/unit/test_jwks.py
@@ -672,12 +672,13 @@ class TestGetJwks:
 
     @respx.mock
     def test_get_jwks_json_decode_error(self):
-        # Mock response that raises JSON decode error
+        # Mock response with valid Content-Type but invalid JSON body
         url = "https://example.com/jwks"
         respx.get(url).mock(
             return_value=httpx.Response(
                 200,
                 content=b"invalid json{",
+                headers={"Content-Type": "application/json"},
             )
         )
 


### PR DESCRIPTION
## Summary

- Change missing JWKS Content-Type from warning to hard rejection (`is_successful=False`)
- Prevents non-JWKS payloads (HTML error pages, generic JSON) from reaching key parsing

Closes #379

## Exploit Scenario Blocked

An HTTP intermediary (load balancer, CDN) returning an error page without Content-Type would previously pass through as a warning and reach `response.json()`, causing confusing `JSONDecodeError` or worse — valid JSON that isn't a JWKS (e.g., `{"error": "unauthorized"}`) would bypass Content-Type validation entirely.

## Test plan
- [x] Unit tests pass (959 passed, 95.58% coverage)
- [x] Lint passes (`make lint`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)