### PR TITLE
fix(jwks-cache): respect HTTP cache headers (no-store, no-cache, failed-response handling)

### DIFF
--- a/src/py_identity_model/aio/token_validation.py
+++ b/src/py_identity_model/aio/token_validation.py
@@ -13,6 +13,7 @@ from ..core.jwks_cache import (
     DiscoCacheEntry,
     JwksCacheEntry,
     is_cache_expired,
+    is_uncacheable,
     resolve_disco_ttl,
     resolve_ttl,
 )
@@ -76,10 +77,11 @@ async def _get_disco_response(
         response = await get_discovery_document(
             DiscoveryDocumentRequest(address=disco_doc_address, policy=policy),
         )
-        ttl = resolve_disco_ttl(response.cache_control)
-        _disco_cache[cache_key] = DiscoCacheEntry(
-            response=response, cached_at=time.time(), ttl=ttl
-        )
+        if response.is_successful and not is_uncacheable(response.cache_control):
+            ttl = resolve_disco_ttl(response.cache_control)
+            _disco_cache[cache_key] = DiscoCacheEntry(
+                response=response, cached_at=time.time(), ttl=ttl
+            )
         return response
 
 
@@ -105,10 +107,11 @@ async def _get_cached_jwks(jwks_uri: str) -> JwksResponse:
 
         # Fetch under lock to prevent cache stampede (single-flight refresh)
         response = await get_jwks(JwksRequest(address=jwks_uri))
-        ttl = resolve_ttl(response.cache_control)
-        _jwks_cache[jwks_uri] = JwksCacheEntry(
-            response=response, cached_at=time.time(), ttl=ttl
-        )
+        if response.is_successful and not is_uncacheable(response.cache_control):
+            ttl = resolve_ttl(response.cache_control)
+            _jwks_cache[jwks_uri] = JwksCacheEntry(
+                response=response, cached_at=time.time(), ttl=ttl
+            )
         return response
 
 
@@ -124,10 +127,11 @@ async def _refresh_jwks(jwks_uri: str) -> JwksResponse:
 
         logger.info("Forcing JWKS refresh for %s (possible key rotation)", jwks_uri)
         response = await get_jwks(JwksRequest(address=jwks_uri))
-        ttl = resolve_ttl(response.cache_control)
-        _jwks_cache[jwks_uri] = JwksCacheEntry(
-            response=response, cached_at=time.time(), ttl=ttl
-        )
+        if response.is_successful and not is_uncacheable(response.cache_control):
+            ttl = resolve_ttl(response.cache_control)
+            _jwks_cache[jwks_uri] = JwksCacheEntry(
+                response=response, cached_at=time.time(), ttl=ttl
+            )
         return response
 
 

--- a/src/py_identity_model/core/jwks_cache.py
+++ b/src/py_identity_model/core/jwks_cache.py
@@ -40,6 +40,8 @@ MAX_CACHE_TTL_SECONDS: float = 86400.0
 _env_ttl: float | None = None
 _disco_env_ttl: float | None = None
 _MAX_AGE_RE = re.compile(r"max-age=(\d+)", re.IGNORECASE)
+_NO_STORE_RE = re.compile(r"\bno-store\b", re.IGNORECASE)
+_NO_CACHE_RE = re.compile(r"\bno-cache\b", re.IGNORECASE)
 
 
 def _get_env_ttl() -> float:
@@ -60,6 +62,20 @@ def _get_disco_env_ttl() -> float:
             os.getenv("DISCO_CACHE_TTL", str(DEFAULT_DISCO_CACHE_TTL_SECONDS))
         )
     return _disco_env_ttl
+
+
+def is_uncacheable(cache_control: str | None) -> bool:
+    """Return True when Cache-Control forbids caching the response.
+
+    Honors RFC 7234 §5.2.2.5 (``no-store``) and §5.2.2.4 (``no-cache``).
+    ``no-cache`` requires revalidation before use; the simplest correct
+    behavior is to skip caching so the next call re-fetches.
+    """
+    if not cache_control:
+        return False
+    return bool(
+        _NO_STORE_RE.search(cache_control) or _NO_CACHE_RE.search(cache_control)
+    )
 
 
 def parse_max_age(cache_control: str | None) -> float | None:
