### PR TITLE
chore(deps): widen caps to unblock dependabot grouped PRs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 dependencies = [
     "PyJWT>=2.9.0,<3",
     "httpx>=0.28.1,<1",
-    "cryptography>=45.0.2,<47",
+    "cryptography>=45.0.2,<49",
     "async-lru>=2.0.4,<3",
 ]
 
@@ -37,11 +37,11 @@ dev = [
 docs = [
     "mkdocs>=1.6.0,<2",
     "mkdocs-material>=9.6.0,<10",
-    "mkdocstrings[python]>=0.29.0,<1",
+    "mkdocstrings[python]>=0.29.0,<2",
 ]
 
 [build-system]
-requires = ["uv_build>=0.6,<0.11"]
+requires = ["uv_build>=0.6,<0.12"]
 build-backend = "uv_build"
 
 [tool.semantic_release]

--- a/uv.lock
+++ b/uv.lock
@@ -881,7 +881,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "async-lru", specifier = ">=2.0.4,<3" },
-    { name = "cryptography", specifier = ">=45.0.2,<47" },
+    { name = "cryptography", specifier = ">=45.0.2,<49" },
     { name = "httpx", specifier = ">=0.28.1,<1" },
     { name = "pyjwt", specifier = ">=2.9.0,<3" },
 ]
@@ -905,7 +905,7 @@ dev = [
 docs = [
     { name = "mkdocs", specifier = ">=1.6.0,<2" },
     { name = "mkdocs-material", specifier = ">=9.6.0,<10" },
-    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.29.0,<1" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.29.0,<2" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Widen three upper-bound caps so Dependabot can resume opening grouped dependency PRs
- `cryptography <47` → `<49`, `mkdocstrings[python] <1` → `<2`, `uv_build <0.11` → `<0.12`

## Why
Dependabot has been running daily but creating no PRs since 2026-04-20. Job logs show every grouped run aborts with:

```
Skipping change to group python-dependencies in directory /:
  Previous version was not provided for: 'mkdocstrings[python], uv-build, python-multipart'
  No requirements change for: 'filelock, pre-commit, respx, ruff, pyrefly, fastapi, types-requests'
Nothing to update for Dependency Group: 'python-dependencies'
```

The latest releases of `cryptography` (48.0.0), `mkdocstrings` (1.0.4), and `uv_build` (0.11.11) all violate our existing caps. With no satisfiable target version, Dependabot can't compute a "previous version" for those packages, the grouped-update consistency guard discards the whole batch, and no PR is ever opened — even for the lockfile-only updates (filelock, pre-commit, ruff, pyrefly, fastapi, etc.) that would otherwise succeed.

Widening the caps to span the next major lets the next daily run produce a real grouped PR.

## Test plan
- [x] `make lint` passes (ruff, ruff format, pyrefly, pytest 80% coverage)
- [x] `uv sync` resolves cleanly with the new specifiers
- [ ] After merge, confirm next 03:00 UTC dependabot run opens a grouped python-dependencies PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)