### PR TITLE
fix(token-validation): refresh JWKS on cached kid miss + stampede pinning + hardening

### DIFF
--- a/conformance/results/basic-rp-latest.json
+++ b/conformance/results/basic-rp-latest.json
@@ -1,104 +1,104 @@
 {
   "plan": "basic-rp",
-  "plan_id": "k14GyYkholz4l",
+  "plan_id": "T6YsG1bnx4c8E",
   "suite_url": "https://localhost.emobix.co.uk:8443",
   "results": [
     {
       "test": "oidcc-client-test",
       "status": "PASSED",
-      "test_id": "qAV7nbRtxkI4c40",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=qAV7nbRtxkI4c40",
+      "test_id": "J6RZ0QYLIqSqnmN",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=J6RZ0QYLIqSqnmN",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-invalid-iss",
       "status": "PASSED",
-      "test_id": "EtKLH4AXQe4Uh0n",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=EtKLH4AXQe4Uh0n",
+      "test_id": "9NiPTvBCVqm8Ual",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=9NiPTvBCVqm8Ual",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-missing-sub",
       "status": "PASSED",
-      "test_id": "dumfCr7PFyQP10b",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=dumfCr7PFyQP10b",
+      "test_id": "3HXnY2MWHR5ZpOr",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=3HXnY2MWHR5ZpOr",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-invalid-aud",
       "status": "PASSED",
-      "test_id": "c5kOspGFCSX3L2v",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=c5kOspGFCSX3L2v",
+      "test_id": "VITlE4esdcuZwts",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=VITlE4esdcuZwts",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-missing-iat",
       "status": "PASSED",
-      "test_id": "5BwxiEdKzRHEbbx",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=5BwxiEdKzRHEbbx",
+      "test_id": "1TI5WuNnibFfkqu",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=1TI5WuNnibFfkqu",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-kid-absent-single-jwks",
       "status": "PASSED",
-      "test_id": "Uw4Vo06HGj64KAA",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=Uw4Vo06HGj64KAA",
+      "test_id": "2ng4W5V8Q422YOQ",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=2ng4W5V8Q422YOQ",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-kid-absent-multiple-jwks",
       "status": "PASSED",
-      "test_id": "UTBbYd6j3zh7mzd",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=UTBbYd6j3zh7mzd",
+      "test_id": "SPuILLfsPnpE4oI",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=SPuILLfsPnpE4oI",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-idtoken-sig-rs256",
       "status": "PASSED",
-      "test_id": "teLrnYICPG6ueEx",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=teLrnYICPG6ueEx",
+      "test_id": "6Yu73KTPvCYdFKp",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=6Yu73KTPvCYdFKp",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-idtoken-sig-none",
       "status": "SKIPPED",
-      "test_id": "IlMch9Tv777LU8u",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=IlMch9Tv777LU8u",
+      "test_id": "1kO1WrjwzHBdQst",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=1kO1WrjwzHBdQst",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-invalid-sig-rs256",
       "status": "PASSED",
-      "test_id": "ipGQGlIKJh2JQB6",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=ipGQGlIKJh2JQB6",
+      "test_id": "XrXhBeEVlsD2o7Q",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=XrXhBeEVlsD2o7Q",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-userinfo-invalid-sub",
       "status": "PASSED",
-      "test_id": "BsbyPguPrxeh1iF",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=BsbyPguPrxeh1iF",
+      "test_id": "qzNpJ0b0TH84sSF",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=qzNpJ0b0TH84sSF",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-nonce-invalid",
       "status": "PASSED",
-      "test_id": "1vKdDNwdbM00S4I",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=1vKdDNwdbM00S4I",
+      "test_id": "9InKz3n5he7nP6j",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=9InKz3n5he7nP6j",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-scope-userinfo-claims",
       "status": "PASSED",
-      "test_id": "tEHWC2dSRVFxU0X",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=tEHWC2dSRVFxU0X",
+      "test_id": "z2fcENu4kpNYIGx",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=z2fcENu4kpNYIGx",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-client-secret-basic",
       "status": "PASSED",
-      "test_id": "oBKNnHtBiVF7TcP",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=oBKNnHtBiVF7TcP",
+      "test_id": "TsGSMps1eK02fUp",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=TsGSMps1eK02fUp",
       "detail": ""
     }
   ],

--- a/conformance/results/config-rp-latest.json
+++ b/conformance/results/config-rp-latest.json
@@ -1,48 +1,48 @@
 {
   "plan": "config-rp",
-  "plan_id": "aopFGhgJXtbOT",
+  "plan_id": "rYNtbteMozOBP",
   "suite_url": "https://localhost.emobix.co.uk:8443",
   "results": [
     {
       "test": "oidcc-client-test-discovery-openid-config",
       "status": "PASSED",
-      "test_id": "WYDY0MALD506SWj",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=WYDY0MALD506SWj",
+      "test_id": "R4jFsLk6cf1RBuq",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=R4jFsLk6cf1RBuq",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-discovery-jwks-uri-keys",
       "status": "PASSED",
-      "test_id": "D2lh3wpqKZiTqLh",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=D2lh3wpqKZiTqLh",
+      "test_id": "F2TEjqWA5VXCMzf",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=F2TEjqWA5VXCMzf",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-discovery-issuer-mismatch",
       "status": "PASSED",
-      "test_id": "N98F3JcfxgExs29",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=N98F3JcfxgExs29",
+      "test_id": "1pKj0eqrCUhVdH7",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=1pKj0eqrCUhVdH7",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-idtoken-sig-none",
       "status": "SKIPPED",
-      "test_id": "kp8G0vg8QmPoKFu",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=kp8G0vg8QmPoKFu",
+      "test_id": "DMIpMCFlV9j1uAv",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=DMIpMCFlV9j1uAv",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-signing-key-rotation-just-before-signing",
       "status": "PASSED",
-      "test_id": "rvYuDsaDSap7nRc",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=rvYuDsaDSap7nRc",
+      "test_id": "Cq6WSp3h3KqyoG6",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=Cq6WSp3h3KqyoG6",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-signing-key-rotation",
       "status": "PASSED",
-      "test_id": "yUv01CxpuBvUc3Q",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=yUv01CxpuBvUc3Q",
+      "test_id": "5E1KpDObbdYyfOA",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=5E1KpDObbdYyfOA",
       "detail": ""
     }
   ],

--- a/conformance/results/form-post-basic-rp-latest.json
+++ b/conformance/results/form-post-basic-rp-latest.json
@@ -1,0 +1,114 @@
+{
+  "plan": "form-post-basic-rp",
+  "plan_id": "qNFEJarULszzl",
+  "suite_url": "https://localhost.emobix.co.uk:8443",
+  "results": [
+    {
+      "test": "oidcc-client-test",
+      "status": "PASSED",
+      "test_id": "Wm7XmvGcbvYPfXc",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=Wm7XmvGcbvYPfXc",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-invalid-iss",
+      "status": "PASSED",
+      "test_id": "EkUtK5tCLnLbDEe",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=EkUtK5tCLnLbDEe",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-missing-sub",
+      "status": "PASSED",
+      "test_id": "j2SPY1MmMpFiyhJ",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=j2SPY1MmMpFiyhJ",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-invalid-aud",
+      "status": "PASSED",
+      "test_id": "kGCrMBnv2VxboY0",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=kGCrMBnv2VxboY0",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-missing-iat",
+      "status": "PASSED",
+      "test_id": "uqaSfhQyGhDuvvQ",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=uqaSfhQyGhDuvvQ",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-kid-absent-single-jwks",
+      "status": "PASSED",
+      "test_id": "1A65b0KqDTdAGC2",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=1A65b0KqDTdAGC2",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-kid-absent-multiple-jwks",
+      "status": "PASSED",
+      "test_id": "hhM4zPLGibdV3JI",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=hhM4zPLGibdV3JI",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-idtoken-sig-rs256",
+      "status": "PASSED",
+      "test_id": "dfqcZRivLw2wxwD",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=dfqcZRivLw2wxwD",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-idtoken-sig-none",
+      "status": "SKIPPED",
+      "test_id": "qkiwlO6Inkm19zn",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=qkiwlO6Inkm19zn",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-invalid-sig-rs256",
+      "status": "PASSED",
+      "test_id": "LDDalGJbPb5eUZZ",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=LDDalGJbPb5eUZZ",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-userinfo-invalid-sub",
+      "status": "PASSED",
+      "test_id": "KYgMWWjzzv09J2E",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=KYgMWWjzzv09J2E",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-nonce-invalid",
+      "status": "PASSED",
+      "test_id": "S1Ky1pz1lquvKyL",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=S1Ky1pz1lquvKyL",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-scope-userinfo-claims",
+      "status": "PASSED",
+      "test_id": "OHpHtd9S7zjVdpq",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=OHpHtd9S7zjVdpq",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-client-secret-basic",
+      "status": "PASSED",
+      "test_id": "YHR1Qpxb0weJYwe",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=YHR1Qpxb0weJYwe",
+      "detail": ""
+    }
+  ],
+  "summary": {
+    "total": 14,
+    "passed": 13,
+    "warning": 0,
+    "failed": 0,
+    "review": 0,
+    "skipped": 1
+  },
+  "all_passed": true
+}

--- a/src/py_identity_model/aio/token_validation.py
+++ b/src/py_identity_model/aio/token_validation.py
@@ -178,6 +178,16 @@ async def _discover_and_resolve_key(
     jwks_response = await _get_cached_jwks(jwks_uri)
     validate_jwks_response(jwks_response)
     kid, jwt_alg = extract_jwt_header_fields(jwt)
+    # OP key rotation: if the JWT's kid is not in the cached JWKS, the cache
+    # is stale. Force a refresh before lookup so rotation is handled without
+    # waiting for a signature failure on a key we don't have.
+    if kid is not None and not any(k.kid == kid for k in (jwks_response.keys or [])):
+        logger.info(
+            "kid %s not present in cached JWKS; refreshing (possible key rotation)",
+            kid,
+        )
+        jwks_response = await _refresh_jwks(jwks_uri)
+        validate_jwks_response(jwks_response)
     key_dict, alg = find_key_by_kid(kid, jwks_response.keys or [], jwt_alg=jwt_alg)
     return key_dict, alg, disco_doc_response, True
 

--- a/src/py_identity_model/aio/token_validation.py
+++ b/src/py_identity_model/aio/token_validation.py
@@ -188,6 +188,10 @@ async def _discover_and_resolve_key(
         )
         jwks_response = await _refresh_jwks(jwks_uri)
         validate_jwks_response(jwks_response)
+        if not any(k.kid == kid for k in (jwks_response.keys or [])):
+            logger.warning(
+                "kid %s still absent after JWKS refresh of %s", kid, jwks_uri
+            )
     key_dict, alg = find_key_by_kid(kid, jwks_response.keys or [], jwt_alg=jwt_alg)
     return key_dict, alg, disco_doc_response, True
 

--- a/src/py_identity_model/sync/token_validation.py
+++ b/src/py_identity_model/sync/token_validation.py
@@ -175,6 +175,16 @@ def _discover_and_resolve_key(
     jwks_response = _get_cached_jwks(jwks_uri)
     validate_jwks_response(jwks_response)
     kid, jwt_alg = extract_jwt_header_fields(jwt)
+    # OP key rotation: if the JWT's kid is not in the cached JWKS, the cache
+    # is stale. Force a refresh before lookup so rotation is handled without
+    # waiting for a signature failure on a key we don't have.
+    if kid is not None and not any(k.kid == kid for k in (jwks_response.keys or [])):
+        logger.info(
+            "kid %s not present in cached JWKS; refreshing (possible key rotation)",
+            kid,
+        )
+        jwks_response = _refresh_jwks(jwks_uri)
+        validate_jwks_response(jwks_response)
     key_dict, alg = find_key_by_kid(kid, jwks_response.keys or [], jwt_alg=jwt_alg)
     return key_dict, alg, disco_doc_response, True
 

--- a/src/py_identity_model/sync/token_validation.py
+++ b/src/py_identity_model/sync/token_validation.py
@@ -185,6 +185,10 @@ def _discover_and_resolve_key(
         )
         jwks_response = _refresh_jwks(jwks_uri)
         validate_jwks_response(jwks_response)
+        if not any(k.kid == kid for k in (jwks_response.keys or [])):
+            logger.warning(
+                "kid %s still absent after JWKS refresh of %s", kid, jwks_uri
+            )
     key_dict, alg = find_key_by_kid(kid, jwks_response.keys or [], jwt_alg=jwt_alg)
     return key_dict, alg, disco_doc_response, True
 

--- a/src/tests/unit/test_aio_token_validation.py
+++ b/src/tests/unit/test_aio_token_validation.py
@@ -6,6 +6,7 @@ error handling, TTL-based JWKS caching, signature retry on key rotation,
 and enhanced features (leeway, multi-issuer, subject).
 """
 
+import contextlib
 import time
 from unittest.mock import patch
 
@@ -268,6 +269,68 @@ class TestAsyncSignatureRetry:
             audience=None,
             issuer="https://example.com",
         )
+
+        decoded = await validate_token(
+            jwt=token,
+            token_validation_config=config,
+            disco_doc_address="https://example.com/.well-known/openid-configuration",
+        )
+
+        assert decoded["sub"] == "user1"
+        assert jwks_route.call_count == JWKS_FETCH_WITH_RETRY
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_cached_path_refreshes_jwks_when_kid_not_in_cache(self):
+        """Cached JWKS lookup with a kid not in cache forces a refresh.
+
+        OIDC OPs rotate signing keys; when a token arrives with a kid that is
+        not yet in the cached JWKS, the cache is stale. The library must
+        refresh JWKS without waiting for a signature failure on a key it
+        does not have.
+        """
+        old_key_dict, _ = generate_rsa_keypair()
+        old_key_dict["kid"] = "old-kid"
+
+        new_key_dict, new_pem = generate_rsa_keypair()
+        new_key_dict["kid"] = "new-kid"
+
+        token = sign_jwt(
+            new_pem,
+            {"sub": "user1", "iss": "https://example.com"},
+            headers={"kid": "new-kid"},
+        )
+
+        respx.get("https://example.com/.well-known/openid-configuration").mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+        jwks_route = respx.get("https://example.com/jwks").mock(
+            side_effect=[
+                httpx.Response(200, json={"keys": [old_key_dict]}),
+                httpx.Response(200, json={"keys": [new_key_dict]}),
+            ]
+        )
+
+        config = TokenValidationConfig(
+            perform_disco=True,
+            audience=None,
+            issuer="https://example.com",
+        )
+
+        # Prime the cache with the old kid.
+        old_pem_token = sign_jwt(
+            generate_rsa_keypair()[1],
+            {"sub": "warmup"},
+            headers={"kid": "old-kid"},
+        )
+        with contextlib.suppress(
+            SignatureVerificationException, TokenValidationException
+        ):
+            await validate_token(
+                jwt=old_pem_token,
+                token_validation_config=config,
+                disco_doc_address="https://example.com/.well-known/openid-configuration",
+            )
 
         decoded = await validate_token(
             jwt=token,

--- a/src/tests/unit/test_aio_token_validation.py
+++ b/src/tests/unit/test_aio_token_validation.py
@@ -6,7 +6,6 @@ error handling, TTL-based JWKS caching, signature retry on key rotation,
 and enhanced features (leeway, multi-issuer, subject).
 """
 
-import contextlib
 import time
 from unittest.mock import patch
 
@@ -16,6 +15,7 @@ import respx
 
 from py_identity_model.aio.managed_client import AsyncHTTPClient
 from py_identity_model.aio.token_validation import (
+    _get_cached_jwks,
     clear_discovery_cache,
     clear_jwks_cache,
     validate_token,
@@ -242,7 +242,7 @@ class TestAsyncSignatureRetry:
     @respx.mock
     async def test_signature_retry_on_key_rotation(self):
         """When signature fails with cached key, refresh JWKS and retry with new key."""
-        old_key_dict, _old_pem = generate_rsa_keypair()
+        old_key_dict = generate_rsa_keypair()[0]
         old_key_dict["kid"] = "rotated-key"
 
         new_key_dict, new_pem = generate_rsa_keypair()
@@ -289,7 +289,7 @@ class TestAsyncSignatureRetry:
         refresh JWKS without waiting for a signature failure on a key it
         does not have.
         """
-        old_key_dict, _ = generate_rsa_keypair()
+        old_key_dict = generate_rsa_keypair()[0]
         old_key_dict["kid"] = "old-kid"
 
         new_key_dict, new_pem = generate_rsa_keypair()
@@ -317,20 +317,9 @@ class TestAsyncSignatureRetry:
             issuer="https://example.com",
         )
 
-        # Prime the cache with the old kid.
-        old_pem_token = sign_jwt(
-            generate_rsa_keypair()[1],
-            {"sub": "warmup"},
-            headers={"kid": "old-kid"},
-        )
-        with contextlib.suppress(
-            SignatureVerificationException, TokenValidationException
-        ):
-            await validate_token(
-                jwt=old_pem_token,
-                token_validation_config=config,
-                disco_doc_address="https://example.com/.well-known/openid-configuration",
-            )
+        # Prime the JWKS cache directly with the old kid (no validate_token, so
+        # the legacy retry path can't accidentally satisfy the assertion below).
+        await _get_cached_jwks("https://example.com/jwks")
 
         decoded = await validate_token(
             jwt=token,
@@ -339,15 +328,66 @@ class TestAsyncSignatureRetry:
         )
 
         assert decoded["sub"] == "user1"
+        # Now the second fetch can ONLY have come from the new kid-miss refresh
+        # path inside _discover_and_resolve_key (legacy retry never gets a chance
+        # because validate_token only ran once, and the kid was missing pre-decode).
         assert jwks_route.call_count == JWKS_FETCH_WITH_RETRY
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_no_refresh_when_kid_present_in_cache(self):
+        """Negative regression: when kid IS in cached JWKS, no refresh is issued.
+
+        Pins the predicate sense in the kid-miss check. A future change that
+        flipped `not any(...)` to `any(...)` would silently regress to
+        refreshing JWKS on every request.
+        """
+        key_dict, pem = generate_rsa_keypair()
+        key_dict["kid"] = "present-kid"
+
+        respx.get("https://example.com/.well-known/openid-configuration").mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+        jwks_route = respx.get("https://example.com/jwks").mock(
+            return_value=httpx.Response(200, json={"keys": [key_dict]})
+        )
+
+        token = sign_jwt(
+            pem,
+            {"sub": "user1", "iss": "https://example.com"},
+            headers={"kid": "present-kid"},
+        )
+        config = TokenValidationConfig(
+            perform_disco=True, audience=None, issuer="https://example.com"
+        )
+
+        # First call primes the cache (1 fetch).
+        await validate_token(
+            jwt=token,
+            token_validation_config=config,
+            disco_doc_address="https://example.com/.well-known/openid-configuration",
+        )
+        assert jwks_route.call_count == 1
+
+        for _ in range(10):
+            await validate_token(
+                jwt=token,
+                token_validation_config=config,
+                disco_doc_address="https://example.com/.well-known/openid-configuration",
+            )
+
+        assert jwks_route.call_count == 1, (
+            f"Predicate regression: {jwks_route.call_count} fetches for 11 "
+            f"validations with cached kid (expected 1)"
+        )
 
     @pytest.mark.asyncio
     @respx.mock
     async def test_signature_failure_still_raises_after_retry(self):
         """When signature fails with both old and new keys, exception is raised."""
-        wrong_key1, _ = generate_rsa_keypair()
+        wrong_key1 = generate_rsa_keypair()[0]
         wrong_key1["kid"] = "wrong-key"
-        wrong_key2, _ = generate_rsa_keypair()
+        wrong_key2 = generate_rsa_keypair()[0]
         wrong_key2["kid"] = "wrong-key"
 
         _, signing_pem = generate_rsa_keypair()
@@ -384,7 +424,7 @@ class TestAsyncSignatureRetry:
     @respx.mock
     async def test_di_path_retries_on_signature_failure(self):
         """DI (injected client) path retries JWKS fetch for key rotation support."""
-        wrong_key, _ = generate_rsa_keypair()
+        wrong_key = generate_rsa_keypair()[0]
         wrong_key["kid"] = "wrong-key"
 
         _, signing_pem = generate_rsa_keypair()

--- a/src/tests/unit/test_cache_stampede.py
+++ b/src/tests/unit/test_cache_stampede.py
@@ -6,6 +6,7 @@ fetch rather than N parallel fetches (thundering herd).
 """
 
 import asyncio
+from collections.abc import Callable
 import threading
 import time
 
@@ -29,7 +30,11 @@ from py_identity_model.aio.token_validation import (
 from py_identity_model.aio.token_validation import (
     clear_jwks_cache as async_clear_jwks_cache,
 )
+from py_identity_model.aio.token_validation import (
+    validate_token as async_validate_token,
+)
 from py_identity_model.core.jwks_cache import DiscoCacheEntry, JwksCacheEntry
+from py_identity_model.core.models import TokenValidationConfig
 from py_identity_model.sync import token_validation as sync_tv
 from py_identity_model.sync.token_validation import (
     _get_cached_jwks,
@@ -37,11 +42,13 @@ from py_identity_model.sync.token_validation import (
     _refresh_jwks,
     clear_discovery_cache,
     clear_jwks_cache,
+    validate_token,
 )
 
 from .token_validation_helpers import (
     DISCO_RESPONSE_WITH_JWKS,
     generate_rsa_keypair,
+    sign_jwt,
 )
 
 
@@ -410,3 +417,229 @@ class TestAsyncRefreshJwksFreshnessGuard:
         result = await async_refresh_jwks(JWKS_URL)
         assert result is not None
         assert jwks_route.call_count == FETCH_AFTER_EXPIRY
+
+
+# ============================================================================
+# Kid-miss stampede (PR #390): pre-decode refresh path must single-flight
+# ============================================================================
+#
+# The fix in #390 adds a pre-decode JWKS refresh when the JWT's `kid` is not
+# in the cached JWKS. Without protection, N concurrent requests with an
+# unknown kid would each issue their own JWKS fetch (thundering herd against
+# the OP's JWKS endpoint, and an unauthenticated amplification vector since
+# the JWT header is not yet trust-validated).
+#
+# Protection comes from two layers already in the code:
+#   1. `_get_cached_jwks` and `_refresh_jwks` share `_jwks_cache_lock`. While
+#      task A holds the lock during its fetch, tasks B..N block at
+#      `_get_cached_jwks` and read the freshly-refreshed cache when A releases.
+#      Most concurrent tasks therefore never even enter `_refresh_jwks`.
+#   2. The single-flight guard inside `_refresh_jwks`
+#      (`cached_at >= request_time`) catches the residual race where multiple
+#      tasks captured `request_time` before the first fetch completed.
+#
+# These tests pin both layers in place so a future change cannot quietly
+# regress the kid-miss path into an N-fetch fan-out.
+
+# 1 prime fetch + 1 single-flight refresh on rotation = 2 fetches, regardless
+# of how many concurrent validators arrive with the unknown kid.
+KID_MISS_FETCH_BUDGET = 2
+
+
+def _make_rotating_jwks_handler(
+    old_keys_response: dict, new_keys_response: dict
+) -> tuple[list[int], Callable[[httpx.Request], httpx.Response]]:
+    """Return (call_log, handler). First call returns old_keys; rest return new_keys."""
+    call_log: list[int] = []
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        call_log.append(1)
+        if len(call_log) == 1:
+            return httpx.Response(200, json=old_keys_response)
+        return httpx.Response(200, json=new_keys_response)
+
+    return call_log, handler
+
+
+class TestAsyncKidMissStampede:
+    """Concurrent kid-miss validations must produce a single refresh fetch."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_n_concurrent_unknown_kid_triggers_single_refresh(self):
+        """N concurrent validate_token calls with the same unknown kid → 2 fetches total."""
+        old_key_dict, _old_pem = generate_rsa_keypair()
+        old_key_dict["kid"] = "old-kid"
+        new_key_dict, new_pem = generate_rsa_keypair()
+        new_key_dict["kid"] = "new-kid"
+
+        respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+        _, jwks_handler = _make_rotating_jwks_handler(
+            old_keys_response={"keys": [old_key_dict]},
+            new_keys_response={"keys": [new_key_dict]},
+        )
+        jwks_route = respx.get(JWKS_URL).mock(side_effect=jwks_handler)
+
+        # Prime cache with old kid via direct cache access (no validation needed).
+        await async_get_cached_jwks(JWKS_URL)
+        assert jwks_route.call_count == 1
+
+        token = sign_jwt(
+            new_pem,
+            {"sub": "user1", "iss": "https://example.com"},
+            headers={"kid": "new-kid"},
+        )
+        config = TokenValidationConfig(
+            perform_disco=True, audience=None, issuer="https://example.com"
+        )
+
+        N = 25
+        results = await asyncio.gather(
+            *[
+                async_validate_token(
+                    jwt=token,
+                    token_validation_config=config,
+                    disco_doc_address=DISCO_URL,
+                )
+                for _ in range(N)
+            ]
+        )
+
+        assert len(results) == N
+        for decoded in results:
+            assert decoded["sub"] == "user1"
+        # Stampede protection: only 1 prime + 1 refresh, NOT 1 + N.
+        assert jwks_route.call_count == KID_MISS_FETCH_BUDGET, (
+            f"Stampede: {jwks_route.call_count} fetches for {N} concurrent kid-miss "
+            f"validations (expected {KID_MISS_FETCH_BUDGET})"
+        )
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_n_concurrent_distinct_unknown_kids_triggers_single_refresh(self):
+        """N concurrent calls with N distinct unknown kids still single-flight by jwks_uri.
+
+        The single-flight key is jwks_uri, not kid. Even if every concurrent
+        request has a different unknown kid, only one refresh fetch should
+        occur. The first refresh populates the cache; subsequent tasks read
+        the fresh cache (and may then raise per-key errors if their kid still
+        isn't present, which is acceptable — what we're guarding here is the
+        outbound fetch count).
+        """
+        old_key_dict, _ = generate_rsa_keypair()
+        old_key_dict["kid"] = "old-kid"
+
+        # New JWKS contains every kid the rotated batch might use.
+        new_keys = []
+        new_pems: dict[str, bytes] = {}
+        N = 10
+        for i in range(N):
+            kd, pem = generate_rsa_keypair()
+            kd["kid"] = f"new-kid-{i}"
+            new_keys.append(kd)
+            new_pems[f"new-kid-{i}"] = pem
+
+        respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+        _, jwks_handler = _make_rotating_jwks_handler(
+            old_keys_response={"keys": [old_key_dict]},
+            new_keys_response={"keys": new_keys},
+        )
+        jwks_route = respx.get(JWKS_URL).mock(side_effect=jwks_handler)
+
+        await async_get_cached_jwks(JWKS_URL)
+        assert jwks_route.call_count == 1
+
+        config = TokenValidationConfig(
+            perform_disco=True, audience=None, issuer="https://example.com"
+        )
+
+        async def _validate(i: int) -> dict:
+            kid = f"new-kid-{i}"
+            tok = sign_jwt(
+                new_pems[kid],
+                {"sub": f"user{i}", "iss": "https://example.com"},
+                headers={"kid": kid},
+            )
+            return await async_validate_token(
+                jwt=tok,
+                token_validation_config=config,
+                disco_doc_address=DISCO_URL,
+            )
+
+        results = await asyncio.gather(*[_validate(i) for i in range(N)])
+
+        assert {r["sub"] for r in results} == {f"user{i}" for i in range(N)}
+        assert jwks_route.call_count == KID_MISS_FETCH_BUDGET, (
+            f"Stampede: {jwks_route.call_count} fetches for {N} concurrent distinct "
+            f"unknown kids (expected {KID_MISS_FETCH_BUDGET})"
+        )
+
+
+class TestSyncKidMissStampede:
+    """Concurrent kid-miss validations from threads must produce a single refresh fetch."""
+
+    @respx.mock
+    def test_n_concurrent_unknown_kid_triggers_single_refresh_sync(self):
+        """N threads concurrently validating tokens with the same unknown kid → 2 fetches."""
+        old_key_dict, _ = generate_rsa_keypair()
+        old_key_dict["kid"] = "old-kid"
+        new_key_dict, new_pem = generate_rsa_keypair()
+        new_key_dict["kid"] = "new-kid"
+
+        respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+        _, jwks_handler = _make_rotating_jwks_handler(
+            old_keys_response={"keys": [old_key_dict]},
+            new_keys_response={"keys": [new_key_dict]},
+        )
+        jwks_route = respx.get(JWKS_URL).mock(side_effect=jwks_handler)
+
+        # Prime cache.
+        _get_cached_jwks(JWKS_URL)
+        assert jwks_route.call_count == 1
+
+        token = sign_jwt(
+            new_pem,
+            {"sub": "user1", "iss": "https://example.com"},
+            headers={"kid": "new-kid"},
+        )
+        config = TokenValidationConfig(
+            perform_disco=True, audience=None, issuer="https://example.com"
+        )
+
+        N = 25
+        barrier = threading.Barrier(N, timeout=10)
+        results: list[dict | None] = [None] * N
+        errors: list[Exception | None] = [None] * N
+
+        def worker(idx: int) -> None:
+            try:
+                barrier.wait()
+                results[idx] = validate_token(
+                    jwt=token,
+                    token_validation_config=config,
+                    disco_doc_address=DISCO_URL,
+                )
+            except Exception as exc:
+                errors[idx] = exc
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(N)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=20)
+
+        for err in errors:
+            assert err is None, f"Worker raised: {err}"
+        for r in results:
+            assert r is not None
+            assert r["sub"] == "user1"
+        assert jwks_route.call_count == KID_MISS_FETCH_BUDGET, (
+            f"Stampede: {jwks_route.call_count} fetches for {N} concurrent kid-miss "
+            f"validations (expected {KID_MISS_FETCH_BUDGET})"
+        )

--- a/src/tests/unit/test_cache_stampede.py
+++ b/src/tests/unit/test_cache_stampede.py
@@ -7,6 +7,7 @@ fetch rather than N parallel fetches (thundering herd).
 
 import asyncio
 from collections.abc import Callable
+import logging
 import threading
 import time
 
@@ -35,6 +36,7 @@ from py_identity_model.aio.token_validation import (
 )
 from py_identity_model.core.jwks_cache import DiscoCacheEntry, JwksCacheEntry
 from py_identity_model.core.models import TokenValidationConfig
+from py_identity_model.exceptions import TokenValidationException
 from py_identity_model.sync import token_validation as sync_tv
 from py_identity_model.sync.token_validation import (
     _get_cached_jwks,
@@ -115,7 +117,7 @@ class TestSyncJwksCacheStampede:
     @respx.mock
     def test_jwks_cache_stampede_blocked(self):
         """Multiple threads hitting expired JWKS cache produce only 1 HTTP fetch."""
-        key_dict, _ = generate_rsa_keypair()
+        key_dict = generate_rsa_keypair()[0]
         jwks_route = respx.get(JWKS_URL).mock(
             return_value=httpx.Response(200, json={"keys": [key_dict]})
         )
@@ -150,7 +152,7 @@ class TestSyncStampedeAfterExpiry:
     @respx.mock
     def test_jwks_stampede_after_expiry_blocked(self):
         """After TTL expires, concurrent fetches produce only 1 new HTTP request."""
-        key_dict, _ = generate_rsa_keypair()
+        key_dict = generate_rsa_keypair()[0]
         jwks_route = respx.get(JWKS_URL).mock(
             return_value=httpx.Response(200, json={"keys": [key_dict]})
         )
@@ -254,7 +256,7 @@ class TestAsyncJwksCacheStampede:
     @respx.mock
     async def test_jwks_cache_stampede_blocked_async(self):
         """Multiple coroutines hitting expired JWKS cache produce only 1 HTTP fetch."""
-        key_dict, _ = generate_rsa_keypair()
+        key_dict = generate_rsa_keypair()[0]
         jwks_route = respx.get(JWKS_URL).mock(
             return_value=httpx.Response(200, json={"keys": [key_dict]})
         )
@@ -274,7 +276,7 @@ class TestAsyncStampedeAfterExpiry:
     @respx.mock
     async def test_jwks_stampede_after_expiry_blocked_async(self):
         """After TTL expires, concurrent async fetches produce only 1 new request."""
-        key_dict, _ = generate_rsa_keypair()
+        key_dict = generate_rsa_keypair()[0]
         jwks_route = respx.get(JWKS_URL).mock(
             return_value=httpx.Response(200, json={"keys": [key_dict]})
         )
@@ -332,7 +334,7 @@ class TestSyncRefreshJwksFreshnessGuard:
     @respx.mock
     def test_refresh_skips_fetch_when_already_fresh(self):
         """If cache was refreshed while waiting on lock, return cached entry."""
-        key_dict, _ = generate_rsa_keypair()
+        key_dict = generate_rsa_keypair()[0]
         jwks_route = respx.get(JWKS_URL).mock(
             return_value=httpx.Response(200, json={"keys": [key_dict]})
         )
@@ -359,7 +361,7 @@ class TestSyncRefreshJwksFreshnessGuard:
     @respx.mock
     def test_refresh_fetches_when_cache_stale(self):
         """Normal refresh path: fetch when cache is stale."""
-        key_dict, _ = generate_rsa_keypair()
+        key_dict = generate_rsa_keypair()[0]
         jwks_route = respx.get(JWKS_URL).mock(
             return_value=httpx.Response(200, json={"keys": [key_dict]})
         )
@@ -381,7 +383,7 @@ class TestAsyncRefreshJwksFreshnessGuard:
     @respx.mock
     async def test_refresh_skips_fetch_when_already_fresh_async(self):
         """If cache was refreshed while waiting on lock, return cached entry."""
-        key_dict, _ = generate_rsa_keypair()
+        key_dict = generate_rsa_keypair()[0]
         jwks_route = respx.get(JWKS_URL).mock(
             return_value=httpx.Response(200, json={"keys": [key_dict]})
         )
@@ -406,7 +408,7 @@ class TestAsyncRefreshJwksFreshnessGuard:
     @respx.mock
     async def test_refresh_fetches_when_cache_stale_async(self):
         """Normal refresh path: fetch when cache is stale."""
-        key_dict, _ = generate_rsa_keypair()
+        key_dict = generate_rsa_keypair()[0]
         jwks_route = respx.get(JWKS_URL).mock(
             return_value=httpx.Response(200, json={"keys": [key_dict]})
         )
@@ -468,7 +470,7 @@ class TestAsyncKidMissStampede:
     @respx.mock
     async def test_n_concurrent_unknown_kid_triggers_single_refresh(self):
         """N concurrent validate_token calls with the same unknown kid → 2 fetches total."""
-        old_key_dict, _old_pem = generate_rsa_keypair()
+        old_key_dict = generate_rsa_keypair()[0]
         old_key_dict["kid"] = "old-kid"
         new_key_dict, new_pem = generate_rsa_keypair()
         new_key_dict["kid"] = "new-kid"
@@ -528,7 +530,7 @@ class TestAsyncKidMissStampede:
         isn't present, which is acceptable — what we're guarding here is the
         outbound fetch count).
         """
-        old_key_dict, _ = generate_rsa_keypair()
+        old_key_dict = generate_rsa_keypair()[0]
         old_key_dict["kid"] = "old-kid"
 
         # New JWKS contains every kid the rotated batch might use.
@@ -585,7 +587,7 @@ class TestSyncKidMissStampede:
     @respx.mock
     def test_n_concurrent_unknown_kid_triggers_single_refresh_sync(self):
         """N threads concurrently validating tokens with the same unknown kid → 2 fetches."""
-        old_key_dict, _ = generate_rsa_keypair()
+        old_key_dict = generate_rsa_keypair()[0]
         old_key_dict["kid"] = "old-kid"
         new_key_dict, new_pem = generate_rsa_keypair()
         new_key_dict["kid"] = "new-kid"
@@ -642,4 +644,56 @@ class TestSyncKidMissStampede:
         assert jwks_route.call_count == KID_MISS_FETCH_BUDGET, (
             f"Stampede: {jwks_route.call_count} fetches for {N} concurrent kid-miss "
             f"validations (expected {KID_MISS_FETCH_BUDGET})"
+        )
+
+
+# ============================================================================
+# Diagnostic on still-missing kid after refresh (PR #390 hardening)
+# ============================================================================
+
+
+class TestSyncStillMissingDiagnostic:
+    """A successful refresh that doesn't help should leave a diagnostic log."""
+
+    @respx.mock
+    def test_warning_logged_when_kid_still_absent_after_refresh(self, caplog):
+        """If refresh succeeds but the kid is still not in JWKS, log a warning."""
+        old_key_dict = generate_rsa_keypair()[0]
+        old_key_dict["kid"] = "old-kid"
+        # Refreshed JWKS has a different kid — still doesn't help the request.
+        other_key_dict = generate_rsa_keypair()[0]
+        other_key_dict["kid"] = "some-other-kid"
+
+        respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+        _, jwks_handler = _make_rotating_jwks_handler(
+            old_keys_response={"keys": [old_key_dict]},
+            new_keys_response={"keys": [other_key_dict]},
+        )
+        respx.get(JWKS_URL).mock(side_effect=jwks_handler)
+
+        _get_cached_jwks(JWKS_URL)
+
+        new_pem = generate_rsa_keypair()[1]
+        token = sign_jwt(
+            new_pem,
+            {"sub": "user1", "iss": "https://example.com"},
+            headers={"kid": "still-not-here"},
+        )
+        config = TokenValidationConfig(
+            perform_disco=True, audience=None, issuer="https://example.com"
+        )
+
+        with (
+            caplog.at_level(logging.WARNING),
+            pytest.raises(TokenValidationException),
+        ):
+            validate_token(
+                jwt=token,
+                token_validation_config=config,
+                disco_doc_address=DISCO_URL,
+            )
+        assert any("still absent" in rec.message.lower() for rec in caplog.records), (
+            f"Expected 'still absent' warning, got: {[r.message for r in caplog.records]}"
         )

--- a/src/tests/unit/test_sync_token_validation.py
+++ b/src/tests/unit/test_sync_token_validation.py
@@ -5,6 +5,7 @@ These tests verify sync-specific token validation logic including
 error handling, TTL-based JWKS caching, and signature retry on key rotation.
 """
 
+import contextlib
 import time
 from unittest.mock import patch
 
@@ -293,6 +294,72 @@ class TestSyncSignatureRetry:
 
         assert decoded["sub"] == "user1"
         assert jwks_route.call_count == JWKS_FETCH_WITH_RETRY  # initial fetch + refresh
+
+    @respx.mock
+    def test_cached_path_refreshes_jwks_when_kid_not_in_cache(self):
+        """Cached JWKS lookup with a kid not in cache forces a refresh.
+
+        OIDC OPs rotate signing keys; when a token arrives with a kid that is
+        not yet in the cached JWKS, the cache is stale. The library must
+        refresh JWKS without waiting for a signature failure on a key it
+        does not have.
+        """
+        old_key_dict, _ = generate_rsa_keypair()
+        old_key_dict["kid"] = "old-kid"
+
+        new_key_dict, new_pem = generate_rsa_keypair()
+        new_key_dict["kid"] = "new-kid"
+
+        token = sign_jwt(
+            new_pem,
+            {"sub": "user1", "iss": "https://example.com"},
+            headers={"kid": "new-kid"},
+        )
+
+        respx.get("https://example.com/.well-known/openid-configuration").mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+
+        # First fetch returns only the old kid; second fetch returns only the new kid.
+        # If the library waits for signature failure to refresh, the second fetch
+        # will not happen because the lookup raises before decode.
+        jwks_route = respx.get("https://example.com/jwks").mock(
+            side_effect=[
+                httpx.Response(200, json={"keys": [old_key_dict]}),
+                httpx.Response(200, json={"keys": [new_key_dict]}),
+            ]
+        )
+
+        config = TokenValidationConfig(
+            perform_disco=True,
+            audience=None,
+            issuer="https://example.com",
+        )
+
+        # Prime the cache by validating a token with the old kid.
+        old_pem_token = sign_jwt(
+            generate_rsa_keypair()[1],  # discard, we just need to populate cache
+            {"sub": "warmup"},
+            headers={"kid": "old-kid"},
+        )
+        # Trigger a cache populate without caring about the validation outcome.
+        with contextlib.suppress(
+            SignatureVerificationException, TokenValidationException
+        ):
+            validate_token(
+                jwt=old_pem_token,
+                token_validation_config=config,
+                disco_doc_address="https://example.com/.well-known/openid-configuration",
+            )
+
+        decoded = validate_token(
+            jwt=token,
+            token_validation_config=config,
+            disco_doc_address="https://example.com/.well-known/openid-configuration",
+        )
+
+        assert decoded["sub"] == "user1"
+        assert jwks_route.call_count == JWKS_FETCH_WITH_RETRY
 
     @respx.mock
     def test_signature_failure_still_raises_after_retry(self):

--- a/src/tests/unit/test_sync_token_validation.py
+++ b/src/tests/unit/test_sync_token_validation.py
@@ -5,7 +5,6 @@ These tests verify sync-specific token validation logic including
 error handling, TTL-based JWKS caching, and signature retry on key rotation.
 """
 
-import contextlib
 import time
 from unittest.mock import patch
 
@@ -21,6 +20,7 @@ from py_identity_model.exceptions import (
 )
 from py_identity_model.sync.managed_client import HTTPClient
 from py_identity_model.sync.token_validation import (
+    _get_cached_jwks,
     _get_disco_response,
     clear_discovery_cache,
     clear_jwks_cache,
@@ -254,7 +254,7 @@ class TestSyncSignatureRetry:
     def test_signature_retry_on_key_rotation(self):
         """When signature fails with cached key, refresh JWKS and retry with new key."""
         # Key 1 (old) — will be cached initially
-        old_key_dict, _old_pem = generate_rsa_keypair()
+        old_key_dict = generate_rsa_keypair()[0]
         old_key_dict["kid"] = "rotated-key"
 
         # Key 2 (new) — token is signed with this
@@ -304,7 +304,7 @@ class TestSyncSignatureRetry:
         refresh JWKS without waiting for a signature failure on a key it
         does not have.
         """
-        old_key_dict, _ = generate_rsa_keypair()
+        old_key_dict = generate_rsa_keypair()[0]
         old_key_dict["kid"] = "old-kid"
 
         new_key_dict, new_pem = generate_rsa_keypair()
@@ -336,21 +336,9 @@ class TestSyncSignatureRetry:
             issuer="https://example.com",
         )
 
-        # Prime the cache by validating a token with the old kid.
-        old_pem_token = sign_jwt(
-            generate_rsa_keypair()[1],  # discard, we just need to populate cache
-            {"sub": "warmup"},
-            headers={"kid": "old-kid"},
-        )
-        # Trigger a cache populate without caring about the validation outcome.
-        with contextlib.suppress(
-            SignatureVerificationException, TokenValidationException
-        ):
-            validate_token(
-                jwt=old_pem_token,
-                token_validation_config=config,
-                disco_doc_address="https://example.com/.well-known/openid-configuration",
-            )
+        # Prime the JWKS cache directly with the old kid (no validate_token, so
+        # the legacy retry path can't accidentally satisfy the assertion below).
+        _get_cached_jwks("https://example.com/jwks")
 
         decoded = validate_token(
             jwt=token,
@@ -359,15 +347,65 @@ class TestSyncSignatureRetry:
         )
 
         assert decoded["sub"] == "user1"
+        # The second fetch can ONLY have come from the new kid-miss refresh path
+        # inside _discover_and_resolve_key (legacy retry never gets a chance —
+        # validate_token only ran once and the kid was missing pre-decode).
         assert jwks_route.call_count == JWKS_FETCH_WITH_RETRY
+
+    @respx.mock
+    def test_no_refresh_when_kid_present_in_cache(self):
+        """Negative regression: when kid IS in cached JWKS, no refresh is issued.
+
+        Pins the predicate sense in the kid-miss check. A future change that
+        flipped `not any(...)` to `any(...)` would silently regress to
+        refreshing JWKS on every request.
+        """
+        key_dict, pem = generate_rsa_keypair()
+        key_dict["kid"] = "present-kid"
+
+        respx.get("https://example.com/.well-known/openid-configuration").mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+        jwks_route = respx.get("https://example.com/jwks").mock(
+            return_value=httpx.Response(200, json={"keys": [key_dict]})
+        )
+
+        token = sign_jwt(
+            pem,
+            {"sub": "user1", "iss": "https://example.com"},
+            headers={"kid": "present-kid"},
+        )
+        config = TokenValidationConfig(
+            perform_disco=True, audience=None, issuer="https://example.com"
+        )
+
+        # First call primes the cache (1 fetch).
+        validate_token(
+            jwt=token,
+            token_validation_config=config,
+            disco_doc_address="https://example.com/.well-known/openid-configuration",
+        )
+        assert jwks_route.call_count == 1
+
+        for _ in range(10):
+            validate_token(
+                jwt=token,
+                token_validation_config=config,
+                disco_doc_address="https://example.com/.well-known/openid-configuration",
+            )
+
+        assert jwks_route.call_count == 1, (
+            f"Predicate regression: {jwks_route.call_count} fetches for 11 "
+            f"validations with cached kid (expected 1)"
+        )
 
     @respx.mock
     def test_signature_failure_still_raises_after_retry(self):
         """When signature fails with both old and new keys, exception is raised."""
         # Both keys are different from the signing key
-        wrong_key1, _ = generate_rsa_keypair()
+        wrong_key1 = generate_rsa_keypair()[0]
         wrong_key1["kid"] = "wrong-key"
-        wrong_key2, _ = generate_rsa_keypair()
+        wrong_key2 = generate_rsa_keypair()[0]
         wrong_key2["kid"] = "wrong-key"
 
         # Sign with a completely different key
@@ -404,7 +442,7 @@ class TestSyncSignatureRetry:
     @respx.mock
     def test_di_path_retries_on_signature_failure(self):
         """DI (injected client) path retries JWKS fetch for key rotation support."""
-        wrong_key, _ = generate_rsa_keypair()
+        wrong_key = generate_rsa_keypair()[0]
         wrong_key["kid"] = "wrong-key"
 
         _, signing_pem = generate_rsa_keypair()


### PR DESCRIPTION
## Summary

Consolidates #390 (kid-miss rotation fix) into a single PR. Three commits:

- **72e6808** `fix(token-validation): refresh JWKS on cached kid miss` — original rotation fix from #390. On the cached JWKS path, when the incoming JWT's \`kid\` is not in the cached JWKS, force a refresh via \`_refresh_jwks\` instead of waiting for a \`SignatureVerificationException\` that never fires (\`find_key_by_kid\` raises before \`decode_with_config\` runs). Mirrored in sync + async \`_discover_and_resolve_key\`. DI (injected \`http_client\`) path unchanged. Required for the OIDF Config RP \`oidcc-client-test-signing-key-rotation\` conformance test.

- **6ceaa12** `test(token-validation): pin kid-miss stampede protection` — three tests in \`test_cache_stampede.py\` that prove the new pre-decode refresh path cannot fan out into N concurrent JWKS fetches under contention. 25 concurrent async tasks with the same unknown kid → exactly 2 fetches (1 prime + 1 refresh). Same with 10 distinct unknown kids (single-flight is keyed by \`jwks_uri\`, not kid). Same with 25 sync threads. Pins the existing protection (\`_jwks_cache_lock\` serialization + the \`cached_at >= request_time\` guard inside \`_refresh_jwks\`).

- **5a5a189** `fix(token-validation): harden kid-miss refresh path...` — three substantive improvements from the adversarial review:
  1. **Diagnostic warning** when refresh succeeds but the kid is still absent. Distinguishes rotation issues from configuration issues in production logs.
  2. **Fixed test priming** in \`test_cached_path_refreshes_jwks_when_kid_not_in_cache\` (sync + async). The prior \`contextlib.suppress\` warmup actually triggered the legacy retry path during priming, so the assertion passed without exercising the new code. Direct \`_get_cached_jwks\` priming makes the assertion meaningful.
  3. **Negative regression test** \`test_no_refresh_when_kid_present_in_cache\` (sync + async) — pins the \`not any(...)\` predicate sense; a future flip would be caught immediately.
  4. Replaced \`var, _ = generate_rsa_keypair()\` with \`var = generate_rsa_keypair()[0]\` across affected test files so unused PEMs aren't bound to local frame variables that pytest's \`--showlocals\` would dump on failure.

## What was considered and rejected

A \`KID_MISS_REFRESH_COOLDOWN\` to rate-limit attacker amplification, and a \`try/except\` around \`_refresh_jwks\` to fall through to stale cache on network failures. Both were overengineered:
- The amplification factor is 1:1, not 1:N — every request triggers one fetch with or without cooldown. Real DoS protection belongs at the edge / WAF / OP, not in a token-validation library masquerading as a rate limiter.
- The error fallback masked actual network errors with \"no matching kid found\", which is less diagnostic than the original behavior.
- The cooldown could only be tested by monkeypatching the constant — which proves nothing about production behavior at the production cooldown.

## Known follow-ups (not in this PR)

- HTTP cache header handling has real gaps: failed responses get cached for the default 24h, \`Cache-Control: no-store\` / \`no-cache\` are ignored, no \`Age\` subtraction, no \`ETag\`/conditional revalidation. Pre-existing — separate PR.

## Test plan

- [x] \`make lint\` — ruff + ruff format + pyrefly + pytest 80% coverage all pass
- [x] \`make test-unit\` — 993 tests pass locally
- [ ] Local conformance suite — confirm Config RP rotation test still PASSes

🤖 Generated with [Claude Code](https://claude.com/claude-code)