@@ -150,6 +166,7 @@ __all__ = [
     "DiscoCacheEntry",
     "JwksCacheEntry",
     "is_cache_expired",
+    "is_uncacheable",
     "parse_max_age",
     "resolve_disco_ttl",
     "resolve_ttl",

--- a/src/py_identity_model/sync/token_validation.py
+++ b/src/py_identity_model/sync/token_validation.py
@@ -16,6 +16,7 @@ from ..core.jwks_cache import (
     DiscoCacheEntry,
     JwksCacheEntry,
     is_cache_expired,
+    is_uncacheable,
     resolve_disco_ttl,
     resolve_ttl,
 )
@@ -75,10 +76,11 @@ def _get_disco_response(
         response = get_discovery_document(
             DiscoveryDocumentRequest(address=disco_doc_address, policy=policy)
         )
-        ttl = resolve_disco_ttl(response.cache_control)
-        _disco_cache[cache_key] = DiscoCacheEntry(
-            response=response, cached_at=time.time(), ttl=ttl
-        )
+        if response.is_successful and not is_uncacheable(response.cache_control):
+            ttl = resolve_disco_ttl(response.cache_control)
+            _disco_cache[cache_key] = DiscoCacheEntry(
+                response=response, cached_at=time.time(), ttl=ttl
+            )
         return response
 
 
@@ -104,10 +106,11 @@ def _get_cached_jwks(jwks_uri: str) -> JwksResponse:
 
         # Fetch under lock to prevent cache stampede (single-flight refresh)
         response = get_jwks(JwksRequest(address=jwks_uri))
-        ttl = resolve_ttl(response.cache_control)
-        _jwks_cache[jwks_uri] = JwksCacheEntry(
-            response=response, cached_at=time.time(), ttl=ttl
-        )
+        if response.is_successful and not is_uncacheable(response.cache_control):
+            ttl = resolve_ttl(response.cache_control)
+            _jwks_cache[jwks_uri] = JwksCacheEntry(
+                response=response, cached_at=time.time(), ttl=ttl
+            )
         return response
 
 
@@ -123,10 +126,11 @@ def _refresh_jwks(jwks_uri: str) -> JwksResponse:
 
         logger.info("Forcing JWKS refresh for %s (possible key rotation)", jwks_uri)
         response = get_jwks(JwksRequest(address=jwks_uri))
-        ttl = resolve_ttl(response.cache_control)
-        _jwks_cache[jwks_uri] = JwksCacheEntry(
-            response=response, cached_at=time.time(), ttl=ttl
-        )
+        if response.is_successful and not is_uncacheable(response.cache_control):
+            ttl = resolve_ttl(response.cache_control)
+            _jwks_cache[jwks_uri] = JwksCacheEntry(
+                response=response, cached_at=time.time(), ttl=ttl
+            )
         return response
 
 

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -35,6 +35,7 @@ from py_identity_model import (
     validate_authorize_callback_state,
 )
 from py_identity_model.core.discovery_policy import DiscoveryPolicy
+from py_identity_model.core.jwks_cache import is_uncacheable
 from py_identity_model.core.models import DiscoveryDocumentResponse
 from py_identity_model.core.parsers import (
     extract_kid_from_jwt,
@@ -212,6 +213,22 @@ def jwks_response(test_config):
     if not response.is_successful:
         pytest.fail(f"Failed to fetch JWKS: {response.error}")
     return response
+
+
+@pytest.fixture(scope="session")
+def provider_caches_responses(discovery_document, jwks_response):
+    """Whether the provider's Cache-Control allows the library to cache.
+
+    Per RFC 7234 §5.2.2.4-5, ``no-store`` and ``no-cache`` directives
+    instruct the client to skip caching. Some providers (e.g., Descope on
+    JWKS) set these directives, which means the library will (correctly)
+    re-fetch on every validation. Benchmarks that rely on caching should
+    skip when this fixture is False.
+    """
+    return not (
+        is_uncacheable(discovery_document.cache_control)
+        or is_uncacheable(jwks_response.cache_control)
+    )
 
 
 @pytest.fixture(scope="session")

--- a/src/tests/integration/test_token_validation.py
+++ b/src/tests/integration/test_token_validation.py
@@ -112,8 +112,15 @@ def test_cache_succeeds(test_config, client_credentials_token, require_https):
     # performance (5 validations complete without 5 separate HTTP round-trips).
 
 
-def test_benchmark_validation(test_config, client_credentials_token, require_https):
+def test_benchmark_validation(
+    test_config, client_credentials_token, require_https, provider_caches_responses
+):
     """Test benchmark using cached fixtures."""
+    if not provider_caches_responses:
+        pytest.skip(
+            "Provider sends Cache-Control: no-store/no-cache; "
+            "benchmark assumes caching is in effect"
+        )
     assert client_credentials_token.token is not None
     validation_config = TokenValidationConfig(
         perform_disco=True,

--- a/src/tests/integration/test_token_validation_cache.py
+++ b/src/tests/integration/test_token_validation_cache.py
@@ -189,7 +189,11 @@ class TestBenchmarkWithPreGeneratedTokens:
     """
 
     def test_benchmark_with_multiple_unique_tokens(
-        self, test_config, token_endpoint, validation_config
+        self,
+        test_config,
+        token_endpoint,
+        validation_config,
+        provider_caches_responses,
     ):
         """
         Benchmark validation with multiple unique tokens.
@@ -200,6 +204,11 @@ class TestBenchmarkWithPreGeneratedTokens:
         3. Ensures the benchmark reflects real-world usage where
            different tokens are validated
         """
+        if not provider_caches_responses:
+            pytest.skip(
+                "Provider sends Cache-Control: no-store/no-cache; "
+                "benchmark assumes caching is in effect"
+            )
         num_unique_tokens = 5
         tokens = generate_tokens(test_config, token_endpoint, num_unique_tokens)
 
@@ -241,6 +250,7 @@ class TestBenchmarkWithPreGeneratedTokens:
         test_config,
         client_credentials_token,
         validation_config,
+        provider_caches_responses,
     ):
         """
         Benchmark validation of a single token repeated many times.
@@ -248,6 +258,11 @@ class TestBenchmarkWithPreGeneratedTokens:
         This represents the optimal caching scenario where the same
         token is validated repeatedly (e.g., during its lifetime).
         """
+        if not provider_caches_responses:
+            pytest.skip(
+                "Provider sends Cache-Control: no-store/no-cache; "
+                "benchmark assumes caching is in effect"
+            )
         token = client_credentials_token.token["access_token"]
 
         # Warm up

--- a/src/tests/unit/test_cache_http_headers.py
+++ b/src/tests/unit/test_cache_http_headers.py
@@ -1,0 +1,315 @@
+"""
+Tests for HTTP cache header semantics in JWKS and discovery caches.
+
+Covers three correctness fixes:
+1. Failed JWKS/discovery responses must not be cached (a transient 5xx or
+   network error would otherwise poison the cache for up to 24h).
+2. ``Cache-Control: no-store`` must not be cached at all (RFC 7234 §5.2.2.5).
+3. ``Cache-Control: no-cache`` must always re-fetch (RFC 7234 §5.2.2.4) —
+   simplest correct behavior is to skip caching.
+"""
+
+import httpx
+import pytest
+import respx
+
+from py_identity_model.aio import token_validation as aio_tv
+from py_identity_model.aio.token_validation import (
+    _get_cached_jwks as async_get_cached_jwks,
+)
+from py_identity_model.aio.token_validation import (
+    _get_disco_response as async_get_disco_response,
+)
+from py_identity_model.aio.token_validation import (
+    clear_discovery_cache as async_clear_discovery_cache,
+)
+from py_identity_model.aio.token_validation import (
+    clear_jwks_cache as async_clear_jwks_cache,
+)
+from py_identity_model.sync import token_validation as sync_tv
+from py_identity_model.sync.token_validation import (
+    _get_cached_jwks,
+    _get_disco_response,
+    clear_discovery_cache,
+    clear_jwks_cache,
+)
+
+from .token_validation_helpers import (
+    DISCO_RESPONSE_WITH_JWKS,
+    generate_rsa_keypair,
+)
+
+
+DISCO_URL = "https://example.com/.well-known/openid-configuration"
+JWKS_URL = "https://example.com/jwks"
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    clear_discovery_cache()
+    clear_jwks_cache()
+    async_clear_discovery_cache()
+    async_clear_jwks_cache()
+    yield
+    clear_discovery_cache()
+    clear_jwks_cache()
+    async_clear_discovery_cache()
+    async_clear_jwks_cache()
+
+
+# ============================================================================
+# Failed responses must not be cached
+# ============================================================================
+
+
+class TestSyncFailedResponseNotCached:
+    @respx.mock
+    def test_jwks_failure_then_success_refetches(self):
+        """A transient JWKS failure must not poison the cache.
+
+        Uses 404 to bypass the HTTP client's built-in 5xx retry behavior
+        and isolate the cache-layer policy: ``is_successful=False`` must
+        never be cached, regardless of the upstream status code.
+        """
+        key_dict = generate_rsa_keypair()[0]
+        call_log: list[int] = []
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            call_log.append(1)
+            if len(call_log) == 1:
+                return httpx.Response(404, text="not found")
+            return httpx.Response(200, json={"keys": [key_dict]})
+
+        respx.get(JWKS_URL).mock(side_effect=handler)
+
+        failed = _get_cached_jwks(JWKS_URL)
+        assert failed.is_successful is False
+        assert JWKS_URL not in sync_tv._jwks_cache
+
+        # Next call must re-fetch and succeed.
+        success = _get_cached_jwks(JWKS_URL)
+        assert success.is_successful is True
+        assert JWKS_URL in sync_tv._jwks_cache
+        assert len(call_log) == 2  # noqa: PLR2004
+
+    @respx.mock
+    def test_disco_failure_then_success_refetches(self):
+        """A transient discovery failure must not poison the cache."""
+        call_log: list[int] = []
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            call_log.append(1)
+            if len(call_log) == 1:
+                return httpx.Response(404, text="not found")
+            return httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+
+        respx.get(DISCO_URL).mock(side_effect=handler)
+
+        failed = _get_disco_response(DISCO_URL)
+        assert failed.is_successful is False
+        assert (DISCO_URL, True) not in sync_tv._disco_cache
+
+        success = _get_disco_response(DISCO_URL)
+        assert success.is_successful is True
+        assert (DISCO_URL, True) in sync_tv._disco_cache
+        assert len(call_log) == 2  # noqa: PLR2004
+
+
+class TestAsyncFailedResponseNotCached:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_jwks_failure_then_success_refetches_async(self):
+        key_dict = generate_rsa_keypair()[0]
+        call_log: list[int] = []
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            call_log.append(1)
+            if len(call_log) == 1:
+                return httpx.Response(404, text="not found")
+            return httpx.Response(200, json={"keys": [key_dict]})
+
+        respx.get(JWKS_URL).mock(side_effect=handler)
+
+        failed = await async_get_cached_jwks(JWKS_URL)
+        assert failed.is_successful is False
+        assert JWKS_URL not in aio_tv._jwks_cache
+
+        success = await async_get_cached_jwks(JWKS_URL)
+        assert success.is_successful is True
+        assert JWKS_URL in aio_tv._jwks_cache
+        assert len(call_log) == 2  # noqa: PLR2004
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_disco_failure_then_success_refetches_async(self):
+        call_log: list[int] = []
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            call_log.append(1)
+            if len(call_log) == 1:
+                return httpx.Response(404, text="not found")
+            return httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+
+        respx.get(DISCO_URL).mock(side_effect=handler)
+
+        failed = await async_get_disco_response(DISCO_URL)
+        assert failed.is_successful is False
+        assert (DISCO_URL, True) not in aio_tv._disco_cache
+
+        success = await async_get_disco_response(DISCO_URL)
+        assert success.is_successful is True
+        assert (DISCO_URL, True) in aio_tv._disco_cache
+        assert len(call_log) == 2  # noqa: PLR2004
+
+
+# ============================================================================
+# Cache-Control: no-store — never cached
+# ============================================================================
+
+
+class TestSyncNoStoreNotCached:
+    @respx.mock
+    def test_jwks_no_store_skips_cache(self):
+        """no-store responses are returned but not cached, even with max-age."""
+        key_dict = generate_rsa_keypair()[0]
+        respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={"keys": [key_dict]},
+                headers={"Cache-Control": "no-store, max-age=600"},
+            )
+        )
+
+        response = _get_cached_jwks(JWKS_URL)
+        assert response.is_successful is True
+        assert response.keys is not None
+        assert JWKS_URL not in sync_tv._jwks_cache
+
+    @respx.mock
+    def test_disco_no_store_skips_cache(self):
+        respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json=DISCO_RESPONSE_WITH_JWKS,
+                headers={"Cache-Control": "no-store"},
+            )
+        )
+
+        response = _get_disco_response(DISCO_URL)
+        assert response.is_successful is True
+        assert (DISCO_URL, True) not in sync_tv._disco_cache
+
+
+class TestAsyncNoStoreNotCached:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_jwks_no_store_skips_cache_async(self):
+        key_dict = generate_rsa_keypair()[0]
+        respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={"keys": [key_dict]},
+                headers={"Cache-Control": "no-store, max-age=600"},
+            )
+        )
+
+        response = await async_get_cached_jwks(JWKS_URL)
+        assert response.is_successful is True
+        assert JWKS_URL not in aio_tv._jwks_cache
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_disco_no_store_skips_cache_async(self):
+        respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json=DISCO_RESPONSE_WITH_JWKS,
+                headers={"Cache-Control": "no-store"},
+            )
+        )
+
+        response = await async_get_disco_response(DISCO_URL)
+        assert response.is_successful is True
+        assert (DISCO_URL, True) not in aio_tv._disco_cache
+
+
+# ============================================================================
+# Cache-Control: no-cache — always re-fetch
+# ============================================================================
+
+
+class TestSyncNoCacheRefetched:
+    @respx.mock
+    def test_jwks_no_cache_refetches_each_call(self):
+        """no-cache responses always re-fetch (we don't store them)."""
+        key_dict = generate_rsa_keypair()[0]
+        jwks_route = respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={"keys": [key_dict]},
+                headers={"Cache-Control": "no-cache, max-age=600"},
+            )
+        )
+
+        for _ in range(3):
+            response = _get_cached_jwks(JWKS_URL)
+            assert response.is_successful is True
+
+        assert JWKS_URL not in sync_tv._jwks_cache
+        assert jwks_route.call_count == 3  # noqa: PLR2004
+
+    @respx.mock
+    def test_disco_no_cache_refetches_each_call(self):
+        disco_route = respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json=DISCO_RESPONSE_WITH_JWKS,
+                headers={"Cache-Control": "no-cache"},
+            )
+        )
+
+        for _ in range(3):
+            response = _get_disco_response(DISCO_URL)
+            assert response.is_successful is True
+
+        assert (DISCO_URL, True) not in sync_tv._disco_cache
+        assert disco_route.call_count == 3  # noqa: PLR2004
+
+
+class TestAsyncNoCacheRefetched:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_jwks_no_cache_refetches_each_call_async(self):
+        key_dict = generate_rsa_keypair()[0]
+        jwks_route = respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={"keys": [key_dict]},
+                headers={"Cache-Control": "no-cache, max-age=600"},
+            )
+        )
+
+        for _ in range(3):
+            response = await async_get_cached_jwks(JWKS_URL)
+            assert response.is_successful is True
+
+        assert JWKS_URL not in aio_tv._jwks_cache
+        assert jwks_route.call_count == 3  # noqa: PLR2004
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_disco_no_cache_refetches_each_call_async(self):
+        disco_route = respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json=DISCO_RESPONSE_WITH_JWKS,
+                headers={"Cache-Control": "no-cache"},
+            )
+        )
+
+        # Sequential awaits — async lock would serialize concurrent ones into one fetch.
+        for _ in range(3):
+            await async_get_disco_response(DISCO_URL)
+
+        assert (DISCO_URL, True) not in aio_tv._disco_cache
+        assert disco_route.call_count == 3  # noqa: PLR2004

