### PR TITLE
fix(token-validation): refresh JWKS on cached kid miss

### DIFF
--- a/conformance/results/basic-rp-latest.json
+++ b/conformance/results/basic-rp-latest.json
@@ -1,104 +1,104 @@
 {
   "plan": "basic-rp",
-  "plan_id": "k14GyYkholz4l",
+  "plan_id": "T6YsG1bnx4c8E",
   "suite_url": "https://localhost.emobix.co.uk:8443",
   "results": [
     {
       "test": "oidcc-client-test",
       "status": "PASSED",
-      "test_id": "qAV7nbRtxkI4c40",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=qAV7nbRtxkI4c40",
+      "test_id": "J6RZ0QYLIqSqnmN",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=J6RZ0QYLIqSqnmN",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-invalid-iss",
       "status": "PASSED",
-      "test_id": "EtKLH4AXQe4Uh0n",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=EtKLH4AXQe4Uh0n",
+      "test_id": "9NiPTvBCVqm8Ual",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=9NiPTvBCVqm8Ual",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-missing-sub",
       "status": "PASSED",
-      "test_id": "dumfCr7PFyQP10b",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=dumfCr7PFyQP10b",
+      "test_id": "3HXnY2MWHR5ZpOr",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=3HXnY2MWHR5ZpOr",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-invalid-aud",
       "status": "PASSED",
-      "test_id": "c5kOspGFCSX3L2v",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=c5kOspGFCSX3L2v",
+      "test_id": "VITlE4esdcuZwts",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=VITlE4esdcuZwts",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-missing-iat",
       "status": "PASSED",
-      "test_id": "5BwxiEdKzRHEbbx",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=5BwxiEdKzRHEbbx",
+      "test_id": "1TI5WuNnibFfkqu",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=1TI5WuNnibFfkqu",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-kid-absent-single-jwks",
       "status": "PASSED",
-      "test_id": "Uw4Vo06HGj64KAA",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=Uw4Vo06HGj64KAA",
+      "test_id": "2ng4W5V8Q422YOQ",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=2ng4W5V8Q422YOQ",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-kid-absent-multiple-jwks",
       "status": "PASSED",
-      "test_id": "UTBbYd6j3zh7mzd",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=UTBbYd6j3zh7mzd",
+      "test_id": "SPuILLfsPnpE4oI",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=SPuILLfsPnpE4oI",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-idtoken-sig-rs256",
       "status": "PASSED",
-      "test_id": "teLrnYICPG6ueEx",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=teLrnYICPG6ueEx",
+      "test_id": "6Yu73KTPvCYdFKp",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=6Yu73KTPvCYdFKp",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-idtoken-sig-none",
       "status": "SKIPPED",
-      "test_id": "IlMch9Tv777LU8u",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=IlMch9Tv777LU8u",
+      "test_id": "1kO1WrjwzHBdQst",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=1kO1WrjwzHBdQst",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-invalid-sig-rs256",
       "status": "PASSED",
-      "test_id": "ipGQGlIKJh2JQB6",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=ipGQGlIKJh2JQB6",
+      "test_id": "XrXhBeEVlsD2o7Q",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=XrXhBeEVlsD2o7Q",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-userinfo-invalid-sub",
       "status": "PASSED",
-      "test_id": "BsbyPguPrxeh1iF",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=BsbyPguPrxeh1iF",
+      "test_id": "qzNpJ0b0TH84sSF",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=qzNpJ0b0TH84sSF",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-nonce-invalid",
       "status": "PASSED",
-      "test_id": "1vKdDNwdbM00S4I",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=1vKdDNwdbM00S4I",
+      "test_id": "9InKz3n5he7nP6j",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=9InKz3n5he7nP6j",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-scope-userinfo-claims",
       "status": "PASSED",
-      "test_id": "tEHWC2dSRVFxU0X",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=tEHWC2dSRVFxU0X",
+      "test_id": "z2fcENu4kpNYIGx",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=z2fcENu4kpNYIGx",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-client-secret-basic",
       "status": "PASSED",
-      "test_id": "oBKNnHtBiVF7TcP",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=oBKNnHtBiVF7TcP",
+      "test_id": "TsGSMps1eK02fUp",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=TsGSMps1eK02fUp",
       "detail": ""
     }
   ],

--- a/conformance/results/config-rp-latest.json
+++ b/conformance/results/config-rp-latest.json
@@ -1,48 +1,48 @@
 {
   "plan": "config-rp",
-  "plan_id": "aopFGhgJXtbOT",
+  "plan_id": "rYNtbteMozOBP",
   "suite_url": "https://localhost.emobix.co.uk:8443",
   "results": [
     {
       "test": "oidcc-client-test-discovery-openid-config",
       "status": "PASSED",
-      "test_id": "WYDY0MALD506SWj",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=WYDY0MALD506SWj",
+      "test_id": "R4jFsLk6cf1RBuq",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=R4jFsLk6cf1RBuq",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-discovery-jwks-uri-keys",
       "status": "PASSED",
-      "test_id": "D2lh3wpqKZiTqLh",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=D2lh3wpqKZiTqLh",
+      "test_id": "F2TEjqWA5VXCMzf",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=F2TEjqWA5VXCMzf",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-discovery-issuer-mismatch",
       "status": "PASSED",
-      "test_id": "N98F3JcfxgExs29",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=N98F3JcfxgExs29",
+      "test_id": "1pKj0eqrCUhVdH7",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=1pKj0eqrCUhVdH7",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-idtoken-sig-none",
       "status": "SKIPPED",
-      "test_id": "kp8G0vg8QmPoKFu",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=kp8G0vg8QmPoKFu",
+      "test_id": "DMIpMCFlV9j1uAv",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=DMIpMCFlV9j1uAv",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-signing-key-rotation-just-before-signing",
       "status": "PASSED",
-      "test_id": "rvYuDsaDSap7nRc",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=rvYuDsaDSap7nRc",
+      "test_id": "Cq6WSp3h3KqyoG6",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=Cq6WSp3h3KqyoG6",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-signing-key-rotation",
       "status": "PASSED",
-      "test_id": "yUv01CxpuBvUc3Q",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=yUv01CxpuBvUc3Q",
+      "test_id": "5E1KpDObbdYyfOA",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=5E1KpDObbdYyfOA",
       "detail": ""
     }
   ],

--- a/conformance/results/form-post-basic-rp-latest.json
+++ b/conformance/results/form-post-basic-rp-latest.json
@@ -1,0 +1,114 @@
+{
+  "plan": "form-post-basic-rp",
+  "plan_id": "qNFEJarULszzl",
+  "suite_url": "https://localhost.emobix.co.uk:8443",
+  "results": [
+    {
+      "test": "oidcc-client-test",
+      "status": "PASSED",
+      "test_id": "Wm7XmvGcbvYPfXc",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=Wm7XmvGcbvYPfXc",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-invalid-iss",
+      "status": "PASSED",
+      "test_id": "EkUtK5tCLnLbDEe",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=EkUtK5tCLnLbDEe",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-missing-sub",
+      "status": "PASSED",
+      "test_id": "j2SPY1MmMpFiyhJ",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=j2SPY1MmMpFiyhJ",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-invalid-aud",
+      "status": "PASSED",
+      "test_id": "kGCrMBnv2VxboY0",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=kGCrMBnv2VxboY0",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-missing-iat",
+      "status": "PASSED",
+      "test_id": "uqaSfhQyGhDuvvQ",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=uqaSfhQyGhDuvvQ",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-kid-absent-single-jwks",
+      "status": "PASSED",
+      "test_id": "1A65b0KqDTdAGC2",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=1A65b0KqDTdAGC2",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-kid-absent-multiple-jwks",
+      "status": "PASSED",
+      "test_id": "hhM4zPLGibdV3JI",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=hhM4zPLGibdV3JI",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-idtoken-sig-rs256",
+      "status": "PASSED",
+      "test_id": "dfqcZRivLw2wxwD",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=dfqcZRivLw2wxwD",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-idtoken-sig-none",
+      "status": "SKIPPED",
+      "test_id": "qkiwlO6Inkm19zn",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=qkiwlO6Inkm19zn",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-invalid-sig-rs256",
+      "status": "PASSED",
+      "test_id": "LDDalGJbPb5eUZZ",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=LDDalGJbPb5eUZZ",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-userinfo-invalid-sub",
+      "status": "PASSED",
+      "test_id": "KYgMWWjzzv09J2E",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=KYgMWWjzzv09J2E",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-nonce-invalid",
+      "status": "PASSED",
+      "test_id": "S1Ky1pz1lquvKyL",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=S1Ky1pz1lquvKyL",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-scope-userinfo-claims",
+      "status": "PASSED",
+      "test_id": "OHpHtd9S7zjVdpq",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=OHpHtd9S7zjVdpq",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-client-secret-basic",
+      "status": "PASSED",
+      "test_id": "YHR1Qpxb0weJYwe",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=YHR1Qpxb0weJYwe",
+      "detail": ""
+    }
+  ],
+  "summary": {
+    "total": 14,
+    "passed": 13,
+    "warning": 0,
+    "failed": 0,
+    "review": 0,
+    "skipped": 1
+  },
+  "all_passed": true
+}

--- a/src/py_identity_model/aio/token_validation.py
+++ b/src/py_identity_model/aio/token_validation.py
@@ -178,6 +178,16 @@ async def _discover_and_resolve_key(
     jwks_response = await _get_cached_jwks(jwks_uri)
     validate_jwks_response(jwks_response)
     kid, jwt_alg = extract_jwt_header_fields(jwt)
+    # OP key rotation: if the JWT's kid is not in the cached JWKS, the cache
+    # is stale. Force a refresh before lookup so rotation is handled without
+    # waiting for a signature failure on a key we don't have.
+    if kid is not None and not any(k.kid == kid for k in (jwks_response.keys or [])):
+        logger.info(
+            "kid %s not present in cached JWKS; refreshing (possible key rotation)",
+            kid,
+        )
+        jwks_response = await _refresh_jwks(jwks_uri)
+        validate_jwks_response(jwks_response)
     key_dict, alg = find_key_by_kid(kid, jwks_response.keys or [], jwt_alg=jwt_alg)
     return key_dict, alg, disco_doc_response, True
 

--- a/src/py_identity_model/sync/token_validation.py
+++ b/src/py_identity_model/sync/token_validation.py
@@ -175,6 +175,16 @@ def _discover_and_resolve_key(
     jwks_response = _get_cached_jwks(jwks_uri)
     validate_jwks_response(jwks_response)
     kid, jwt_alg = extract_jwt_header_fields(jwt)
+    # OP key rotation: if the JWT's kid is not in the cached JWKS, the cache
+    # is stale. Force a refresh before lookup so rotation is handled without
+    # waiting for a signature failure on a key we don't have.
+    if kid is not None and not any(k.kid == kid for k in (jwks_response.keys or [])):
+        logger.info(
+            "kid %s not present in cached JWKS; refreshing (possible key rotation)",
+            kid,
+        )
+        jwks_response = _refresh_jwks(jwks_uri)
+        validate_jwks_response(jwks_response)
     key_dict, alg = find_key_by_kid(kid, jwks_response.keys or [], jwt_alg=jwt_alg)
     return key_dict, alg, disco_doc_response, True
 

--- a/src/tests/unit/test_aio_token_validation.py
+++ b/src/tests/unit/test_aio_token_validation.py
@@ -6,6 +6,7 @@ error handling, TTL-based JWKS caching, signature retry on key rotation,
 and enhanced features (leeway, multi-issuer, subject).
 """
 
+import contextlib
 import time
 from unittest.mock import patch
 
@@ -268,6 +269,68 @@ class TestAsyncSignatureRetry:
             audience=None,
             issuer="https://example.com",
         )
+
+        decoded = await validate_token(
+            jwt=token,
+            token_validation_config=config,
+            disco_doc_address="https://example.com/.well-known/openid-configuration",
+        )
+
+        assert decoded["sub"] == "user1"
+        assert jwks_route.call_count == JWKS_FETCH_WITH_RETRY
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_cached_path_refreshes_jwks_when_kid_not_in_cache(self):
+        """Cached JWKS lookup with a kid not in cache forces a refresh.
+
+        OIDC OPs rotate signing keys; when a token arrives with a kid that is
+        not yet in the cached JWKS, the cache is stale. The library must
+        refresh JWKS without waiting for a signature failure on a key it
+        does not have.
+        """
+        old_key_dict, _ = generate_rsa_keypair()
+        old_key_dict["kid"] = "old-kid"
+
+        new_key_dict, new_pem = generate_rsa_keypair()
+        new_key_dict["kid"] = "new-kid"
+
+        token = sign_jwt(
+            new_pem,
+            {"sub": "user1", "iss": "https://example.com"},
+            headers={"kid": "new-kid"},
+        )
+
+        respx.get("https://example.com/.well-known/openid-configuration").mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+        jwks_route = respx.get("https://example.com/jwks").mock(
+            side_effect=[
+                httpx.Response(200, json={"keys": [old_key_dict]}),
+                httpx.Response(200, json={"keys": [new_key_dict]}),
+            ]
+        )
+
+        config = TokenValidationConfig(
+            perform_disco=True,
+            audience=None,
+            issuer="https://example.com",
+        )
+
+        # Prime the cache with the old kid.
+        old_pem_token = sign_jwt(
+            generate_rsa_keypair()[1],
+            {"sub": "warmup"},
+            headers={"kid": "old-kid"},
+        )
+        with contextlib.suppress(
+            SignatureVerificationException, TokenValidationException
+        ):
+            await validate_token(
+                jwt=old_pem_token,
+                token_validation_config=config,
+                disco_doc_address="https://example.com/.well-known/openid-configuration",
+            )
 
         decoded = await validate_token(
             jwt=token,

--- a/src/tests/unit/test_cache_stampede.py
+++ b/src/tests/unit/test_cache_stampede.py
@@ -6,6 +6,7 @@ fetch rather than N parallel fetches (thundering herd).
 """
 
 import asyncio
+from collections.abc import Callable
 import threading
 import time
 
@@ -29,7 +30,11 @@ from py_identity_model.aio.token_validation import (
 from py_identity_model.aio.token_validation import (
     clear_jwks_cache as async_clear_jwks_cache,
 )
+from py_identity_model.aio.token_validation import (
+    validate_token as async_validate_token,
+)
 from py_identity_model.core.jwks_cache import DiscoCacheEntry, JwksCacheEntry
+from py_identity_model.core.models import TokenValidationConfig
 from py_identity_model.sync import token_validation as sync_tv
 from py_identity_model.sync.token_validation import (
     _get_cached_jwks,
@@ -37,11 +42,13 @@ from py_identity_model.sync.token_validation import (
     _refresh_jwks,
     clear_discovery_cache,
     clear_jwks_cache,
+    validate_token,
 )
 
 from .token_validation_helpers import (
     DISCO_RESPONSE_WITH_JWKS,
     generate_rsa_keypair,
+    sign_jwt,
 )
 
 
@@ -410,3 +417,229 @@ class TestAsyncRefreshJwksFreshnessGuard:
         result = await async_refresh_jwks(JWKS_URL)
         assert result is not None
         assert jwks_route.call_count == FETCH_AFTER_EXPIRY
+
+
+# ============================================================================
+# Kid-miss stampede (PR #390): pre-decode refresh path must single-flight
+# ============================================================================
+#
+# The fix in #390 adds a pre-decode JWKS refresh when the JWT's `kid` is not
+# in the cached JWKS. Without protection, N concurrent requests with an
+# unknown kid would each issue their own JWKS fetch (thundering herd against
+# the OP's JWKS endpoint, and an unauthenticated amplification vector since
+# the JWT header is not yet trust-validated).
+#
+# Protection comes from two layers already in the code:
+#   1. `_get_cached_jwks` and `_refresh_jwks` share `_jwks_cache_lock`. While
+#      task A holds the lock during its fetch, tasks B..N block at
+#      `_get_cached_jwks` and read the freshly-refreshed cache when A releases.
+#      Most concurrent tasks therefore never even enter `_refresh_jwks`.
+#   2. The single-flight guard inside `_refresh_jwks`
+#      (`cached_at >= request_time`) catches the residual race where multiple
+#      tasks captured `request_time` before the first fetch completed.
+#
+# These tests pin both layers in place so a future change cannot quietly
+# regress the kid-miss path into an N-fetch fan-out.
+
+# 1 prime fetch + 1 single-flight refresh on rotation = 2 fetches, regardless
+# of how many concurrent validators arrive with the unknown kid.
+KID_MISS_FETCH_BUDGET = 2
+
+
+def _make_rotating_jwks_handler(
+    old_keys_response: dict, new_keys_response: dict
+) -> tuple[list[int], Callable[[httpx.Request], httpx.Response]]:
+    """Return (call_log, handler). First call returns old_keys; rest return new_keys."""
+    call_log: list[int] = []
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        call_log.append(1)
+        if len(call_log) == 1:
+            return httpx.Response(200, json=old_keys_response)
+        return httpx.Response(200, json=new_keys_response)
+
+    return call_log, handler
+
+
+class TestAsyncKidMissStampede:
+    """Concurrent kid-miss validations must produce a single refresh fetch."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_n_concurrent_unknown_kid_triggers_single_refresh(self):
+        """N concurrent validate_token calls with the same unknown kid → 2 fetches total."""
+        old_key_dict, _old_pem = generate_rsa_keypair()
+        old_key_dict["kid"] = "old-kid"
+        new_key_dict, new_pem = generate_rsa_keypair()
+        new_key_dict["kid"] = "new-kid"
+
+        respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+        _, jwks_handler = _make_rotating_jwks_handler(
+            old_keys_response={"keys": [old_key_dict]},
+            new_keys_response={"keys": [new_key_dict]},
+        )
+        jwks_route = respx.get(JWKS_URL).mock(side_effect=jwks_handler)
+
+        # Prime cache with old kid via direct cache access (no validation needed).
+        await async_get_cached_jwks(JWKS_URL)
+        assert jwks_route.call_count == 1
+
+        token = sign_jwt(
+            new_pem,
+            {"sub": "user1", "iss": "https://example.com"},
+            headers={"kid": "new-kid"},
+        )
+        config = TokenValidationConfig(
+            perform_disco=True, audience=None, issuer="https://example.com"
+        )
+
+        N = 25
+        results = await asyncio.gather(
+            *[
+                async_validate_token(
+                    jwt=token,
+                    token_validation_config=config,
+                    disco_doc_address=DISCO_URL,
+                )
+                for _ in range(N)
+            ]
+        )
+
+        assert len(results) == N
+        for decoded in results:
+            assert decoded["sub"] == "user1"
+        # Stampede protection: only 1 prime + 1 refresh, NOT 1 + N.
+        assert jwks_route.call_count == KID_MISS_FETCH_BUDGET, (
+            f"Stampede: {jwks_route.call_count} fetches for {N} concurrent kid-miss "
+            f"validations (expected {KID_MISS_FETCH_BUDGET})"
+        )
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_n_concurrent_distinct_unknown_kids_triggers_single_refresh(self):
+        """N concurrent calls with N distinct unknown kids still single-flight by jwks_uri.
+
+        The single-flight key is jwks_uri, not kid. Even if every concurrent
+        request has a different unknown kid, only one refresh fetch should
+        occur. The first refresh populates the cache; subsequent tasks read
+        the fresh cache (and may then raise per-key errors if their kid still
+        isn't present, which is acceptable — what we're guarding here is the
+        outbound fetch count).
+        """
+        old_key_dict, _ = generate_rsa_keypair()
+        old_key_dict["kid"] = "old-kid"
+
+        # New JWKS contains every kid the rotated batch might use.
+        new_keys = []
+        new_pems: dict[str, bytes] = {}
+        N = 10
+        for i in range(N):
+            kd, pem = generate_rsa_keypair()
+            kd["kid"] = f"new-kid-{i}"
+            new_keys.append(kd)
+            new_pems[f"new-kid-{i}"] = pem
+
+        respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+        _, jwks_handler = _make_rotating_jwks_handler(
+            old_keys_response={"keys": [old_key_dict]},
+            new_keys_response={"keys": new_keys},
+        )
+        jwks_route = respx.get(JWKS_URL).mock(side_effect=jwks_handler)
+
+        await async_get_cached_jwks(JWKS_URL)
+        assert jwks_route.call_count == 1
+
+        config = TokenValidationConfig(
+            perform_disco=True, audience=None, issuer="https://example.com"
+        )
+
+        async def _validate(i: int) -> dict:
+            kid = f"new-kid-{i}"
+            tok = sign_jwt(
+                new_pems[kid],
+                {"sub": f"user{i}", "iss": "https://example.com"},
+                headers={"kid": kid},
+            )
+            return await async_validate_token(
+                jwt=tok,
+                token_validation_config=config,
+                disco_doc_address=DISCO_URL,
+            )
+
+        results = await asyncio.gather(*[_validate(i) for i in range(N)])
+
+        assert {r["sub"] for r in results} == {f"user{i}" for i in range(N)}
+        assert jwks_route.call_count == KID_MISS_FETCH_BUDGET, (
+            f"Stampede: {jwks_route.call_count} fetches for {N} concurrent distinct "
+            f"unknown kids (expected {KID_MISS_FETCH_BUDGET})"
+        )
+
+
+class TestSyncKidMissStampede:
+    """Concurrent kid-miss validations from threads must produce a single refresh fetch."""
+
+    @respx.mock
+    def test_n_concurrent_unknown_kid_triggers_single_refresh_sync(self):
+        """N threads concurrently validating tokens with the same unknown kid → 2 fetches."""
+        old_key_dict, _ = generate_rsa_keypair()
+        old_key_dict["kid"] = "old-kid"
+        new_key_dict, new_pem = generate_rsa_keypair()
+        new_key_dict["kid"] = "new-kid"
+
+        respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+        _, jwks_handler = _make_rotating_jwks_handler(
+            old_keys_response={"keys": [old_key_dict]},
+            new_keys_response={"keys": [new_key_dict]},
+        )
+        jwks_route = respx.get(JWKS_URL).mock(side_effect=jwks_handler)
+
+        # Prime cache.
+        _get_cached_jwks(JWKS_URL)
+        assert jwks_route.call_count == 1
+
+        token = sign_jwt(
+            new_pem,
+            {"sub": "user1", "iss": "https://example.com"},
+            headers={"kid": "new-kid"},
+        )
+        config = TokenValidationConfig(
+            perform_disco=True, audience=None, issuer="https://example.com"
+        )
+
+        N = 25
+        barrier = threading.Barrier(N, timeout=10)
+        results: list[dict | None] = [None] * N
+        errors: list[Exception | None] = [None] * N
+
+        def worker(idx: int) -> None:
+            try:
+                barrier.wait()
+                results[idx] = validate_token(
+                    jwt=token,
+                    token_validation_config=config,
+                    disco_doc_address=DISCO_URL,
+                )
+            except Exception as exc:
+                errors[idx] = exc
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(N)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=20)
+
+        for err in errors:
+            assert err is None, f"Worker raised: {err}"
+        for r in results:
+            assert r is not None
+            assert r["sub"] == "user1"
+        assert jwks_route.call_count == KID_MISS_FETCH_BUDGET, (
+            f"Stampede: {jwks_route.call_count} fetches for {N} concurrent kid-miss "
+            f"validations (expected {KID_MISS_FETCH_BUDGET})"
+        )

--- a/src/tests/unit/test_sync_token_validation.py
+++ b/src/tests/unit/test_sync_token_validation.py
@@ -5,6 +5,7 @@ These tests verify sync-specific token validation logic including
 error handling, TTL-based JWKS caching, and signature retry on key rotation.
 """
 
+import contextlib
 import time
 from unittest.mock import patch
 
@@ -293,6 +294,72 @@ class TestSyncSignatureRetry:
 
         assert decoded["sub"] == "user1"
         assert jwks_route.call_count == JWKS_FETCH_WITH_RETRY  # initial fetch + refresh
+
+    @respx.mock
+    def test_cached_path_refreshes_jwks_when_kid_not_in_cache(self):
+        """Cached JWKS lookup with a kid not in cache forces a refresh.
+
+        OIDC OPs rotate signing keys; when a token arrives with a kid that is
+        not yet in the cached JWKS, the cache is stale. The library must
+        refresh JWKS without waiting for a signature failure on a key it
+        does not have.
+        """
+        old_key_dict, _ = generate_rsa_keypair()
+        old_key_dict["kid"] = "old-kid"
+
+        new_key_dict, new_pem = generate_rsa_keypair()
+        new_key_dict["kid"] = "new-kid"
+
+        token = sign_jwt(
+            new_pem,
+            {"sub": "user1", "iss": "https://example.com"},
+            headers={"kid": "new-kid"},
+        )
+
+        respx.get("https://example.com/.well-known/openid-configuration").mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+
+        # First fetch returns only the old kid; second fetch returns only the new kid.
+        # If the library waits for signature failure to refresh, the second fetch
+        # will not happen because the lookup raises before decode.
+        jwks_route = respx.get("https://example.com/jwks").mock(
+            side_effect=[
+                httpx.Response(200, json={"keys": [old_key_dict]}),
+                httpx.Response(200, json={"keys": [new_key_dict]}),
+            ]
+        )
+
+        config = TokenValidationConfig(
+            perform_disco=True,
+            audience=None,
+            issuer="https://example.com",
+        )
+
+        # Prime the cache by validating a token with the old kid.
+        old_pem_token = sign_jwt(
+            generate_rsa_keypair()[1],  # discard, we just need to populate cache
+            {"sub": "warmup"},
+            headers={"kid": "old-kid"},
+        )
+        # Trigger a cache populate without caring about the validation outcome.
+        with contextlib.suppress(
+            SignatureVerificationException, TokenValidationException
+        ):
+            validate_token(
+                jwt=old_pem_token,
+                token_validation_config=config,
+                disco_doc_address="https://example.com/.well-known/openid-configuration",
+            )
+
+        decoded = validate_token(
+            jwt=token,
+            token_validation_config=config,
+            disco_doc_address="https://example.com/.well-known/openid-configuration",
+        )
+
+        assert decoded["sub"] == "user1"
+        assert jwks_route.call_count == JWKS_FETCH_WITH_RETRY
 
     @respx.mock
     def test_signature_failure_still_raises_after_retry(self):


### PR DESCRIPTION
## Summary
- Refresh cached JWKS when an incoming JWT's `kid` is not in cache, instead of waiting for a signature failure that never happens.
- Mirrored fix in sync (`src/py_identity_model/sync/token_validation.py`) and async (`src/py_identity_model/aio/token_validation.py`) `_discover_and_resolve_key`.
- New unit test in `TestSyncSignatureRetry` and `TestAsyncSignatureRetry` covering the kid-miss refresh path.
- Local conformance suite now passes `oidcc-client-test-signing-key-rotation` for Config RP. Updated committed result artifacts for Basic RP (13 PASS / 1 SKIP), Config RP (5 PASS / 1 SKIP), and Form Post Basic RP (13 PASS / 1 SKIP).

## Why
The OIDF Config RP `oidcc-client-test-signing-key-rotation` test was timing out. Trace:

```
id_token_validation: No matching kid found: 68327549-0b39-46cd-9db3-055f17907423
```

The OP rotates signing keys mid-flow. The new ID token's `kid` is not in the cached JWKS. `find_key_by_kid()` raises `TokenValidationException("No matching kid found")` **before** `decode_with_config` runs, so the existing `_retry_with_refreshed_jwks` path (which only fires on `SignatureVerificationException`) never executes. Cache is never refreshed.

The fix: in the cached path, peek for the JWT's `kid` in the cached JWKS. On miss, force a refresh via `_refresh_jwks` and proceed. This mirrors the OIDC-correct behavior every certified RP library implements and is required for the rotation conformance test. The DI (injected `http_client`) path is unchanged because it always fetches fresh.

## Test plan
- [x] `make lint` — ruff + ruff format + pyrefly + pytest 80% coverage all pass
- [x] `pytest TestSyncSignatureRetry TestAsyncSignatureRetry -v` — all 8 tests pass (4 existing + 2 new + 2 unchanged DI variants)
- [x] Local conformance suite — Config RP rotation test now PASS (was TIMEOUT)
- [x] Local conformance suite — Basic RP and Form Post Basic RP unchanged (no regression)

Refs #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)