--- a/src/tests/unit/test_cache_http_headers.py
+++ b/src/tests/unit/test_cache_http_headers.py
@@ -307,7 +307,6 @@ class TestAsyncNoCacheRefetched:
             )
         )
 
-        # Sequential awaits — async lock would serialize concurrent ones into one fetch.
         for _ in range(3):
             await async_get_disco_response(DISCO_URL)
 

--- a/src/tests/unit/test_jwks_cache.py
+++ b/src/tests/unit/test_jwks_cache.py
@@ -10,6 +10,7 @@ from py_identity_model.core.jwks_cache import (
     MIN_CACHE_TTL_SECONDS,
     JwksCacheEntry,
     is_cache_expired,
+    is_uncacheable,
     parse_max_age,
     resolve_ttl,
 )
@@ -89,6 +90,37 @@ class TestCacheEntry:
     def test_entry_stores_custom_ttl(self):
         entry = self._make_entry(ttl=7200)
         assert entry.ttl == 7200
+
+
+class TestIsUncacheable:
+    def test_no_store(self):
+        assert is_uncacheable("no-store") is True
+
+    def test_no_cache(self):
+        assert is_uncacheable("no-cache") is True
+
+    def test_no_store_with_max_age(self):
+        """Per RFC 7234 §5.2.2.5, no-store overrides max-age."""
+        assert is_uncacheable("no-store, max-age=600") is True
+
+    def test_no_cache_with_max_age(self):
+        assert is_uncacheable("no-cache, max-age=600") is True
+
+    def test_case_insensitive(self):
+        assert is_uncacheable("No-Store") is True
+        assert is_uncacheable("NO-CACHE") is True
+
+    def test_plain_max_age_is_cacheable(self):
+        assert is_uncacheable("max-age=3600") is False
+
+    def test_public_max_age_is_cacheable(self):
+        assert is_uncacheable("public, max-age=19800") is False
+
+    def test_none_header(self):
+        assert is_uncacheable(None) is False
+
+    def test_empty_string(self):
+        assert is_uncacheable("") is False
 
 
 class TestMultiProviderCacheIsolation:

--- a/src/tests/unit/test_jwks_cache.py
+++ b/src/tests/unit/test_jwks_cache.py
@@ -106,6 +106,10 @@ class TestIsUncacheable:
     def test_no_cache_with_max_age(self):
         assert is_uncacheable("no-cache, max-age=600") is True
 
+    def test_descope_combined_directives(self):
+        """Real-world: Descope sends both no-store and no-cache on JWKS."""
+        assert is_uncacheable("no-store, no-cache") is True
+
     def test_case_insensitive(self):
         assert is_uncacheable("No-Store") is True
         assert is_uncacheable("NO-CACHE") is True


### PR DESCRIPTION
## Summary

Three correctness fixes to the JWKS and discovery cache, all confined to the cache layer. No behavior change for the happy path (successful response with plain `max-age`).

- **Failed responses are no longer cached.** Previously, when `get_jwks()` or `get_discovery_document()` returned `is_successful=False` (network error, 4xx after retries, etc.), the cache layer still stored the failed response under the default 24h TTL (JWKS) or 1h TTL (discovery). A transient blip could therefore poison the cache for up to a day. Now the cache layer checks `response.is_successful` and skips caching on failure, so the next call re-fetches.
- **`Cache-Control: no-store` is honored** (RFC 7234 §5.2.2.5). When present, the response is returned to the caller but not stored in the cache.
- **`Cache-Control: no-cache` is honored** (RFC 7234 §5.2.2.4). The simplest correct behavior is to skip caching and re-fetch on every call.

Implementation:
- Adds `is_uncacheable(cache_control)` in `core/jwks_cache.py` — case-insensitive regex match for `no-store` or `no-cache` directives.
- Gates the cache write in `_get_cached_jwks`, `_refresh_jwks`, and `_get_disco_response` (sync and async) on both `response.is_successful` and `not is_uncacheable(response.cache_control)`.

Deferred (lower priority, not implemented):
- `Age` header subtraction from effective TTL (matters mainly behind CDNs).
- `Expires` header (HTTP/1.0 fallback) parsing — modern OPs send `Cache-Control`.
- `ETag` / `If-None-Match` conditional revalidation — bandwidth optimization, not a correctness bug.

## Test plan

- [x] New unit tests in `test_cache_http_headers.py` cover all three fixes for both sync and async paths:
  - 404 → cache miss; subsequent fetch succeeds and populates the cache.
  - `no-store, max-age=600` → response returned, cache empty.
  - `no-cache, max-age=600` → every call hits the origin (3-call assertion).
- [x] New unit tests for `is_uncacheable()` covering no-store, no-cache, combined directives, case-insensitivity, and the non-matching cases (plain `max-age`, `None`, `""`).
- [x] `make lint` passes (ruff lint, ruff format, pyrefly, coverage gate at 95.55%).
- [x] `make test-unit` passes (1006 tests).