### PR TITLE
fix(jwks-cache): combined PR #391+#392 with adversarial-review hardening

### DIFF
--- a/conformance/results/basic-rp-latest.json
+++ b/conformance/results/basic-rp-latest.json
@@ -1,104 +1,104 @@
 {
   "plan": "basic-rp",
-  "plan_id": "k14GyYkholz4l",
+  "plan_id": "T6YsG1bnx4c8E",
   "suite_url": "https://localhost.emobix.co.uk:8443",
   "results": [
     {
       "test": "oidcc-client-test",
       "status": "PASSED",
-      "test_id": "qAV7nbRtxkI4c40",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=qAV7nbRtxkI4c40",
+      "test_id": "J6RZ0QYLIqSqnmN",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=J6RZ0QYLIqSqnmN",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-invalid-iss",
       "status": "PASSED",
-      "test_id": "EtKLH4AXQe4Uh0n",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=EtKLH4AXQe4Uh0n",
+      "test_id": "9NiPTvBCVqm8Ual",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=9NiPTvBCVqm8Ual",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-missing-sub",
       "status": "PASSED",
-      "test_id": "dumfCr7PFyQP10b",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=dumfCr7PFyQP10b",
+      "test_id": "3HXnY2MWHR5ZpOr",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=3HXnY2MWHR5ZpOr",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-invalid-aud",
       "status": "PASSED",
-      "test_id": "c5kOspGFCSX3L2v",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=c5kOspGFCSX3L2v",
+      "test_id": "VITlE4esdcuZwts",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=VITlE4esdcuZwts",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-missing-iat",
       "status": "PASSED",
-      "test_id": "5BwxiEdKzRHEbbx",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=5BwxiEdKzRHEbbx",
+      "test_id": "1TI5WuNnibFfkqu",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=1TI5WuNnibFfkqu",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-kid-absent-single-jwks",
       "status": "PASSED",
-      "test_id": "Uw4Vo06HGj64KAA",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=Uw4Vo06HGj64KAA",
+      "test_id": "2ng4W5V8Q422YOQ",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=2ng4W5V8Q422YOQ",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-kid-absent-multiple-jwks",
       "status": "PASSED",
-      "test_id": "UTBbYd6j3zh7mzd",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=UTBbYd6j3zh7mzd",
+      "test_id": "SPuILLfsPnpE4oI",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=SPuILLfsPnpE4oI",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-idtoken-sig-rs256",
       "status": "PASSED",
-      "test_id": "teLrnYICPG6ueEx",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=teLrnYICPG6ueEx",
+      "test_id": "6Yu73KTPvCYdFKp",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=6Yu73KTPvCYdFKp",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-idtoken-sig-none",
       "status": "SKIPPED",
-      "test_id": "IlMch9Tv777LU8u",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=IlMch9Tv777LU8u",
+      "test_id": "1kO1WrjwzHBdQst",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=1kO1WrjwzHBdQst",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-invalid-sig-rs256",
       "status": "PASSED",
-      "test_id": "ipGQGlIKJh2JQB6",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=ipGQGlIKJh2JQB6",
+      "test_id": "XrXhBeEVlsD2o7Q",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=XrXhBeEVlsD2o7Q",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-userinfo-invalid-sub",
       "status": "PASSED",
-      "test_id": "BsbyPguPrxeh1iF",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=BsbyPguPrxeh1iF",
+      "test_id": "qzNpJ0b0TH84sSF",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=qzNpJ0b0TH84sSF",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-nonce-invalid",
       "status": "PASSED",
-      "test_id": "1vKdDNwdbM00S4I",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=1vKdDNwdbM00S4I",
+      "test_id": "9InKz3n5he7nP6j",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=9InKz3n5he7nP6j",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-scope-userinfo-claims",
       "status": "PASSED",
-      "test_id": "tEHWC2dSRVFxU0X",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=tEHWC2dSRVFxU0X",
+      "test_id": "z2fcENu4kpNYIGx",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=z2fcENu4kpNYIGx",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-client-secret-basic",
       "status": "PASSED",
-      "test_id": "oBKNnHtBiVF7TcP",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=oBKNnHtBiVF7TcP",
+      "test_id": "TsGSMps1eK02fUp",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=TsGSMps1eK02fUp",
       "detail": ""
     }
   ],

--- a/conformance/results/config-rp-latest.json
+++ b/conformance/results/config-rp-latest.json
@@ -1,48 +1,48 @@
 {
   "plan": "config-rp",
-  "plan_id": "aopFGhgJXtbOT",
+  "plan_id": "rYNtbteMozOBP",
   "suite_url": "https://localhost.emobix.co.uk:8443",
   "results": [
     {
       "test": "oidcc-client-test-discovery-openid-config",
       "status": "PASSED",
-      "test_id": "WYDY0MALD506SWj",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=WYDY0MALD506SWj",
+      "test_id": "R4jFsLk6cf1RBuq",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=R4jFsLk6cf1RBuq",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-discovery-jwks-uri-keys",
       "status": "PASSED",
-      "test_id": "D2lh3wpqKZiTqLh",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=D2lh3wpqKZiTqLh",
+      "test_id": "F2TEjqWA5VXCMzf",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=F2TEjqWA5VXCMzf",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-discovery-issuer-mismatch",
       "status": "PASSED",
-      "test_id": "N98F3JcfxgExs29",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=N98F3JcfxgExs29",
+      "test_id": "1pKj0eqrCUhVdH7",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=1pKj0eqrCUhVdH7",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-idtoken-sig-none",
       "status": "SKIPPED",
-      "test_id": "kp8G0vg8QmPoKFu",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=kp8G0vg8QmPoKFu",
+      "test_id": "DMIpMCFlV9j1uAv",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=DMIpMCFlV9j1uAv",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-signing-key-rotation-just-before-signing",
       "status": "PASSED",
-      "test_id": "rvYuDsaDSap7nRc",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=rvYuDsaDSap7nRc",
+      "test_id": "Cq6WSp3h3KqyoG6",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=Cq6WSp3h3KqyoG6",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-signing-key-rotation",
       "status": "PASSED",
-      "test_id": "yUv01CxpuBvUc3Q",
-      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=yUv01CxpuBvUc3Q",
+      "test_id": "5E1KpDObbdYyfOA",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=5E1KpDObbdYyfOA",
       "detail": ""
     }
   ],

--- a/conformance/results/form-post-basic-rp-latest.json
+++ b/conformance/results/form-post-basic-rp-latest.json
@@ -1,0 +1,114 @@
+{
+  "plan": "form-post-basic-rp",
+  "plan_id": "qNFEJarULszzl",
+  "suite_url": "https://localhost.emobix.co.uk:8443",
+  "results": [
+    {
+      "test": "oidcc-client-test",
+      "status": "PASSED",
+      "test_id": "Wm7XmvGcbvYPfXc",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=Wm7XmvGcbvYPfXc",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-invalid-iss",
+      "status": "PASSED",
+      "test_id": "EkUtK5tCLnLbDEe",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=EkUtK5tCLnLbDEe",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-missing-sub",
+      "status": "PASSED",
+      "test_id": "j2SPY1MmMpFiyhJ",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=j2SPY1MmMpFiyhJ",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-invalid-aud",
+      "status": "PASSED",
+      "test_id": "kGCrMBnv2VxboY0",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=kGCrMBnv2VxboY0",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-missing-iat",
+      "status": "PASSED",
+      "test_id": "uqaSfhQyGhDuvvQ",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=uqaSfhQyGhDuvvQ",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-kid-absent-single-jwks",
+      "status": "PASSED",
+      "test_id": "1A65b0KqDTdAGC2",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=1A65b0KqDTdAGC2",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-kid-absent-multiple-jwks",
+      "status": "PASSED",
+      "test_id": "hhM4zPLGibdV3JI",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=hhM4zPLGibdV3JI",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-idtoken-sig-rs256",
+      "status": "PASSED",
+      "test_id": "dfqcZRivLw2wxwD",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=dfqcZRivLw2wxwD",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-idtoken-sig-none",
+      "status": "SKIPPED",
+      "test_id": "qkiwlO6Inkm19zn",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=qkiwlO6Inkm19zn",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-invalid-sig-rs256",
+      "status": "PASSED",
+      "test_id": "LDDalGJbPb5eUZZ",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=LDDalGJbPb5eUZZ",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-userinfo-invalid-sub",
+      "status": "PASSED",
+      "test_id": "KYgMWWjzzv09J2E",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=KYgMWWjzzv09J2E",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-nonce-invalid",
+      "status": "PASSED",
+      "test_id": "S1Ky1pz1lquvKyL",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=S1Ky1pz1lquvKyL",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-scope-userinfo-claims",
+      "status": "PASSED",
+      "test_id": "OHpHtd9S7zjVdpq",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=OHpHtd9S7zjVdpq",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-client-secret-basic",
+      "status": "PASSED",
+      "test_id": "YHR1Qpxb0weJYwe",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=YHR1Qpxb0weJYwe",
+      "detail": ""
+    }
+  ],
+  "summary": {
+    "total": 14,
+    "passed": 13,
+    "warning": 0,
+    "failed": 0,
+    "review": 0,
+    "skipped": 1
+  },
+  "all_passed": true
+}

--- a/src/py_identity_model/aio/token_validation.py
+++ b/src/py_identity_model/aio/token_validation.py
@@ -15,6 +15,7 @@ from ..core.jwks_cache import (
     apply_disco_cache_outcome,
     apply_jwks_cache_outcome,
     is_cache_expired,
+    should_attempt_kid_miss_refresh,
 )
 from ..core.models import (
     DiscoveryDocumentRequest,
@@ -92,6 +93,9 @@ def clear_discovery_cache() -> None:
 _jwks_cache: dict[str, JwksCacheEntry] = {}
 _jwks_cache_lock = asyncio.Lock()
 
+# See sync._kid_miss_last_attempt for rationale. Guarded by _jwks_cache_lock.
+_kid_miss_last_attempt: dict[str, float] = {}
+
 
 async def _get_cached_jwks(jwks_uri: str) -> JwksResponse:
     """Return cached JWKS response if fresh, otherwise fetch and cache."""
@@ -125,6 +129,7 @@ async def _refresh_jwks(jwks_uri: str) -> JwksResponse:
 def clear_jwks_cache() -> None:
     """Clear the JWKS cache. Useful for testing."""
     _jwks_cache.clear()
+    _kid_miss_last_attempt.clear()
 
 
 # ============================================================================
@@ -171,17 +176,35 @@ async def _discover_and_resolve_key(
     kid, jwt_alg = extract_jwt_header_fields(jwt)
     # OP key rotation: if the JWT's kid is not in the cached JWKS, the cache
     # is stale. Force a refresh before lookup so rotation is handled without
-    # waiting for a signature failure on a key we don't have.
-    if kid is not None and not any(k.kid == kid for k in (jwks_response.keys or [])):
-        logger.info(
-            "kid %s not present in cached JWKS; refreshing (possible key rotation)",
-            kid,
-        )
-        jwks_response = await _refresh_jwks(jwks_uri)
-        validate_jwks_response(jwks_response)
-        if not any(k.kid == kid for k in (jwks_response.keys or [])):
-            logger.warning(
-                "kid %s still absent after JWKS refresh of %s", kid, jwks_uri
+    # waiting for a signature failure on a key we don't have. The cooldown
+    # gate prevents an unauthenticated attacker from amplifying inbound JWT
+    # traffic into upstream JWKS fetches by spamming random kids.
+    cached_keys = jwks_response.keys or []
+    if kid is not None and not any(k.kid == kid for k in cached_keys):
+        if should_attempt_kid_miss_refresh(
+            _kid_miss_last_attempt,
+            jwks_uri,
+            has_cached_keys=bool(cached_keys),
+            now=time.time(),
+        ):
+            logger.info(
+                "kid %s not present in cached JWKS; refreshing (possible key rotation)",
+                kid,
+            )
+            async with _jwks_cache_lock:
+                _kid_miss_last_attempt[jwks_uri] = time.time()
+            jwks_response = await _refresh_jwks(jwks_uri)
+            validate_jwks_response(jwks_response)
+            if not any(k.kid == kid for k in (jwks_response.keys or [])):
+                logger.warning(
+                    "kid %s still absent after JWKS refresh of %s", kid, jwks_uri
+                )
+        else:
+            logger.debug(
+                "kid %s not in cached JWKS for %s but refresh cooldown active; "
+                "falling through to no-matching-kid error",
+                kid,
+                jwks_uri,
             )
     key_dict, alg = find_key_by_kid(kid, jwks_response.keys or [], jwt_alg=jwt_alg)
     return key_dict, alg, disco_doc_response, True

--- a/src/py_identity_model/aio/token_validation.py
+++ b/src/py_identity_model/aio/token_validation.py
@@ -53,31 +53,54 @@ from .managed_client import AsyncHTTPClient
 
 # Discovery TTL cache — keyed by (address, require_https) to prevent policy bypass
 _disco_cache: dict[tuple[str, bool], DiscoCacheEntry] = {}
-_disco_cache_lock = asyncio.Lock()
+# Brief CPU-only write lock; does NOT span the upstream HTTP fetch. See
+# the sync module for the full rationale and the cache-aside pattern.
+_disco_cache_write_lock = asyncio.Lock()
+# Per-URI fetch locks (striped). Allows two coroutines waiting on
+# discovery for *different* addresses to run in parallel rather than
+# serializing on a single global lock held across an awaited HTTP call.
+_DISCO_LOCK_STRIPES = 32
+_disco_fetch_locks: list[asyncio.Lock] = [
+    asyncio.Lock() for _ in range(_DISCO_LOCK_STRIPES)
+]
+
+
+def _get_disco_fetch_lock(cache_key: tuple[str, bool]) -> asyncio.Lock:
+    return _disco_fetch_locks[hash(cache_key) % _DISCO_LOCK_STRIPES]
 
 
 async def _get_disco_response(
     disco_doc_address: str | None,
     require_https: bool = True,
 ) -> DiscoveryDocumentResponse:
-    """Cached async discovery document fetching with TTL."""
+    """Cached async discovery document fetching with TTL.
+
+    Cache-aside with per-URI single-flight: a fresh cached entry returns
+    without acquiring any lock; only the upstream fetch on a cache miss
+    is serialized, and only against other requests for the same address.
+    """
     if disco_doc_address is None:
         raise ConfigurationException(
             "disco_doc_address is required when perform_disco is True"
         )
 
     cache_key = (disco_doc_address, require_https)
-    async with _disco_cache_lock:
+    entry = _disco_cache.get(cache_key)
+    if entry is not None and not is_cache_expired(entry):
+        return entry.response
+
+    fetch_lock = _get_disco_fetch_lock(cache_key)
+    async with fetch_lock:
         entry = _disco_cache.get(cache_key)
         if entry is not None and not is_cache_expired(entry):
             return entry.response
 
-        # Fetch under lock to prevent cache stampede (single-flight refresh)
         policy = DiscoveryPolicy(require_https=require_https)
         response = await get_discovery_document(
             DiscoveryDocumentRequest(address=disco_doc_address, policy=policy),
         )
-        apply_disco_cache_outcome(_disco_cache, cache_key, response, time.time())
+        async with _disco_cache_write_lock:
+            apply_disco_cache_outcome(_disco_cache, cache_key, response, time.time())
         return response
 
 
@@ -91,38 +114,60 @@ def clear_discovery_cache() -> None:
 # ============================================================================
 
 _jwks_cache: dict[str, JwksCacheEntry] = {}
-_jwks_cache_lock = asyncio.Lock()
+_jwks_cache_write_lock = asyncio.Lock()
+_JWKS_LOCK_STRIPES = 32
+_jwks_fetch_locks: list[asyncio.Lock] = [
+    asyncio.Lock() for _ in range(_JWKS_LOCK_STRIPES)
+]
 
-# See sync._kid_miss_last_attempt for rationale. Guarded by _jwks_cache_lock.
+# See sync._kid_miss_last_attempt for rationale. Guarded by _jwks_cache_write_lock.
 _kid_miss_last_attempt: dict[str, float] = {}
 
 
+def _get_jwks_fetch_lock(jwks_uri: str) -> asyncio.Lock:
+    return _jwks_fetch_locks[hash(jwks_uri) % _JWKS_LOCK_STRIPES]
+
+
 async def _get_cached_jwks(jwks_uri: str) -> JwksResponse:
-    """Return cached JWKS response if fresh, otherwise fetch and cache."""
-    async with _jwks_cache_lock:
+    """Return cached JWKS response if fresh, otherwise fetch and cache.
+
+    Cache-aside with per-URI single-flight (see ``_get_disco_response``).
+    """
+    entry = _jwks_cache.get(jwks_uri)
+    if entry is not None and not is_cache_expired(entry):
+        return entry.response
+
+    fetch_lock = _get_jwks_fetch_lock(jwks_uri)
+    async with fetch_lock:
         entry = _jwks_cache.get(jwks_uri)
         if entry is not None and not is_cache_expired(entry):
             return entry.response
 
-        # Fetch under lock to prevent cache stampede (single-flight refresh)
         response = await get_jwks(JwksRequest(address=jwks_uri))
-        apply_jwks_cache_outcome(_jwks_cache, jwks_uri, response, time.time())
+        async with _jwks_cache_write_lock:
+            apply_jwks_cache_outcome(_jwks_cache, jwks_uri, response, time.time())
         return response
 
 
 async def _refresh_jwks(jwks_uri: str) -> JwksResponse:
-    """Force re-fetch JWKS and update cache (key rotation)."""
+    """Force re-fetch JWKS and update cache (key rotation).
+
+    Uses the per-URI fetch lock to coalesce concurrent refreshes for the
+    same URI while leaving unrelated URIs unblocked. The ``request_time``
+    guard catches the case where another coroutine for *this* URI completed
+    a refresh while we were blocked.
+    """
     request_time = time.time()
-    async with _jwks_cache_lock:
-        # If another coroutine already refreshed while we waited on the lock,
-        # return the fresh entry to avoid redundant sequential fetches
+    fetch_lock = _get_jwks_fetch_lock(jwks_uri)
+    async with fetch_lock:
         entry = _jwks_cache.get(jwks_uri)
         if entry is not None and entry.cached_at >= request_time:
             return entry.response
 
         logger.info("Forcing JWKS refresh for %s (possible key rotation)", jwks_uri)
         response = await get_jwks(JwksRequest(address=jwks_uri))
-        apply_jwks_cache_outcome(_jwks_cache, jwks_uri, response, time.time())
+        async with _jwks_cache_write_lock:
+            apply_jwks_cache_outcome(_jwks_cache, jwks_uri, response, time.time())
         return response
 
 
@@ -191,7 +236,7 @@ async def _discover_and_resolve_key(
                 "kid %s not present in cached JWKS; refreshing (possible key rotation)",
                 kid,
             )
-            async with _jwks_cache_lock:
+            async with _jwks_cache_write_lock:
                 _kid_miss_last_attempt[jwks_uri] = time.time()
             jwks_response = await _refresh_jwks(jwks_uri)
             validate_jwks_response(jwks_response)

--- a/src/py_identity_model/aio/token_validation.py
+++ b/src/py_identity_model/aio/token_validation.py
@@ -12,10 +12,9 @@ from ..core.discovery_policy import DiscoveryPolicy
 from ..core.jwks_cache import (
     DiscoCacheEntry,
     JwksCacheEntry,
+    apply_disco_cache_outcome,
+    apply_jwks_cache_outcome,
     is_cache_expired,
-    is_uncacheable,
-    resolve_disco_ttl,
-    resolve_ttl,
 )
 from ..core.models import (
     DiscoveryDocumentRequest,
@@ -77,11 +76,7 @@ async def _get_disco_response(
         response = await get_discovery_document(
             DiscoveryDocumentRequest(address=disco_doc_address, policy=policy),
         )
-        if response.is_successful and not is_uncacheable(response.cache_control):
-            ttl = resolve_disco_ttl(response.cache_control)
-            _disco_cache[cache_key] = DiscoCacheEntry(
-                response=response, cached_at=time.time(), ttl=ttl
-            )
+        apply_disco_cache_outcome(_disco_cache, cache_key, response, time.time())
         return response
 
 
@@ -107,11 +102,7 @@ async def _get_cached_jwks(jwks_uri: str) -> JwksResponse:
 
         # Fetch under lock to prevent cache stampede (single-flight refresh)
         response = await get_jwks(JwksRequest(address=jwks_uri))
-        if response.is_successful and not is_uncacheable(response.cache_control):
-            ttl = resolve_ttl(response.cache_control)
-            _jwks_cache[jwks_uri] = JwksCacheEntry(
-                response=response, cached_at=time.time(), ttl=ttl
-            )
+        apply_jwks_cache_outcome(_jwks_cache, jwks_uri, response, time.time())
         return response
 
 
@@ -127,11 +118,7 @@ async def _refresh_jwks(jwks_uri: str) -> JwksResponse:
 
         logger.info("Forcing JWKS refresh for %s (possible key rotation)", jwks_uri)
         response = await get_jwks(JwksRequest(address=jwks_uri))
-        if response.is_successful and not is_uncacheable(response.cache_control):
-            ttl = resolve_ttl(response.cache_control)
-            _jwks_cache[jwks_uri] = JwksCacheEntry(
-                response=response, cached_at=time.time(), ttl=ttl
-            )
+        apply_jwks_cache_outcome(_jwks_cache, jwks_uri, response, time.time())
         return response
 
 

--- a/src/py_identity_model/aio/token_validation.py
+++ b/src/py_identity_model/aio/token_validation.py
@@ -178,6 +178,16 @@ async def _discover_and_resolve_key(
     jwks_response = await _get_cached_jwks(jwks_uri)
     validate_jwks_response(jwks_response)
     kid, jwt_alg = extract_jwt_header_fields(jwt)
+    # OP key rotation: if the JWT's kid is not in the cached JWKS, the cache
+    # is stale. Force a refresh before lookup so rotation is handled without
+    # waiting for a signature failure on a key we don't have.
+    if kid is not None and not any(k.kid == kid for k in (jwks_response.keys or [])):
+        logger.info(
+            "kid %s not present in cached JWKS; refreshing (possible key rotation)",
+            kid,
+        )
+        jwks_response = await _refresh_jwks(jwks_uri)
+        validate_jwks_response(jwks_response)
     key_dict, alg = find_key_by_kid(kid, jwks_response.keys or [], jwt_alg=jwt_alg)
     return key_dict, alg, disco_doc_response, True
 

--- a/src/py_identity_model/aio/token_validation.py
+++ b/src/py_identity_model/aio/token_validation.py
@@ -13,6 +13,7 @@ from ..core.jwks_cache import (
     DiscoCacheEntry,
     JwksCacheEntry,
     is_cache_expired,
+    is_uncacheable,
     resolve_disco_ttl,
     resolve_ttl,
 )
@@ -76,10 +77,11 @@ async def _get_disco_response(
         response = await get_discovery_document(
             DiscoveryDocumentRequest(address=disco_doc_address, policy=policy),
         )
-        ttl = resolve_disco_ttl(response.cache_control)
-        _disco_cache[cache_key] = DiscoCacheEntry(
-            response=response, cached_at=time.time(), ttl=ttl
-        )
+        if response.is_successful and not is_uncacheable(response.cache_control):
+            ttl = resolve_disco_ttl(response.cache_control)
+            _disco_cache[cache_key] = DiscoCacheEntry(
+                response=response, cached_at=time.time(), ttl=ttl
+            )
         return response
 
 
@@ -105,10 +107,11 @@ async def _get_cached_jwks(jwks_uri: str) -> JwksResponse:
 
         # Fetch under lock to prevent cache stampede (single-flight refresh)
         response = await get_jwks(JwksRequest(address=jwks_uri))
-        ttl = resolve_ttl(response.cache_control)
-        _jwks_cache[jwks_uri] = JwksCacheEntry(
-            response=response, cached_at=time.time(), ttl=ttl
-        )
+        if response.is_successful and not is_uncacheable(response.cache_control):
+            ttl = resolve_ttl(response.cache_control)
+            _jwks_cache[jwks_uri] = JwksCacheEntry(
+                response=response, cached_at=time.time(), ttl=ttl
+            )
         return response
 
 
@@ -124,10 +127,11 @@ async def _refresh_jwks(jwks_uri: str) -> JwksResponse:
 
         logger.info("Forcing JWKS refresh for %s (possible key rotation)", jwks_uri)
         response = await get_jwks(JwksRequest(address=jwks_uri))
-        ttl = resolve_ttl(response.cache_control)
-        _jwks_cache[jwks_uri] = JwksCacheEntry(
-            response=response, cached_at=time.time(), ttl=ttl
-        )
+        if response.is_successful and not is_uncacheable(response.cache_control):
+            ttl = resolve_ttl(response.cache_control)
+            _jwks_cache[jwks_uri] = JwksCacheEntry(
+                response=response, cached_at=time.time(), ttl=ttl
+            )
         return response
 
 

--- a/src/py_identity_model/aio/token_validation.py
+++ b/src/py_identity_model/aio/token_validation.py
@@ -188,6 +188,10 @@ async def _discover_and_resolve_key(
         )
         jwks_response = await _refresh_jwks(jwks_uri)
         validate_jwks_response(jwks_response)
+        if not any(k.kid == kid for k in (jwks_response.keys or [])):
+            logger.warning(
+                "kid %s still absent after JWKS refresh of %s", kid, jwks_uri
+            )
     key_dict, alg = find_key_by_kid(kid, jwks_response.keys or [], jwt_alg=jwt_alg)
     return key_dict, alg, disco_doc_response, True
 

--- a/src/py_identity_model/core/jwks_cache.py
+++ b/src/py_identity_model/core/jwks_cache.py
@@ -37,20 +37,80 @@ DEFAULT_DISCO_CACHE_TTL_SECONDS: float = 3600.0  # 1 hour
 MIN_CACHE_TTL_SECONDS: float = 60.0
 MAX_CACHE_TTL_SECONDS: float = 86400.0
 
+# Minimum gap between forced JWKS refreshes for the *same* jwks_uri when the
+# incoming JWT's kid is not in the cached set. Bounds the DoS amplification
+# factor an unauthenticated attacker can drive by spamming JWTs with random
+# kids: under sustained load at most ⌈window / cooldown⌉ requests reach the
+# upstream JWKS endpoint per window. The cached keys remain usable inside the
+# window — the cooldown only short-circuits the refresh attempt, not the
+# lookup, so legitimate already-cached kids continue to validate normally.
+# Mirrors Microsoft IdentityModel's RefreshInterval (default 5 minutes) and
+# Auth0's node-jwks-rsa rateLimit (default 10 req/min); 5s is the conservative
+# floor between those two — small enough that a real rotation propagates
+# within one cooldown window per process.
+DEFAULT_KID_MISS_REFRESH_COOLDOWN_SECONDS: float = 5.0
+
+# Caps the number of distinct (jwks_uri) or (disco_address, require_https)
+# entries the cache will hold per process. Bounds an unbounded-growth attack
+# where attacker-controlled discovery addresses (multi-tenant gateways,
+# attacker-supplied issuer headers) accumulate cache entries forever — at
+# ~5KB per DiscoveryDocumentResponse, a few thousand unique entries is tens
+# of MB of memory leak. Default 64 covers any realistic multi-IdP deployment
+# while keeping worst-case memory bounded. Eviction is FIFO by insertion
+# order (Python dicts preserve insertion order since 3.7) — adequate for a
+# JWKS cache where all entries are roughly equally "hot."
+DEFAULT_MAX_CACHE_ENTRIES: int = 64
+
 _env_ttl: float | None = None
 _disco_env_ttl: float | None = None
+_kid_miss_cooldown: float | None = None
+_max_cache_entries: int | None = None
 _MAX_AGE_RE = re.compile(r"max-age=(\d+)", re.IGNORECASE)
 _NO_STORE_RE = re.compile(r"\bno-store\b", re.IGNORECASE)
 _NO_CACHE_RE = re.compile(r"\bno-cache\b", re.IGNORECASE)
+
+
+def _safe_env_ttl(env_var: str, default: float) -> float:
+    """Read a TTL env var with clamp + fail-safe parsing.
+
+    Garbage values (``""``, ``"60s"``, non-numeric) log a warning and fall
+    back to the default rather than crashing the process at first cache
+    access. Values outside ``[MIN_CACHE_TTL_SECONDS, MAX_CACHE_TTL_SECONDS]``
+    are clamped — without this, ``JWKS_CACHE_TTL=0`` silently disables the
+    cache (every entry instantly expired) and ``JWKS_CACHE_TTL=2592000``
+    silently disables the documented 24h ceiling on key-rotation latency.
+    """
+    raw = os.getenv(env_var)
+    if raw is None or raw == "":
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid %s=%r; falling back to default %.0fs",
+            env_var,
+            raw,
+            default,
+        )
+        return default
+    clamped = max(MIN_CACHE_TTL_SECONDS, min(value, MAX_CACHE_TTL_SECONDS))
+    if clamped != value:
+        logger.warning(
+            "Clamped %s=%s to [%.0fs, %.0fs] → %.0fs",
+            env_var,
+            value,
+            MIN_CACHE_TTL_SECONDS,
+            MAX_CACHE_TTL_SECONDS,
+            clamped,
+        )
+    return clamped
 
 
 def _get_env_ttl() -> float:
     """Read JWKS_CACHE_TTL from env once, cache the result."""
     global _env_ttl  # noqa: PLW0603
     if _env_ttl is None:
-        _env_ttl = float(
-            os.getenv("JWKS_CACHE_TTL", str(DEFAULT_JWKS_CACHE_TTL_SECONDS))
-        )
+        _env_ttl = _safe_env_ttl("JWKS_CACHE_TTL", DEFAULT_JWKS_CACHE_TTL_SECONDS)
     return _env_ttl
 
 
@@ -58,10 +118,113 @@ def _get_disco_env_ttl() -> float:
     """Read DISCO_CACHE_TTL from env once, cache the result."""
     global _disco_env_ttl  # noqa: PLW0603
     if _disco_env_ttl is None:
-        _disco_env_ttl = float(
-            os.getenv("DISCO_CACHE_TTL", str(DEFAULT_DISCO_CACHE_TTL_SECONDS))
+        _disco_env_ttl = _safe_env_ttl(
+            "DISCO_CACHE_TTL", DEFAULT_DISCO_CACHE_TTL_SECONDS
         )
     return _disco_env_ttl
+
+
+def get_max_cache_entries() -> int:
+    """Read JWKS_CACHE_MAX_ENTRIES from env once, cache the result.
+
+    Falls back to the default on garbage or non-positive values, logging
+    a warning. Reset via ``_reset_env_for_testing``.
+    """
+    global _max_cache_entries  # noqa: PLW0603
+    if _max_cache_entries is None:
+        raw = os.getenv("JWKS_CACHE_MAX_ENTRIES")
+        if raw is None or raw == "":
+            _max_cache_entries = DEFAULT_MAX_CACHE_ENTRIES
+        else:
+            try:
+                value = int(raw)
+                if value < 1:
+                    logger.warning(
+                        "JWKS_CACHE_MAX_ENTRIES=%s must be >= 1; "
+                        "falling back to default %d",
+                        value,
+                        DEFAULT_MAX_CACHE_ENTRIES,
+                    )
+                    value = DEFAULT_MAX_CACHE_ENTRIES
+            except ValueError:
+                logger.warning(
+                    "Invalid JWKS_CACHE_MAX_ENTRIES=%r; falling back to default %d",
+                    raw,
+                    DEFAULT_MAX_CACHE_ENTRIES,
+                )
+                value = DEFAULT_MAX_CACHE_ENTRIES
+            _max_cache_entries = value
+    return _max_cache_entries
+
+
+def _enforce_size_limit(cache: dict) -> None:
+    """Evict oldest entries (by insertion order) until the cache fits."""
+    max_size = get_max_cache_entries()
+    while len(cache) > max_size:
+        oldest_key = next(iter(cache))
+        cache.pop(oldest_key)
+        logger.debug(
+            "Cache size %d exceeds max %d; evicted oldest entry",
+            len(cache) + 1,
+            max_size,
+        )
+
+
+def get_kid_miss_cooldown() -> float:
+    """Read KID_MISS_REFRESH_COOLDOWN from env once, cache the result."""
+    global _kid_miss_cooldown  # noqa: PLW0603
+    if _kid_miss_cooldown is None:
+        _kid_miss_cooldown = float(
+            os.getenv(
+                "KID_MISS_REFRESH_COOLDOWN",
+                str(DEFAULT_KID_MISS_REFRESH_COOLDOWN_SECONDS),
+            )
+        )
+    return _kid_miss_cooldown
+
+
+def should_attempt_kid_miss_refresh(
+    last_attempts: dict[str, float],
+    jwks_uri: str,
+    has_cached_keys: bool,
+    now: float,
+) -> bool:
+    """Gate the kid-miss forced refresh to bound DoS amplification.
+
+    Returns True (proceed with refresh) when:
+    - We have no cached keys to fall back on (the cache cannot be a cause of
+      the kid miss — refusing here would brick token validation), OR
+    - The cooldown has elapsed since the last attempted refresh for this URI.
+
+    Returns False (skip refresh, let find_key_by_kid fail naturally) when a
+    recent kid-miss refresh for this URI did not produce the requested kid
+    and the cached keys are non-empty. The caller will hit the no-matching-kid
+    error path with cached keys still usable for already-known kids.
+
+    The state is keyed by ``jwks_uri`` so an attacker spamming kids against
+    one OP cannot suppress legitimate refreshes for a different OP.
+    """
+    if not has_cached_keys:
+        return True
+    last = last_attempts.get(jwks_uri)
+    if last is None:
+        return True
+    return (now - last) >= get_kid_miss_cooldown()
+
+
+def _reset_env_for_testing() -> None:
+    """Test-only helper: clear memoized env-derived values.
+
+    The module-level memoization (``_env_ttl``, ``_disco_env_ttl``,
+    ``_kid_miss_cooldown``, ``_max_cache_entries``) makes ``monkeypatch.setenv``
+    a silent no-op after any prior call has populated the cache. Tests that
+    need to vary these knobs across runs call this to reset the memos.
+    """
+    global _env_ttl, _disco_env_ttl, _kid_miss_cooldown, _max_cache_entries  # noqa: PLW0603
+    _env_ttl = None
+    _disco_env_ttl = None
+    _kid_miss_cooldown = None
+    _max_cache_entries = None
 
 
 def is_uncacheable(cache_control: str | None) -> bool:
@@ -186,11 +349,15 @@ def apply_jwks_cache_outcome(
         return
     if not response.keys:
         return
+    # Pop-and-reinsert so a refreshed URI moves to the end of insertion order
+    # (FIFO eviction will not target it next when the cache is under pressure).
+    cache.pop(jwks_uri, None)
     cache[jwks_uri] = JwksCacheEntry(
         response=response,
         cached_at=now,
         ttl=resolve_ttl(response.cache_control),
     )
+    _enforce_size_limit(cache)
 
 
 def apply_disco_cache_outcome(
@@ -210,23 +377,30 @@ def apply_disco_cache_outcome(
     if is_uncacheable(response.cache_control):
         cache.pop(cache_key, None)
         return
+    cache.pop(cache_key, None)
     cache[cache_key] = DiscoCacheEntry(
         response=response,
         cached_at=now,
         ttl=resolve_disco_ttl(response.cache_control),
     )
+    _enforce_size_limit(cache)
 
 
 __all__ = [
     "DEFAULT_DISCO_CACHE_TTL_SECONDS",
     "DEFAULT_JWKS_CACHE_TTL_SECONDS",
+    "DEFAULT_KID_MISS_REFRESH_COOLDOWN_SECONDS",
+    "DEFAULT_MAX_CACHE_ENTRIES",
     "DiscoCacheEntry",
     "JwksCacheEntry",
     "apply_disco_cache_outcome",
     "apply_jwks_cache_outcome",
+    "get_kid_miss_cooldown",
+    "get_max_cache_entries",
     "is_cache_expired",
     "is_uncacheable",
     "parse_max_age",
     "resolve_disco_ttl",
     "resolve_ttl",
+    "should_attempt_kid_miss_refresh",
 ]

--- a/src/py_identity_model/core/jwks_cache.py
+++ b/src/py_identity_model/core/jwks_cache.py
@@ -40,6 +40,8 @@ MAX_CACHE_TTL_SECONDS: float = 86400.0
 _env_ttl: float | None = None
 _disco_env_ttl: float | None = None
 _MAX_AGE_RE = re.compile(r"max-age=(\d+)", re.IGNORECASE)
+_NO_STORE_RE = re.compile(r"\bno-store\b", re.IGNORECASE)
+_NO_CACHE_RE = re.compile(r"\bno-cache\b", re.IGNORECASE)
 
 
 def _get_env_ttl() -> float:
@@ -60,6 +62,20 @@ def _get_disco_env_ttl() -> float:
             os.getenv("DISCO_CACHE_TTL", str(DEFAULT_DISCO_CACHE_TTL_SECONDS))
         )
     return _disco_env_ttl
+
+
+def is_uncacheable(cache_control: str | None) -> bool:
+    """Return True when Cache-Control forbids caching the response.
+
+    Honors RFC 7234 §5.2.2.5 (``no-store``) and §5.2.2.4 (``no-cache``).
+    ``no-cache`` requires revalidation before use; the simplest correct
+    behavior is to skip caching so the next call re-fetches.
+    """
+    if not cache_control:
+        return False
+    return bool(
+        _NO_STORE_RE.search(cache_control) or _NO_CACHE_RE.search(cache_control)
+    )
 
 
 def parse_max_age(cache_control: str | None) -> float | None:
@@ -150,6 +166,7 @@ __all__ = [
     "DiscoCacheEntry",
     "JwksCacheEntry",
     "is_cache_expired",
+    "is_uncacheable",
     "parse_max_age",
     "resolve_disco_ttl",
     "resolve_ttl",

--- a/src/py_identity_model/core/jwks_cache.py
+++ b/src/py_identity_model/core/jwks_cache.py
@@ -160,11 +160,70 @@ def is_cache_expired(entry: JwksCacheEntry | DiscoCacheEntry) -> bool:
     return expired
 
 
+def apply_jwks_cache_outcome(
+    cache: dict[str, JwksCacheEntry],
+    jwks_uri: str,
+    response: JwksResponse,
+    now: float,
+) -> None:
+    """Apply the cache-write/invalidate/retain decision for a JWKS response.
+
+    Decision matrix:
+    - Unsuccessful (network error, 4xx, parse failure): retain any existing
+      entry. The last known-good keys remain available while transient errors
+      pass. Mirrors the "retain cache on error" pattern from jose4j.
+    - ``Cache-Control: no-store`` or ``no-cache``: invalidate the existing
+      entry. Any stale entry would otherwise survive its TTL alongside a
+      provider that explicitly forbade caching, defeating key rotation.
+    - Empty ``keys``: retain the existing entry. An empty JWKS is treated as
+      a transient upstream blip, never a valid replacement for working keys.
+    - Successful, cacheable, non-empty: store with the resolved TTL.
+    """
+    if not response.is_successful:
+        return
+    if is_uncacheable(response.cache_control):
+        cache.pop(jwks_uri, None)
+        return
+    if not response.keys:
+        return
+    cache[jwks_uri] = JwksCacheEntry(
+        response=response,
+        cached_at=now,
+        ttl=resolve_ttl(response.cache_control),
+    )
+
+
+def apply_disco_cache_outcome(
+    cache: dict[tuple[str, bool], DiscoCacheEntry],
+    cache_key: tuple[str, bool],
+    response: DiscoveryDocumentResponse,
+    now: float,
+) -> None:
+    """Apply the cache-write/invalidate/retain decision for a discovery response.
+
+    Mirrors :func:`apply_jwks_cache_outcome` but without the empty-payload
+    check, since discovery responses do not have a single "payload" field
+    whose emptiness signals a broken response.
+    """
+    if not response.is_successful:
+        return
+    if is_uncacheable(response.cache_control):
+        cache.pop(cache_key, None)
+        return
+    cache[cache_key] = DiscoCacheEntry(
+        response=response,
+        cached_at=now,
+        ttl=resolve_disco_ttl(response.cache_control),
+    )
+
+
 __all__ = [
     "DEFAULT_DISCO_CACHE_TTL_SECONDS",
     "DEFAULT_JWKS_CACHE_TTL_SECONDS",
     "DiscoCacheEntry",
     "JwksCacheEntry",
+    "apply_disco_cache_outcome",
+    "apply_jwks_cache_outcome",
     "is_cache_expired",
     "is_uncacheable",
     "parse_max_age",

--- a/src/py_identity_model/sync/token_validation.py
+++ b/src/py_identity_model/sync/token_validation.py
@@ -15,10 +15,9 @@ from ..core.discovery_policy import DiscoveryPolicy
 from ..core.jwks_cache import (
     DiscoCacheEntry,
     JwksCacheEntry,
+    apply_disco_cache_outcome,
+    apply_jwks_cache_outcome,
     is_cache_expired,
-    is_uncacheable,
-    resolve_disco_ttl,
-    resolve_ttl,
 )
 from ..core.models import (
     DiscoveryDocumentRequest,
@@ -76,11 +75,7 @@ def _get_disco_response(
         response = get_discovery_document(
             DiscoveryDocumentRequest(address=disco_doc_address, policy=policy)
         )
-        if response.is_successful and not is_uncacheable(response.cache_control):
-            ttl = resolve_disco_ttl(response.cache_control)
-            _disco_cache[cache_key] = DiscoCacheEntry(
-                response=response, cached_at=time.time(), ttl=ttl
-            )
+        apply_disco_cache_outcome(_disco_cache, cache_key, response, time.time())
         return response
 
 
@@ -106,11 +101,7 @@ def _get_cached_jwks(jwks_uri: str) -> JwksResponse:
 
         # Fetch under lock to prevent cache stampede (single-flight refresh)
         response = get_jwks(JwksRequest(address=jwks_uri))
-        if response.is_successful and not is_uncacheable(response.cache_control):
-            ttl = resolve_ttl(response.cache_control)
-            _jwks_cache[jwks_uri] = JwksCacheEntry(
-                response=response, cached_at=time.time(), ttl=ttl
-            )
+        apply_jwks_cache_outcome(_jwks_cache, jwks_uri, response, time.time())
         return response
 
 
@@ -126,11 +117,7 @@ def _refresh_jwks(jwks_uri: str) -> JwksResponse:
 
         logger.info("Forcing JWKS refresh for %s (possible key rotation)", jwks_uri)
         response = get_jwks(JwksRequest(address=jwks_uri))
-        if response.is_successful and not is_uncacheable(response.cache_control):
-            ttl = resolve_ttl(response.cache_control)
-            _jwks_cache[jwks_uri] = JwksCacheEntry(
-                response=response, cached_at=time.time(), ttl=ttl
-            )
+        apply_jwks_cache_outcome(_jwks_cache, jwks_uri, response, time.time())
         return response
 
 

--- a/src/py_identity_model/sync/token_validation.py
+++ b/src/py_identity_model/sync/token_validation.py
@@ -16,6 +16,7 @@ from ..core.jwks_cache import (
     DiscoCacheEntry,
     JwksCacheEntry,
     is_cache_expired,
+    is_uncacheable,
     resolve_disco_ttl,
     resolve_ttl,
 )
@@ -75,10 +76,11 @@ def _get_disco_response(
         response = get_discovery_document(
             DiscoveryDocumentRequest(address=disco_doc_address, policy=policy)
         )
-        ttl = resolve_disco_ttl(response.cache_control)
-        _disco_cache[cache_key] = DiscoCacheEntry(
-            response=response, cached_at=time.time(), ttl=ttl
-        )
+        if response.is_successful and not is_uncacheable(response.cache_control):
+            ttl = resolve_disco_ttl(response.cache_control)
+            _disco_cache[cache_key] = DiscoCacheEntry(
+                response=response, cached_at=time.time(), ttl=ttl
+            )
         return response
 
 
@@ -104,10 +106,11 @@ def _get_cached_jwks(jwks_uri: str) -> JwksResponse:
 
         # Fetch under lock to prevent cache stampede (single-flight refresh)
         response = get_jwks(JwksRequest(address=jwks_uri))
-        ttl = resolve_ttl(response.cache_control)
-        _jwks_cache[jwks_uri] = JwksCacheEntry(
-            response=response, cached_at=time.time(), ttl=ttl
-        )
+        if response.is_successful and not is_uncacheable(response.cache_control):
+            ttl = resolve_ttl(response.cache_control)
+            _jwks_cache[jwks_uri] = JwksCacheEntry(
+                response=response, cached_at=time.time(), ttl=ttl
+            )
         return response
 
 
@@ -123,10 +126,11 @@ def _refresh_jwks(jwks_uri: str) -> JwksResponse:
 
         logger.info("Forcing JWKS refresh for %s (possible key rotation)", jwks_uri)
         response = get_jwks(JwksRequest(address=jwks_uri))
-        ttl = resolve_ttl(response.cache_control)
-        _jwks_cache[jwks_uri] = JwksCacheEntry(
-            response=response, cached_at=time.time(), ttl=ttl
-        )
+        if response.is_successful and not is_uncacheable(response.cache_control):
+            ttl = resolve_ttl(response.cache_control)
+            _jwks_cache[jwks_uri] = JwksCacheEntry(
+                response=response, cached_at=time.time(), ttl=ttl
+            )
         return response
 
 

--- a/src/py_identity_model/sync/token_validation.py
+++ b/src/py_identity_model/sync/token_validation.py
@@ -52,37 +52,66 @@ from .managed_client import HTTPClient
 
 # Discovery TTL cache — keyed by (address, require_https) to prevent policy bypass
 _disco_cache: dict[tuple[str, bool], DiscoCacheEntry] = {}
-_disco_cache_lock = threading.Lock()
+# Global lock used only for the brief cache write + eviction critical section.
+# It does NOT span the upstream HTTP fetch — see ``_get_disco_response`` for
+# the cache-aside pattern that lets fetches for distinct addresses proceed in
+# parallel rather than serializing on this single lock.
+_disco_cache_write_lock = threading.Lock()
+# Per-URI locks (striped) protect the fetch+populate critical section so two
+# requests for the same address coalesce into one upstream fetch, while two
+# requests for *different* addresses do not block each other.
+_DISCO_LOCK_STRIPES = 32
+_disco_fetch_locks: list[threading.Lock] = [
+    threading.Lock() for _ in range(_DISCO_LOCK_STRIPES)
+]
+
+
+def _get_disco_fetch_lock(cache_key: tuple[str, bool]) -> threading.Lock:
+    return _disco_fetch_locks[hash(cache_key) % _DISCO_LOCK_STRIPES]
 
 
 def _get_disco_response(
     disco_doc_address: str | None,
     require_https: bool = True,
 ) -> DiscoveryDocumentResponse:
-    """Cached discovery document fetching with TTL."""
+    """Cached discovery document fetching with TTL.
+
+    Uses cache-aside with per-URI single-flight: a fresh cached entry is
+    returned without any lock; only the upstream fetch on a cache miss is
+    serialized, and only against other requests for the same address.
+    """
     if disco_doc_address is None:
         raise ConfigurationException(
             "disco_doc_address is required when perform_disco is True"
         )
 
     cache_key = (disco_doc_address, require_https)
-    with _disco_cache_lock:
+    # Cheap atomic dict read — no lock required for a single .get() in CPython.
+    entry = _disco_cache.get(cache_key)
+    if entry is not None and not is_cache_expired(entry):
+        return entry.response
+
+    fetch_lock = _get_disco_fetch_lock(cache_key)
+    with fetch_lock:
+        # Re-check under the URI lock — another thread may have populated
+        # the entry while we waited.
         entry = _disco_cache.get(cache_key)
         if entry is not None and not is_cache_expired(entry):
             return entry.response
 
-        # Fetch under lock to prevent cache stampede (single-flight refresh)
         policy = DiscoveryPolicy(require_https=require_https)
         response = get_discovery_document(
             DiscoveryDocumentRequest(address=disco_doc_address, policy=policy)
         )
-        apply_disco_cache_outcome(_disco_cache, cache_key, response, time.time())
+        with _disco_cache_write_lock:
+            apply_disco_cache_outcome(_disco_cache, cache_key, response, time.time())
         return response
 
 
 def clear_discovery_cache() -> None:
     """Clear the discovery cache."""
-    _disco_cache.clear()
+    with _disco_cache_write_lock:
+        _disco_cache.clear()
 
 
 # ============================================================================
@@ -90,47 +119,71 @@ def clear_discovery_cache() -> None:
 # ============================================================================
 
 _jwks_cache: dict[str, JwksCacheEntry] = {}
-_jwks_cache_lock = threading.Lock()
+# See _disco_cache_write_lock — same factoring: brief CPU-only write lock,
+# per-URI fetch locks for the actual single-flight semantics.
+_jwks_cache_write_lock = threading.Lock()
+_JWKS_LOCK_STRIPES = 32
+_jwks_fetch_locks: list[threading.Lock] = [
+    threading.Lock() for _ in range(_JWKS_LOCK_STRIPES)
+]
 
 # Tracks the last time each jwks_uri was force-refreshed because of a kid
 # miss. Used by ``should_attempt_kid_miss_refresh`` to bound DoS amplification
-# from attacker-controlled JWT headers. Guarded by ``_jwks_cache_lock`` since
-# every mutation happens immediately adjacent to a cache mutation.
+# from attacker-controlled JWT headers. Guarded by ``_jwks_cache_write_lock``
+# since every mutation happens adjacent to a cache mutation.
 _kid_miss_last_attempt: dict[str, float] = {}
 
 
+def _get_jwks_fetch_lock(jwks_uri: str) -> threading.Lock:
+    return _jwks_fetch_locks[hash(jwks_uri) % _JWKS_LOCK_STRIPES]
+
+
 def _get_cached_jwks(jwks_uri: str) -> JwksResponse:
-    """Return cached JWKS response if fresh, otherwise fetch and cache."""
-    with _jwks_cache_lock:
+    """Return cached JWKS response if fresh, otherwise fetch and cache.
+
+    Cache-aside with per-URI single-flight (see ``_get_disco_response``).
+    """
+    entry = _jwks_cache.get(jwks_uri)
+    if entry is not None and not is_cache_expired(entry):
+        return entry.response
+
+    fetch_lock = _get_jwks_fetch_lock(jwks_uri)
+    with fetch_lock:
         entry = _jwks_cache.get(jwks_uri)
         if entry is not None and not is_cache_expired(entry):
             return entry.response
 
-        # Fetch under lock to prevent cache stampede (single-flight refresh)
         response = get_jwks(JwksRequest(address=jwks_uri))
-        apply_jwks_cache_outcome(_jwks_cache, jwks_uri, response, time.time())
+        with _jwks_cache_write_lock:
+            apply_jwks_cache_outcome(_jwks_cache, jwks_uri, response, time.time())
         return response
 
 
 def _refresh_jwks(jwks_uri: str) -> JwksResponse:
-    """Force re-fetch JWKS and update cache (key rotation)."""
+    """Force re-fetch JWKS and update cache (key rotation).
+
+    Uses the per-URI fetch lock to coalesce concurrent refresh requests for
+    the same URI while leaving unrelated URIs unblocked. The ``request_time``
+    guard catches the case where another caller for *this* URI completed a
+    refresh while we were blocked.
+    """
     request_time = time.time()
-    with _jwks_cache_lock:
-        # If another thread already refreshed while we waited on the lock,
-        # return the fresh entry to avoid redundant sequential fetches
+    fetch_lock = _get_jwks_fetch_lock(jwks_uri)
+    with fetch_lock:
         entry = _jwks_cache.get(jwks_uri)
         if entry is not None and entry.cached_at >= request_time:
             return entry.response
 
         logger.info("Forcing JWKS refresh for %s (possible key rotation)", jwks_uri)
         response = get_jwks(JwksRequest(address=jwks_uri))
-        apply_jwks_cache_outcome(_jwks_cache, jwks_uri, response, time.time())
+        with _jwks_cache_write_lock:
+            apply_jwks_cache_outcome(_jwks_cache, jwks_uri, response, time.time())
         return response
 
 
 def clear_jwks_cache() -> None:
     """Clear the JWKS cache. Useful for testing."""
-    with _jwks_cache_lock:
+    with _jwks_cache_write_lock:
         _jwks_cache.clear()
         _kid_miss_last_attempt.clear()
 
@@ -192,7 +245,7 @@ def _discover_and_resolve_key(
                 "kid %s not present in cached JWKS; refreshing (possible key rotation)",
                 kid,
             )
-            with _jwks_cache_lock:
+            with _jwks_cache_write_lock:
                 _kid_miss_last_attempt[jwks_uri] = time.time()
             jwks_response = _refresh_jwks(jwks_uri)
             validate_jwks_response(jwks_response)

--- a/src/py_identity_model/sync/token_validation.py
+++ b/src/py_identity_model/sync/token_validation.py
@@ -175,6 +175,16 @@ def _discover_and_resolve_key(
     jwks_response = _get_cached_jwks(jwks_uri)
     validate_jwks_response(jwks_response)
     kid, jwt_alg = extract_jwt_header_fields(jwt)
+    # OP key rotation: if the JWT's kid is not in the cached JWKS, the cache
+    # is stale. Force a refresh before lookup so rotation is handled without
+    # waiting for a signature failure on a key we don't have.
+    if kid is not None and not any(k.kid == kid for k in (jwks_response.keys or [])):
+        logger.info(
+            "kid %s not present in cached JWKS; refreshing (possible key rotation)",
+            kid,
+        )
+        jwks_response = _refresh_jwks(jwks_uri)
+        validate_jwks_response(jwks_response)
     key_dict, alg = find_key_by_kid(kid, jwks_response.keys or [], jwt_alg=jwt_alg)
     return key_dict, alg, disco_doc_response, True
 

--- a/src/py_identity_model/sync/token_validation.py
+++ b/src/py_identity_model/sync/token_validation.py
@@ -185,6 +185,10 @@ def _discover_and_resolve_key(
         )
         jwks_response = _refresh_jwks(jwks_uri)
         validate_jwks_response(jwks_response)
+        if not any(k.kid == kid for k in (jwks_response.keys or [])):
+            logger.warning(
+                "kid %s still absent after JWKS refresh of %s", kid, jwks_uri
+            )
     key_dict, alg = find_key_by_kid(kid, jwks_response.keys or [], jwt_alg=jwt_alg)
     return key_dict, alg, disco_doc_response, True
 

--- a/src/py_identity_model/sync/token_validation.py
+++ b/src/py_identity_model/sync/token_validation.py
@@ -18,6 +18,7 @@ from ..core.jwks_cache import (
     apply_disco_cache_outcome,
     apply_jwks_cache_outcome,
     is_cache_expired,
+    should_attempt_kid_miss_refresh,
 )
 from ..core.models import (
     DiscoveryDocumentRequest,
@@ -91,6 +92,12 @@ def clear_discovery_cache() -> None:
 _jwks_cache: dict[str, JwksCacheEntry] = {}
 _jwks_cache_lock = threading.Lock()
 
+# Tracks the last time each jwks_uri was force-refreshed because of a kid
+# miss. Used by ``should_attempt_kid_miss_refresh`` to bound DoS amplification
+# from attacker-controlled JWT headers. Guarded by ``_jwks_cache_lock`` since
+# every mutation happens immediately adjacent to a cache mutation.
+_kid_miss_last_attempt: dict[str, float] = {}
+
 
 def _get_cached_jwks(jwks_uri: str) -> JwksResponse:
     """Return cached JWKS response if fresh, otherwise fetch and cache."""
@@ -123,7 +130,9 @@ def _refresh_jwks(jwks_uri: str) -> JwksResponse:
 
 def clear_jwks_cache() -> None:
     """Clear the JWKS cache. Useful for testing."""
-    _jwks_cache.clear()
+    with _jwks_cache_lock:
+        _jwks_cache.clear()
+        _kid_miss_last_attempt.clear()
 
 
 # ============================================================================
@@ -168,17 +177,35 @@ def _discover_and_resolve_key(
     kid, jwt_alg = extract_jwt_header_fields(jwt)
     # OP key rotation: if the JWT's kid is not in the cached JWKS, the cache
     # is stale. Force a refresh before lookup so rotation is handled without
-    # waiting for a signature failure on a key we don't have.
-    if kid is not None and not any(k.kid == kid for k in (jwks_response.keys or [])):
-        logger.info(
-            "kid %s not present in cached JWKS; refreshing (possible key rotation)",
-            kid,
-        )
-        jwks_response = _refresh_jwks(jwks_uri)
-        validate_jwks_response(jwks_response)
-        if not any(k.kid == kid for k in (jwks_response.keys or [])):
-            logger.warning(
-                "kid %s still absent after JWKS refresh of %s", kid, jwks_uri
+    # waiting for a signature failure on a key we don't have. The cooldown
+    # gate prevents an unauthenticated attacker from amplifying inbound JWT
+    # traffic into upstream JWKS fetches by spamming random kids.
+    cached_keys = jwks_response.keys or []
+    if kid is not None and not any(k.kid == kid for k in cached_keys):
+        if should_attempt_kid_miss_refresh(
+            _kid_miss_last_attempt,
+            jwks_uri,
+            has_cached_keys=bool(cached_keys),
+            now=time.time(),
+        ):
+            logger.info(
+                "kid %s not present in cached JWKS; refreshing (possible key rotation)",
+                kid,
+            )
+            with _jwks_cache_lock:
+                _kid_miss_last_attempt[jwks_uri] = time.time()
+            jwks_response = _refresh_jwks(jwks_uri)
+            validate_jwks_response(jwks_response)
+            if not any(k.kid == kid for k in (jwks_response.keys or [])):
+                logger.warning(
+                    "kid %s still absent after JWKS refresh of %s", kid, jwks_uri
+                )
+        else:
+            logger.debug(
+                "kid %s not in cached JWKS for %s but refresh cooldown active; "
+                "falling through to no-matching-kid error",
+                kid,
+                jwks_uri,
             )
     key_dict, alg = find_key_by_kid(kid, jwks_response.keys or [], jwt_alg=jwt_alg)
     return key_dict, alg, disco_doc_response, True

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -35,6 +35,7 @@ from py_identity_model import (
     validate_authorize_callback_state,
 )
 from py_identity_model.core.discovery_policy import DiscoveryPolicy
+from py_identity_model.core.jwks_cache import is_uncacheable
 from py_identity_model.core.models import DiscoveryDocumentResponse
 from py_identity_model.core.parsers import (
     extract_kid_from_jwt,
@@ -212,6 +213,22 @@ def jwks_response(test_config):
     if not response.is_successful:
         pytest.fail(f"Failed to fetch JWKS: {response.error}")
     return response
+
+
+@pytest.fixture(scope="session")
+def provider_caches_responses(discovery_document, jwks_response):
+    """Whether the provider's Cache-Control allows the library to cache.
+
+    Per RFC 7234 §5.2.2.4-5, ``no-store`` and ``no-cache`` directives
+    instruct the client to skip caching. Some providers (e.g., Descope on
+    JWKS) set these directives, which means the library will (correctly)
+    re-fetch on every validation. Benchmarks that rely on caching should
+    skip when this fixture is False.
+    """
+    return not (
+        is_uncacheable(discovery_document.cache_control)
+        or is_uncacheable(jwks_response.cache_control)
+    )
 
 
 @pytest.fixture(scope="session")

--- a/src/tests/integration/test_token_validation.py
+++ b/src/tests/integration/test_token_validation.py
@@ -112,8 +112,15 @@ def test_cache_succeeds(test_config, client_credentials_token, require_https):
     # performance (5 validations complete without 5 separate HTTP round-trips).
 
 
-def test_benchmark_validation(test_config, client_credentials_token, require_https):
+def test_benchmark_validation(
+    test_config, client_credentials_token, require_https, provider_caches_responses
+):
     """Test benchmark using cached fixtures."""
+    if not provider_caches_responses:
+        pytest.skip(
+            "Provider sends Cache-Control: no-store/no-cache; "
+            "benchmark assumes caching is in effect"
+        )
     assert client_credentials_token.token is not None
     validation_config = TokenValidationConfig(
         perform_disco=True,

--- a/src/tests/integration/test_token_validation_cache.py
+++ b/src/tests/integration/test_token_validation_cache.py
@@ -189,7 +189,11 @@ class TestBenchmarkWithPreGeneratedTokens:
     """
 
     def test_benchmark_with_multiple_unique_tokens(
-        self, test_config, token_endpoint, validation_config
+        self,
+        test_config,
+        token_endpoint,
+        validation_config,
+        provider_caches_responses,
     ):
         """
         Benchmark validation with multiple unique tokens.
@@ -200,6 +204,11 @@ class TestBenchmarkWithPreGeneratedTokens:
         3. Ensures the benchmark reflects real-world usage where
            different tokens are validated
         """
+        if not provider_caches_responses:
+            pytest.skip(
+                "Provider sends Cache-Control: no-store/no-cache; "
+                "benchmark assumes caching is in effect"
+            )
         num_unique_tokens = 5
         tokens = generate_tokens(test_config, token_endpoint, num_unique_tokens)
 
@@ -241,6 +250,7 @@ class TestBenchmarkWithPreGeneratedTokens:
         test_config,
         client_credentials_token,
         validation_config,
+        provider_caches_responses,
     ):
         """
         Benchmark validation of a single token repeated many times.
@@ -248,6 +258,11 @@ class TestBenchmarkWithPreGeneratedTokens:
         This represents the optimal caching scenario where the same
         token is validated repeatedly (e.g., during its lifetime).
         """
+        if not provider_caches_responses:
+            pytest.skip(
+                "Provider sends Cache-Control: no-store/no-cache; "
+                "benchmark assumes caching is in effect"
+            )
         token = client_credentials_token.token["access_token"]
 
         # Warm up

--- a/src/tests/unit/test_aio_token_validation.py
+++ b/src/tests/unit/test_aio_token_validation.py
@@ -6,6 +6,7 @@ error handling, TTL-based JWKS caching, signature retry on key rotation,
 and enhanced features (leeway, multi-issuer, subject).
 """
 
+import contextlib
 import time
 from unittest.mock import patch
 
@@ -268,6 +269,68 @@ class TestAsyncSignatureRetry:
             audience=None,
             issuer="https://example.com",
         )
+
+        decoded = await validate_token(
+            jwt=token,
+            token_validation_config=config,
+            disco_doc_address="https://example.com/.well-known/openid-configuration",
+        )
+
+        assert decoded["sub"] == "user1"
+        assert jwks_route.call_count == JWKS_FETCH_WITH_RETRY
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_cached_path_refreshes_jwks_when_kid_not_in_cache(self):
+        """Cached JWKS lookup with a kid not in cache forces a refresh.
+
+        OIDC OPs rotate signing keys; when a token arrives with a kid that is
+        not yet in the cached JWKS, the cache is stale. The library must
+        refresh JWKS without waiting for a signature failure on a key it
+        does not have.
+        """
+        old_key_dict, _ = generate_rsa_keypair()
+        old_key_dict["kid"] = "old-kid"
+
+        new_key_dict, new_pem = generate_rsa_keypair()
+        new_key_dict["kid"] = "new-kid"
+
+        token = sign_jwt(
+            new_pem,
+            {"sub": "user1", "iss": "https://example.com"},
+            headers={"kid": "new-kid"},
+        )
+
+        respx.get("https://example.com/.well-known/openid-configuration").mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+        jwks_route = respx.get("https://example.com/jwks").mock(
+            side_effect=[
+                httpx.Response(200, json={"keys": [old_key_dict]}),
+                httpx.Response(200, json={"keys": [new_key_dict]}),
+            ]
+        )
+
+        config = TokenValidationConfig(
+            perform_disco=True,
+            audience=None,
+            issuer="https://example.com",
+        )
+
+        # Prime the cache with the old kid.
+        old_pem_token = sign_jwt(
+            generate_rsa_keypair()[1],
+            {"sub": "warmup"},
+            headers={"kid": "old-kid"},
+        )
+        with contextlib.suppress(
+            SignatureVerificationException, TokenValidationException
+        ):
+            await validate_token(
+                jwt=old_pem_token,
+                token_validation_config=config,
+                disco_doc_address="https://example.com/.well-known/openid-configuration",
+            )
 
         decoded = await validate_token(
             jwt=token,

--- a/src/tests/unit/test_aio_token_validation.py
+++ b/src/tests/unit/test_aio_token_validation.py
@@ -6,7 +6,6 @@ error handling, TTL-based JWKS caching, signature retry on key rotation,
 and enhanced features (leeway, multi-issuer, subject).
 """
 
-import contextlib
 import time
 from unittest.mock import patch
 
@@ -16,6 +15,7 @@ import respx
 
 from py_identity_model.aio.managed_client import AsyncHTTPClient
 from py_identity_model.aio.token_validation import (
+    _get_cached_jwks,
     clear_discovery_cache,
     clear_jwks_cache,
     validate_token,
@@ -242,7 +242,7 @@ class TestAsyncSignatureRetry:
     @respx.mock
     async def test_signature_retry_on_key_rotation(self):
         """When signature fails with cached key, refresh JWKS and retry with new key."""
-        old_key_dict, _old_pem = generate_rsa_keypair()
+        old_key_dict = generate_rsa_keypair()[0]
         old_key_dict["kid"] = "rotated-key"
 
         new_key_dict, new_pem = generate_rsa_keypair()
@@ -289,7 +289,7 @@ class TestAsyncSignatureRetry:
         refresh JWKS without waiting for a signature failure on a key it
         does not have.
         """
-        old_key_dict, _ = generate_rsa_keypair()
+        old_key_dict = generate_rsa_keypair()[0]
         old_key_dict["kid"] = "old-kid"
 
         new_key_dict, new_pem = generate_rsa_keypair()
@@ -317,20 +317,9 @@ class TestAsyncSignatureRetry:
             issuer="https://example.com",
         )
 
-        # Prime the cache with the old kid.
-        old_pem_token = sign_jwt(
-            generate_rsa_keypair()[1],
-            {"sub": "warmup"},
-            headers={"kid": "old-kid"},
-        )
-        with contextlib.suppress(
-            SignatureVerificationException, TokenValidationException
-        ):
-            await validate_token(
-                jwt=old_pem_token,
-                token_validation_config=config,
-                disco_doc_address="https://example.com/.well-known/openid-configuration",
-            )
+        # Prime the JWKS cache directly with the old kid (no validate_token, so
+        # the legacy retry path can't accidentally satisfy the assertion below).
+        await _get_cached_jwks("https://example.com/jwks")
 
         decoded = await validate_token(
             jwt=token,
@@ -339,15 +328,66 @@ class TestAsyncSignatureRetry:
         )
 
         assert decoded["sub"] == "user1"
+        # Now the second fetch can ONLY have come from the new kid-miss refresh
+        # path inside _discover_and_resolve_key (legacy retry never gets a chance
+        # because validate_token only ran once, and the kid was missing pre-decode).
         assert jwks_route.call_count == JWKS_FETCH_WITH_RETRY
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_no_refresh_when_kid_present_in_cache(self):
+        """Negative regression: when kid IS in cached JWKS, no refresh is issued.
+
+        Pins the predicate sense in the kid-miss check. A future change that
+        flipped `not any(...)` to `any(...)` would silently regress to
+        refreshing JWKS on every request.
+        """
+        key_dict, pem = generate_rsa_keypair()
+        key_dict["kid"] = "present-kid"
+
+        respx.get("https://example.com/.well-known/openid-configuration").mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+        jwks_route = respx.get("https://example.com/jwks").mock(
+            return_value=httpx.Response(200, json={"keys": [key_dict]})
+        )
+
+        token = sign_jwt(
+            pem,
+            {"sub": "user1", "iss": "https://example.com"},
+            headers={"kid": "present-kid"},
+        )
+        config = TokenValidationConfig(
+            perform_disco=True, audience=None, issuer="https://example.com"
+        )
+
+        # First call primes the cache (1 fetch).
+        await validate_token(
+            jwt=token,
+            token_validation_config=config,
+            disco_doc_address="https://example.com/.well-known/openid-configuration",
+        )
+        assert jwks_route.call_count == 1
+
+        for _ in range(10):
+            await validate_token(
+                jwt=token,
+                token_validation_config=config,
+                disco_doc_address="https://example.com/.well-known/openid-configuration",
+            )
+
+        assert jwks_route.call_count == 1, (
+            f"Predicate regression: {jwks_route.call_count} fetches for 11 "
+            f"validations with cached kid (expected 1)"
+        )
 
     @pytest.mark.asyncio
     @respx.mock
     async def test_signature_failure_still_raises_after_retry(self):
         """When signature fails with both old and new keys, exception is raised."""
-        wrong_key1, _ = generate_rsa_keypair()
+        wrong_key1 = generate_rsa_keypair()[0]
         wrong_key1["kid"] = "wrong-key"
-        wrong_key2, _ = generate_rsa_keypair()
+        wrong_key2 = generate_rsa_keypair()[0]
         wrong_key2["kid"] = "wrong-key"
 
         _, signing_pem = generate_rsa_keypair()
@@ -384,7 +424,7 @@ class TestAsyncSignatureRetry:
     @respx.mock
     async def test_di_path_retries_on_signature_failure(self):
         """DI (injected client) path retries JWKS fetch for key rotation support."""
-        wrong_key, _ = generate_rsa_keypair()
+        wrong_key = generate_rsa_keypair()[0]
         wrong_key["kid"] = "wrong-key"
 
         _, signing_pem = generate_rsa_keypair()

--- a/src/tests/unit/test_cache_env_and_bounds.py
+++ b/src/tests/unit/test_cache_env_and_bounds.py
@@ -1,0 +1,262 @@
+"""
+Proves the JWKS/discovery cache rejects unsafe env config and bounds memory.
+
+Two pre-existing structural bugs the cache primitive shipped with:
+
+1. **Env-provided TTL was not clamped.** ``JWKS_CACHE_TTL=0`` silently
+   disabled the cache (every entry instantly expired → refetch on every
+   validation → DoS amplifier). ``JWKS_CACHE_TTL=2592000`` silently
+   disabled the documented 24h ceiling on key-rotation latency. Garbage
+   values raised ``ValueError`` at first cache access — process crash on
+   bad config rather than fail-fast at import.
+
+2. **Cache dicts grew without bound.** Any deployment with caller-influenced
+   ``disco_doc_address`` (multi-tenant gateways, attacker-supplied issuer
+   headers) could grow the dict forever. At ~5KB per entry, a few thousand
+   unique addresses leaked tens of MB.
+
+These tests pin the fixes:
+- TTL env values clamped to [MIN, MAX]; garbage falls back to default.
+- Cache size capped at ``JWKS_CACHE_MAX_ENTRIES`` (default 64).
+- FIFO eviction targets the oldest entry, not the newest or a random one.
+- Re-storing a URI (refresh) moves it to "newest" so subsequent eviction
+  doesn't target a just-refreshed entry.
+"""
+
+import time
+
+import httpx
+import pytest
+import respx
+
+from py_identity_model.core.jwks_cache import (
+    DEFAULT_DISCO_CACHE_TTL_SECONDS,
+    DEFAULT_JWKS_CACHE_TTL_SECONDS,
+    DEFAULT_MAX_CACHE_ENTRIES,
+    MAX_CACHE_TTL_SECONDS,
+    MIN_CACHE_TTL_SECONDS,
+    JwksCacheEntry,
+    _reset_env_for_testing,
+    apply_jwks_cache_outcome,
+    get_max_cache_entries,
+    resolve_disco_ttl,
+    resolve_ttl,
+)
+from py_identity_model.core.models import JsonWebKey, JwksResponse
+from py_identity_model.sync import token_validation as sync_tv
+from py_identity_model.sync.token_validation import (
+    _get_cached_jwks,
+    clear_discovery_cache,
+    clear_jwks_cache,
+)
+
+from .token_validation_helpers import generate_rsa_keypair
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    clear_discovery_cache()
+    clear_jwks_cache()
+    _reset_env_for_testing()
+    yield
+    clear_discovery_cache()
+    clear_jwks_cache()
+    _reset_env_for_testing()
+
+
+# ============================================================================
+# TTL env clamping: zero, negative, overflow, and garbage must not break
+# the documented invariants.
+# ============================================================================
+
+JWKS_TTL_CLAMP_CASES = [
+    pytest.param("0", MIN_CACHE_TTL_SECONDS, id="zero-clamped-to-min"),
+    pytest.param("-5", MIN_CACHE_TTL_SECONDS, id="negative-clamped-to-min"),
+    pytest.param("30", MIN_CACHE_TTL_SECONDS, id="below-min-clamped-up"),
+    pytest.param("60", MIN_CACHE_TTL_SECONDS, id="at-min-preserved"),
+    pytest.param("3600", 3600.0, id="middle-passthrough"),
+    pytest.param("86400", MAX_CACHE_TTL_SECONDS, id="at-max-preserved"),
+    pytest.param("999999", MAX_CACHE_TTL_SECONDS, id="above-max-clamped-down"),
+    pytest.param("2592000", MAX_CACHE_TTL_SECONDS, id="month-clamped-down"),
+]
+
+
+class TestEnvTtlClamping:
+    @pytest.mark.parametrize(("env_value", "expected"), JWKS_TTL_CLAMP_CASES)
+    def test_jwks_ttl_env_clamped(self, env_value, expected, monkeypatch):
+        """resolve_ttl(None) reads the env path; values outside [MIN, MAX]
+        must be clamped to the documented bounds, not honored raw."""
+        monkeypatch.setenv("JWKS_CACHE_TTL", env_value)
+        _reset_env_for_testing()
+        assert resolve_ttl(None) == expected
+
+    @pytest.mark.parametrize(("env_value", "expected"), JWKS_TTL_CLAMP_CASES)
+    def test_disco_ttl_env_clamped(self, env_value, expected, monkeypatch):
+        monkeypatch.setenv("DISCO_CACHE_TTL", env_value)
+        _reset_env_for_testing()
+        assert resolve_disco_ttl(None) == expected
+
+    def test_garbage_jwks_ttl_falls_back_to_default(self, monkeypatch):
+        """Malformed env must not crash the process; a warning + default is
+        the correct fail-safe."""
+        monkeypatch.setenv("JWKS_CACHE_TTL", "60s")
+        _reset_env_for_testing()
+        assert resolve_ttl(None) == DEFAULT_JWKS_CACHE_TTL_SECONDS
+
+    def test_empty_jwks_ttl_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("JWKS_CACHE_TTL", "")
+        _reset_env_for_testing()
+        assert resolve_ttl(None) == DEFAULT_JWKS_CACHE_TTL_SECONDS
+
+    def test_garbage_disco_ttl_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("DISCO_CACHE_TTL", "not-a-number")
+        _reset_env_for_testing()
+        assert resolve_disco_ttl(None) == DEFAULT_DISCO_CACHE_TTL_SECONDS
+
+    def test_unset_jwks_ttl_uses_default(self, monkeypatch):
+        monkeypatch.delenv("JWKS_CACHE_TTL", raising=False)
+        _reset_env_for_testing()
+        assert resolve_ttl(None) == DEFAULT_JWKS_CACHE_TTL_SECONDS
+
+
+# ============================================================================
+# Bounded cache: size capped, FIFO eviction targets oldest entry.
+# ============================================================================
+
+
+def _make_jwks_response(kid: str) -> JwksResponse:
+    """Build a successful, cacheable JWKS response carrying a single key."""
+    key_dict, _ = generate_rsa_keypair()
+    key_dict["kid"] = kid
+    jwk = JsonWebKey(
+        kty=key_dict["kty"],
+        kid=key_dict["kid"],
+        alg=key_dict["alg"],
+        use=key_dict["use"],
+        n=key_dict["n"],
+        e=key_dict["e"],
+    )
+    return JwksResponse(
+        is_successful=True,
+        keys=[jwk],
+        cache_control="max-age=3600",
+    )
+
+
+class TestBoundedCacheSize:
+    def test_max_entries_env_override(self, monkeypatch):
+        monkeypatch.setenv("JWKS_CACHE_MAX_ENTRIES", "8")
+        _reset_env_for_testing()
+        assert get_max_cache_entries() == 8  # noqa: PLR2004
+
+    def test_max_entries_default_when_unset(self, monkeypatch):
+        monkeypatch.delenv("JWKS_CACHE_MAX_ENTRIES", raising=False)
+        _reset_env_for_testing()
+        assert get_max_cache_entries() == DEFAULT_MAX_CACHE_ENTRIES
+
+    def test_max_entries_falls_back_on_garbage(self, monkeypatch):
+        monkeypatch.setenv("JWKS_CACHE_MAX_ENTRIES", "abc")
+        _reset_env_for_testing()
+        assert get_max_cache_entries() == DEFAULT_MAX_CACHE_ENTRIES
+
+    def test_max_entries_falls_back_on_non_positive(self, monkeypatch):
+        monkeypatch.setenv("JWKS_CACHE_MAX_ENTRIES", "0")
+        _reset_env_for_testing()
+        assert get_max_cache_entries() == DEFAULT_MAX_CACHE_ENTRIES
+
+    def test_jwks_cache_size_capped_under_overflow(self, monkeypatch):
+        """Insert max+5 distinct URIs into the cache via the apply helper —
+        post-insert the cache holds exactly ``max`` entries."""
+        monkeypatch.setenv("JWKS_CACHE_MAX_ENTRIES", "5")
+        _reset_env_for_testing()
+        cache: dict[str, JwksCacheEntry] = {}
+
+        for i in range(10):
+            apply_jwks_cache_outcome(
+                cache,
+                jwks_uri=f"https://op-{i}.example/jwks",
+                response=_make_jwks_response(f"kid-{i}"),
+                now=time.time(),
+            )
+
+        assert len(cache) == 5  # noqa: PLR2004
+        # FIFO eviction: the *oldest* 5 inserts are gone, *newest* 5 remain.
+        remaining_uris = set(cache.keys())
+        expected_uris = {f"https://op-{i}.example/jwks" for i in range(5, 10)}
+        assert remaining_uris == expected_uris
+
+    def test_refresh_of_existing_uri_does_not_count_as_new_entry(self, monkeypatch):
+        """Re-storing a URI must move it to the end of insertion order so
+        a subsequent overflow doesn't immediately evict a just-refreshed
+        entry. This is the difference between OK-FIFO and broken-FIFO."""
+        monkeypatch.setenv("JWKS_CACHE_MAX_ENTRIES", "3")
+        _reset_env_for_testing()
+        cache: dict[str, JwksCacheEntry] = {}
+
+        # Fill to capacity in known order.
+        for i in range(3):
+            apply_jwks_cache_outcome(
+                cache,
+                jwks_uri=f"https://op-{i}.example/jwks",
+                response=_make_jwks_response(f"kid-{i}"),
+                now=time.time(),
+            )
+        assert list(cache.keys()) == [
+            "https://op-0.example/jwks",
+            "https://op-1.example/jwks",
+            "https://op-2.example/jwks",
+        ]
+
+        # Refresh op-0 (the oldest). It should move to the newest position.
+        apply_jwks_cache_outcome(
+            cache,
+            jwks_uri="https://op-0.example/jwks",
+            response=_make_jwks_response("kid-0-rotated"),
+            now=time.time(),
+        )
+        assert list(cache.keys()) == [
+            "https://op-1.example/jwks",
+            "https://op-2.example/jwks",
+            "https://op-0.example/jwks",
+        ]
+
+        # Add a fourth distinct URI. Eviction should now target op-1 (the
+        # oldest non-refreshed), not the just-refreshed op-0.
+        apply_jwks_cache_outcome(
+            cache,
+            jwks_uri="https://op-3.example/jwks",
+            response=_make_jwks_response("kid-3"),
+            now=time.time(),
+        )
+        assert set(cache.keys()) == {
+            "https://op-2.example/jwks",
+            "https://op-0.example/jwks",
+            "https://op-3.example/jwks",
+        }
+
+    @respx.mock
+    def test_end_to_end_jwks_cache_capped(self, monkeypatch):
+        """End-to-end via _get_cached_jwks: hammering N+5 unique URIs from
+        the real call site enforces the same bound as the apply helper
+        directly. Catches any path that bypasses _enforce_size_limit."""
+        monkeypatch.setenv("JWKS_CACHE_MAX_ENTRIES", "4")
+        _reset_env_for_testing()
+
+        urls_to_visit = [f"https://op-{i}.example/jwks" for i in range(9)]
+        key_dict, _ = generate_rsa_keypair()
+        for url in urls_to_visit:
+            respx.get(url).mock(
+                return_value=httpx.Response(
+                    200,
+                    json={"keys": [key_dict]},
+                    headers={"Cache-Control": "max-age=3600"},
+                )
+            )
+
+        for url in urls_to_visit:
+            response = _get_cached_jwks(url)
+            assert response.is_successful is True
+
+        assert len(sync_tv._jwks_cache) == 4  # noqa: PLR2004
+        # Newest four URIs are the survivors.
+        assert set(sync_tv._jwks_cache.keys()) == set(urls_to_visit[-4:])

--- a/src/tests/unit/test_cache_http_headers.py
+++ b/src/tests/unit/test_cache_http_headers.py
@@ -312,3 +312,306 @@ class TestAsyncNoCacheRefetched:
 
         assert (DISCO_URL, True) not in aio_tv._disco_cache
         assert disco_route.call_count == 3  # noqa: PLR2004
+
+
+# ============================================================================
+# Refresh-time invalidation: when a refresh response is uncacheable, the
+# existing (potentially stale) cache entry must be POPPED, not left in place.
+#
+# Otherwise a key-rotation event against a provider that sends
+# ``no-store``/``no-cache`` (Descope, others) leaves the stale entry live
+# for the remainder of its 24h TTL. Every subsequent validation hits the
+# stale entry, triggers another _refresh_jwks, and pounds the upstream JWKS
+# endpoint — the exact DoS the cache exists to prevent.
+# ============================================================================
+
+
+def _key_with_kid(kid: str) -> dict:
+    key_dict, _ = generate_rsa_keypair()
+    return {**key_dict, "kid": kid}
+
+
+def _kids(response) -> set[str]:
+    return {k.kid for k in (response.keys or [])}
+
+
+REFRESH_UNCACHEABLE_TEST_CASES = [
+    pytest.param("no-store", id="no-store"),
+    pytest.param("no-cache", id="no-cache"),
+    pytest.param("no-store, max-age=3600", id="no-store-with-max-age"),
+    pytest.param("no-cache, max-age=3600", id="no-cache-with-max-age"),
+]
+
+
+class TestSyncRefreshInvalidatesStaleOnUncacheable:
+    @pytest.mark.parametrize("uncacheable_header", REFRESH_UNCACHEABLE_TEST_CASES)
+    @respx.mock
+    def test_refresh_pops_stale_entry_when_response_uncacheable(
+        self, uncacheable_header: str
+    ):
+        old_key = _key_with_kid("old-kid")
+        new_key = _key_with_kid("new-kid")
+        call_log: list[int] = []
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            call_log.append(1)
+            if len(call_log) == 1:
+                return httpx.Response(
+                    200,
+                    json={"keys": [old_key]},
+                    headers={"Cache-Control": "max-age=3600"},
+                )
+            return httpx.Response(
+                200,
+                json={"keys": [new_key]},
+                headers={"Cache-Control": uncacheable_header},
+            )
+
+        respx.get(JWKS_URL).mock(side_effect=handler)
+
+        primed = _get_cached_jwks(JWKS_URL)
+        assert primed.is_successful is True
+        assert JWKS_URL in sync_tv._jwks_cache
+        assert _kids(sync_tv._jwks_cache[JWKS_URL].response) == {"old-kid"}
+
+        refreshed = sync_tv._refresh_jwks(JWKS_URL)
+        assert refreshed.is_successful is True
+        # Fresh response is returned to the caller …
+        assert _kids(refreshed) == {"new-kid"}
+        # … but the stale entry MUST be popped, not left behind.
+        assert JWKS_URL not in sync_tv._jwks_cache
+
+    @pytest.mark.parametrize("uncacheable_header", REFRESH_UNCACHEABLE_TEST_CASES)
+    @respx.mock
+    def test_disco_pops_expired_entry_when_response_uncacheable(
+        self, uncacheable_header: str
+    ):
+        """Disco has no _refresh equivalent, but expired entries still need
+        the pop semantics: when re-fetching past TTL yields an uncacheable
+        response, the expired entry must not linger in the dict (memory
+        hygiene + cleanliness for the cache-size bound landing in a
+        follow-up commit)."""
+        rotated_disco = {
+            **DISCO_RESPONSE_WITH_JWKS,
+            "issuer": "https://rotated.example",
+        }
+        call_log: list[int] = []
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            call_log.append(1)
+            if len(call_log) == 1:
+                return httpx.Response(
+                    200,
+                    json=DISCO_RESPONSE_WITH_JWKS,
+                    headers={"Cache-Control": "max-age=3600"},
+                )
+            return httpx.Response(
+                200,
+                json=rotated_disco,
+                headers={"Cache-Control": uncacheable_header},
+            )
+
+        respx.get(DISCO_URL).mock(side_effect=handler)
+
+        primed = _get_disco_response(DISCO_URL)
+        assert primed.is_successful is True
+        cache_key = (DISCO_URL, True)
+        assert cache_key in sync_tv._disco_cache
+
+        # Manually expire the entry without removing it — this is the state
+        # the cache lands in when the entry's TTL elapses naturally.
+        stale_entry = sync_tv._disco_cache[cache_key]
+        sync_tv._disco_cache[cache_key] = type(stale_entry)(
+            response=stale_entry.response, cached_at=0.0, ttl=stale_entry.ttl
+        )
+
+        _get_disco_response(DISCO_URL)
+        # The expired entry must be popped, not left as dead weight.
+        assert cache_key not in sync_tv._disco_cache
+
+
+class TestAsyncRefreshInvalidatesStaleOnUncacheable:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("uncacheable_header", REFRESH_UNCACHEABLE_TEST_CASES)
+    @respx.mock
+    async def test_refresh_pops_stale_entry_when_response_uncacheable_async(
+        self, uncacheable_header: str
+    ):
+        old_key = _key_with_kid("old-kid")
+        new_key = _key_with_kid("new-kid")
+        call_log: list[int] = []
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            call_log.append(1)
+            if len(call_log) == 1:
+                return httpx.Response(
+                    200,
+                    json={"keys": [old_key]},
+                    headers={"Cache-Control": "max-age=3600"},
+                )
+            return httpx.Response(
+                200,
+                json={"keys": [new_key]},
+                headers={"Cache-Control": uncacheable_header},
+            )
+
+        respx.get(JWKS_URL).mock(side_effect=handler)
+
+        primed = await async_get_cached_jwks(JWKS_URL)
+        assert primed.is_successful is True
+        assert JWKS_URL in aio_tv._jwks_cache
+        assert _kids(aio_tv._jwks_cache[JWKS_URL].response) == {"old-kid"}
+
+        refreshed = await aio_tv._refresh_jwks(JWKS_URL)
+        assert refreshed.is_successful is True
+        assert _kids(refreshed) == {"new-kid"}
+        assert JWKS_URL not in aio_tv._jwks_cache
+
+
+# ============================================================================
+# Empty-keys responses must never replace a populated cache entry, and must
+# not be stored from a fresh fetch either. An empty ``keys: []`` from the
+# provider is treated as a transient upstream blip — never a valid replacement.
+# Without this guard, a transient empty-200 response from the OP poisons the
+# cache for up to 24h, breaking every token validation in the deployment.
+# ============================================================================
+
+
+class TestSyncEmptyKeysNotCached:
+    @respx.mock
+    def test_refresh_with_empty_keys_retains_existing_entry(self):
+        old_key = _key_with_kid("retained-kid")
+        call_log: list[int] = []
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            call_log.append(1)
+            if len(call_log) == 1:
+                return httpx.Response(
+                    200,
+                    json={"keys": [old_key]},
+                    headers={"Cache-Control": "max-age=3600"},
+                )
+            return httpx.Response(
+                200,
+                json={"keys": []},
+                headers={"Cache-Control": "max-age=3600"},
+            )
+
+        respx.get(JWKS_URL).mock(side_effect=handler)
+
+        primed = _get_cached_jwks(JWKS_URL)
+        assert primed.is_successful is True
+
+        refreshed = sync_tv._refresh_jwks(JWKS_URL)
+        # The empty response is returned to the caller (no lying about what
+        # the upstream sent), but the cache retains the last-known-good keys.
+        assert refreshed.is_successful is True
+        assert refreshed.keys == []
+        assert JWKS_URL in sync_tv._jwks_cache
+        assert _kids(sync_tv._jwks_cache[JWKS_URL].response) == {"retained-kid"}
+
+    @respx.mock
+    def test_initial_fetch_with_empty_keys_not_cached(self):
+        respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={"keys": []},
+                headers={"Cache-Control": "max-age=3600"},
+            )
+        )
+
+        response = _get_cached_jwks(JWKS_URL)
+        assert response.is_successful is True
+        assert response.keys == []
+        # Empty-keys responses are never stored, so a subsequent call must
+        # re-fetch rather than serve a poisoned entry.
+        assert JWKS_URL not in sync_tv._jwks_cache
+
+
+class TestAsyncEmptyKeysNotCached:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_refresh_with_empty_keys_retains_existing_entry_async(self):
+        old_key = _key_with_kid("retained-kid")
+        call_log: list[int] = []
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            call_log.append(1)
+            if len(call_log) == 1:
+                return httpx.Response(
+                    200,
+                    json={"keys": [old_key]},
+                    headers={"Cache-Control": "max-age=3600"},
+                )
+            return httpx.Response(
+                200,
+                json={"keys": []},
+                headers={"Cache-Control": "max-age=3600"},
+            )
+
+        respx.get(JWKS_URL).mock(side_effect=handler)
+
+        await async_get_cached_jwks(JWKS_URL)
+        refreshed = await aio_tv._refresh_jwks(JWKS_URL)
+        assert refreshed.is_successful is True
+        assert refreshed.keys == []
+        assert JWKS_URL in aio_tv._jwks_cache
+        assert _kids(aio_tv._jwks_cache[JWKS_URL].response) == {"retained-kid"}
+
+
+# ============================================================================
+# Network errors must never replace a populated cache entry (retain-on-error,
+# mirroring jose4j's setRetainCacheOnErrorDuration semantics). Combined with
+# the existing "failed responses not cached" tests above, this proves the
+# full failure-mode matrix: success+cacheable=write, success+uncacheable=pop,
+# success+empty=retain, failed=retain.
+# ============================================================================
+
+
+class TestRetainOnError:
+    @respx.mock
+    def test_sync_refresh_failure_retains_existing_entry(self):
+        old_key = _key_with_kid("retained-kid")
+        call_log: list[int] = []
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            call_log.append(1)
+            if len(call_log) == 1:
+                return httpx.Response(
+                    200,
+                    json={"keys": [old_key]},
+                    headers={"Cache-Control": "max-age=3600"},
+                )
+            return httpx.Response(404, text="not found")
+
+        respx.get(JWKS_URL).mock(side_effect=handler)
+
+        _get_cached_jwks(JWKS_URL)
+        refreshed = sync_tv._refresh_jwks(JWKS_URL)
+        assert refreshed.is_successful is False
+        assert JWKS_URL in sync_tv._jwks_cache
+        assert _kids(sync_tv._jwks_cache[JWKS_URL].response) == {"retained-kid"}
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_async_refresh_failure_retains_existing_entry(self):
+        old_key = _key_with_kid("retained-kid")
+        call_log: list[int] = []
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            call_log.append(1)
+            if len(call_log) == 1:
+                return httpx.Response(
+                    200,
+                    json={"keys": [old_key]},
+                    headers={"Cache-Control": "max-age=3600"},
+                )
+            return httpx.Response(404, text="not found")
+
+        respx.get(JWKS_URL).mock(side_effect=handler)
+
+        await async_get_cached_jwks(JWKS_URL)
+        refreshed = await aio_tv._refresh_jwks(JWKS_URL)
+        assert refreshed.is_successful is False
+        assert JWKS_URL in aio_tv._jwks_cache
+        assert _kids(aio_tv._jwks_cache[JWKS_URL].response) == {"retained-kid"}

--- a/src/tests/unit/test_cache_http_headers.py
+++ b/src/tests/unit/test_cache_http_headers.py
@@ -1,0 +1,315 @@
+"""
+Tests for HTTP cache header semantics in JWKS and discovery caches.
+
+Covers three correctness fixes:
+1. Failed JWKS/discovery responses must not be cached (a transient 5xx or
+   network error would otherwise poison the cache for up to 24h).
+2. ``Cache-Control: no-store`` must not be cached at all (RFC 7234 §5.2.2.5).
+3. ``Cache-Control: no-cache`` must always re-fetch (RFC 7234 §5.2.2.4) —
+   simplest correct behavior is to skip caching.
+"""
+
+import httpx
+import pytest
+import respx
+
+from py_identity_model.aio import token_validation as aio_tv
+from py_identity_model.aio.token_validation import (
+    _get_cached_jwks as async_get_cached_jwks,
+)
+from py_identity_model.aio.token_validation import (
+    _get_disco_response as async_get_disco_response,
+)
+from py_identity_model.aio.token_validation import (
+    clear_discovery_cache as async_clear_discovery_cache,
+)
+from py_identity_model.aio.token_validation import (
+    clear_jwks_cache as async_clear_jwks_cache,
+)
+from py_identity_model.sync import token_validation as sync_tv
+from py_identity_model.sync.token_validation import (
+    _get_cached_jwks,
+    _get_disco_response,
+    clear_discovery_cache,
+    clear_jwks_cache,
+)
+
+from .token_validation_helpers import (
+    DISCO_RESPONSE_WITH_JWKS,
+    generate_rsa_keypair,
+)
+
+
+DISCO_URL = "https://example.com/.well-known/openid-configuration"
+JWKS_URL = "https://example.com/jwks"
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    clear_discovery_cache()
+    clear_jwks_cache()
+    async_clear_discovery_cache()
+    async_clear_jwks_cache()
+    yield
+    clear_discovery_cache()
+    clear_jwks_cache()
+    async_clear_discovery_cache()
+    async_clear_jwks_cache()
+
+
+# ============================================================================
+# Failed responses must not be cached
+# ============================================================================
+
+
+class TestSyncFailedResponseNotCached:
+    @respx.mock
+    def test_jwks_failure_then_success_refetches(self):
+        """A transient JWKS failure must not poison the cache.
+
+        Uses 404 to bypass the HTTP client's built-in 5xx retry behavior
+        and isolate the cache-layer policy: ``is_successful=False`` must
+        never be cached, regardless of the upstream status code.
+        """
+        key_dict = generate_rsa_keypair()[0]
+        call_log: list[int] = []
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            call_log.append(1)
+            if len(call_log) == 1:
+                return httpx.Response(404, text="not found")
+            return httpx.Response(200, json={"keys": [key_dict]})
+
+        respx.get(JWKS_URL).mock(side_effect=handler)
+
+        failed = _get_cached_jwks(JWKS_URL)
+        assert failed.is_successful is False
+        assert JWKS_URL not in sync_tv._jwks_cache
+
+        # Next call must re-fetch and succeed.
+        success = _get_cached_jwks(JWKS_URL)
+        assert success.is_successful is True
+        assert JWKS_URL in sync_tv._jwks_cache
+        assert len(call_log) == 2  # noqa: PLR2004
+
+    @respx.mock
+    def test_disco_failure_then_success_refetches(self):
+        """A transient discovery failure must not poison the cache."""
+        call_log: list[int] = []
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            call_log.append(1)
+            if len(call_log) == 1:
+                return httpx.Response(404, text="not found")
+            return httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+
+        respx.get(DISCO_URL).mock(side_effect=handler)
+
+        failed = _get_disco_response(DISCO_URL)
+        assert failed.is_successful is False
+        assert (DISCO_URL, True) not in sync_tv._disco_cache
+
+        success = _get_disco_response(DISCO_URL)
+        assert success.is_successful is True
+        assert (DISCO_URL, True) in sync_tv._disco_cache
+        assert len(call_log) == 2  # noqa: PLR2004
+
+
+class TestAsyncFailedResponseNotCached:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_jwks_failure_then_success_refetches_async(self):
+        key_dict = generate_rsa_keypair()[0]
+        call_log: list[int] = []
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            call_log.append(1)
+            if len(call_log) == 1:
+                return httpx.Response(404, text="not found")
+            return httpx.Response(200, json={"keys": [key_dict]})
+
+        respx.get(JWKS_URL).mock(side_effect=handler)
+
+        failed = await async_get_cached_jwks(JWKS_URL)
+        assert failed.is_successful is False
+        assert JWKS_URL not in aio_tv._jwks_cache
+
+        success = await async_get_cached_jwks(JWKS_URL)
+        assert success.is_successful is True
+        assert JWKS_URL in aio_tv._jwks_cache
+        assert len(call_log) == 2  # noqa: PLR2004
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_disco_failure_then_success_refetches_async(self):
+        call_log: list[int] = []
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            call_log.append(1)
+            if len(call_log) == 1:
+                return httpx.Response(404, text="not found")
+            return httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+
+        respx.get(DISCO_URL).mock(side_effect=handler)
+
+        failed = await async_get_disco_response(DISCO_URL)
+        assert failed.is_successful is False
+        assert (DISCO_URL, True) not in aio_tv._disco_cache
+
+        success = await async_get_disco_response(DISCO_URL)
+        assert success.is_successful is True
+        assert (DISCO_URL, True) in aio_tv._disco_cache
+        assert len(call_log) == 2  # noqa: PLR2004
+
+
+# ============================================================================
+# Cache-Control: no-store — never cached
+# ============================================================================
+
+
+class TestSyncNoStoreNotCached:
+    @respx.mock
+    def test_jwks_no_store_skips_cache(self):
+        """no-store responses are returned but not cached, even with max-age."""
+        key_dict = generate_rsa_keypair()[0]
+        respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={"keys": [key_dict]},
+                headers={"Cache-Control": "no-store, max-age=600"},
+            )
+        )
+
+        response = _get_cached_jwks(JWKS_URL)
+        assert response.is_successful is True
+        assert response.keys is not None
+        assert JWKS_URL not in sync_tv._jwks_cache
+
+    @respx.mock
+    def test_disco_no_store_skips_cache(self):
+        respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json=DISCO_RESPONSE_WITH_JWKS,
+                headers={"Cache-Control": "no-store"},
+            )
+        )
+
+        response = _get_disco_response(DISCO_URL)
+        assert response.is_successful is True
+        assert (DISCO_URL, True) not in sync_tv._disco_cache
+
+
+class TestAsyncNoStoreNotCached:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_jwks_no_store_skips_cache_async(self):
+        key_dict = generate_rsa_keypair()[0]
+        respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={"keys": [key_dict]},
+                headers={"Cache-Control": "no-store, max-age=600"},
+            )
+        )
+
+        response = await async_get_cached_jwks(JWKS_URL)
+        assert response.is_successful is True
+        assert JWKS_URL not in aio_tv._jwks_cache
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_disco_no_store_skips_cache_async(self):
+        respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json=DISCO_RESPONSE_WITH_JWKS,
+                headers={"Cache-Control": "no-store"},
+            )
+        )
+
+        response = await async_get_disco_response(DISCO_URL)
+        assert response.is_successful is True
+        assert (DISCO_URL, True) not in aio_tv._disco_cache
+
+
+# ============================================================================
+# Cache-Control: no-cache — always re-fetch
+# ============================================================================
+
+
+class TestSyncNoCacheRefetched:
+    @respx.mock
+    def test_jwks_no_cache_refetches_each_call(self):
+        """no-cache responses always re-fetch (we don't store them)."""
+        key_dict = generate_rsa_keypair()[0]
+        jwks_route = respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={"keys": [key_dict]},
+                headers={"Cache-Control": "no-cache, max-age=600"},
+            )
+        )
+
+        for _ in range(3):
+            response = _get_cached_jwks(JWKS_URL)
+            assert response.is_successful is True
+
+        assert JWKS_URL not in sync_tv._jwks_cache
+        assert jwks_route.call_count == 3  # noqa: PLR2004
+
+    @respx.mock
+    def test_disco_no_cache_refetches_each_call(self):
+        disco_route = respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json=DISCO_RESPONSE_WITH_JWKS,
+                headers={"Cache-Control": "no-cache"},
+            )
+        )
+
+        for _ in range(3):
+            response = _get_disco_response(DISCO_URL)
+            assert response.is_successful is True
+
+        assert (DISCO_URL, True) not in sync_tv._disco_cache
+        assert disco_route.call_count == 3  # noqa: PLR2004
+
+
+class TestAsyncNoCacheRefetched:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_jwks_no_cache_refetches_each_call_async(self):
+        key_dict = generate_rsa_keypair()[0]
+        jwks_route = respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={"keys": [key_dict]},
+                headers={"Cache-Control": "no-cache, max-age=600"},
+            )
+        )
+
+        for _ in range(3):
+            response = await async_get_cached_jwks(JWKS_URL)
+            assert response.is_successful is True
+
+        assert JWKS_URL not in aio_tv._jwks_cache
+        assert jwks_route.call_count == 3  # noqa: PLR2004
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_disco_no_cache_refetches_each_call_async(self):
+        disco_route = respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json=DISCO_RESPONSE_WITH_JWKS,
+                headers={"Cache-Control": "no-cache"},
+            )
+        )
+
+        # Sequential awaits — async lock would serialize concurrent ones into one fetch.
+        for _ in range(3):
+            await async_get_disco_response(DISCO_URL)
+
+        assert (DISCO_URL, True) not in aio_tv._disco_cache
+        assert disco_route.call_count == 3  # noqa: PLR2004

--- a/src/tests/unit/test_cache_http_headers.py
+++ b/src/tests/unit/test_cache_http_headers.py
@@ -307,7 +307,6 @@ class TestAsyncNoCacheRefetched:
             )
         )
 
-        # Sequential awaits — async lock would serialize concurrent ones into one fetch.
         for _ in range(3):
             await async_get_disco_response(DISCO_URL)
 

--- a/src/tests/unit/test_cache_stampede.py
+++ b/src/tests/unit/test_cache_stampede.py
@@ -6,6 +6,7 @@ fetch rather than N parallel fetches (thundering herd).
 """
 
 import asyncio
+from collections.abc import Callable
 import threading
 import time
 
@@ -29,7 +30,11 @@ from py_identity_model.aio.token_validation import (
 from py_identity_model.aio.token_validation import (
     clear_jwks_cache as async_clear_jwks_cache,
 )
+from py_identity_model.aio.token_validation import (
+    validate_token as async_validate_token,
+)
 from py_identity_model.core.jwks_cache import DiscoCacheEntry, JwksCacheEntry
+from py_identity_model.core.models import TokenValidationConfig
 from py_identity_model.sync import token_validation as sync_tv
 from py_identity_model.sync.token_validation import (
     _get_cached_jwks,
@@ -37,11 +42,13 @@ from py_identity_model.sync.token_validation import (
     _refresh_jwks,
     clear_discovery_cache,
     clear_jwks_cache,
+    validate_token,
 )
 
 from .token_validation_helpers import (
     DISCO_RESPONSE_WITH_JWKS,
     generate_rsa_keypair,
+    sign_jwt,
 )
 
 
@@ -410,3 +417,229 @@ class TestAsyncRefreshJwksFreshnessGuard:
         result = await async_refresh_jwks(JWKS_URL)
         assert result is not None
         assert jwks_route.call_count == FETCH_AFTER_EXPIRY
+
+
+# ============================================================================
+# Kid-miss stampede (PR #390): pre-decode refresh path must single-flight
+# ============================================================================
+#
+# The fix in #390 adds a pre-decode JWKS refresh when the JWT's `kid` is not
+# in the cached JWKS. Without protection, N concurrent requests with an
+# unknown kid would each issue their own JWKS fetch (thundering herd against
+# the OP's JWKS endpoint, and an unauthenticated amplification vector since
+# the JWT header is not yet trust-validated).
+#
+# Protection comes from two layers already in the code:
+#   1. `_get_cached_jwks` and `_refresh_jwks` share `_jwks_cache_lock`. While
+#      task A holds the lock during its fetch, tasks B..N block at
+#      `_get_cached_jwks` and read the freshly-refreshed cache when A releases.
+#      Most concurrent tasks therefore never even enter `_refresh_jwks`.
+#   2. The single-flight guard inside `_refresh_jwks`
+#      (`cached_at >= request_time`) catches the residual race where multiple
+#      tasks captured `request_time` before the first fetch completed.
+#
+# These tests pin both layers in place so a future change cannot quietly
+# regress the kid-miss path into an N-fetch fan-out.
+
+# 1 prime fetch + 1 single-flight refresh on rotation = 2 fetches, regardless
+# of how many concurrent validators arrive with the unknown kid.
+KID_MISS_FETCH_BUDGET = 2
+
+
+def _make_rotating_jwks_handler(
+    old_keys_response: dict, new_keys_response: dict
+) -> tuple[list[int], Callable[[httpx.Request], httpx.Response]]:
+    """Return (call_log, handler). First call returns old_keys; rest return new_keys."""
+    call_log: list[int] = []
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        call_log.append(1)
+        if len(call_log) == 1:
+            return httpx.Response(200, json=old_keys_response)
+        return httpx.Response(200, json=new_keys_response)
+
+    return call_log, handler
+
+
+class TestAsyncKidMissStampede:
+    """Concurrent kid-miss validations must produce a single refresh fetch."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_n_concurrent_unknown_kid_triggers_single_refresh(self):
+        """N concurrent validate_token calls with the same unknown kid → 2 fetches total."""
+        old_key_dict, _old_pem = generate_rsa_keypair()
+        old_key_dict["kid"] = "old-kid"
+        new_key_dict, new_pem = generate_rsa_keypair()
+        new_key_dict["kid"] = "new-kid"
+
+        respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+        _, jwks_handler = _make_rotating_jwks_handler(
+            old_keys_response={"keys": [old_key_dict]},
+            new_keys_response={"keys": [new_key_dict]},
+        )
+        jwks_route = respx.get(JWKS_URL).mock(side_effect=jwks_handler)
+
+        # Prime cache with old kid via direct cache access (no validation needed).
+        await async_get_cached_jwks(JWKS_URL)
+        assert jwks_route.call_count == 1
+
+        token = sign_jwt(
+            new_pem,
+            {"sub": "user1", "iss": "https://example.com"},
+            headers={"kid": "new-kid"},
+        )
+        config = TokenValidationConfig(
+            perform_disco=True, audience=None, issuer="https://example.com"
+        )
+
+        N = 25
+        results = await asyncio.gather(
+            *[
+                async_validate_token(
+                    jwt=token,
+                    token_validation_config=config,
+                    disco_doc_address=DISCO_URL,
+                )
+                for _ in range(N)
+            ]
+        )
+
+        assert len(results) == N
+        for decoded in results:
+            assert decoded["sub"] == "user1"
+        # Stampede protection: only 1 prime + 1 refresh, NOT 1 + N.
+        assert jwks_route.call_count == KID_MISS_FETCH_BUDGET, (
+            f"Stampede: {jwks_route.call_count} fetches for {N} concurrent kid-miss "
+            f"validations (expected {KID_MISS_FETCH_BUDGET})"
+        )
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_n_concurrent_distinct_unknown_kids_triggers_single_refresh(self):
+        """N concurrent calls with N distinct unknown kids still single-flight by jwks_uri.
+
+        The single-flight key is jwks_uri, not kid. Even if every concurrent
+        request has a different unknown kid, only one refresh fetch should
+        occur. The first refresh populates the cache; subsequent tasks read
+        the fresh cache (and may then raise per-key errors if their kid still
+        isn't present, which is acceptable — what we're guarding here is the
+        outbound fetch count).
+        """
+        old_key_dict, _ = generate_rsa_keypair()
+        old_key_dict["kid"] = "old-kid"
+
+        # New JWKS contains every kid the rotated batch might use.
+        new_keys = []
+        new_pems: dict[str, bytes] = {}
+        N = 10
+        for i in range(N):
+            kd, pem = generate_rsa_keypair()
+            kd["kid"] = f"new-kid-{i}"
+            new_keys.append(kd)
+            new_pems[f"new-kid-{i}"] = pem
+
+        respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+        _, jwks_handler = _make_rotating_jwks_handler(
+            old_keys_response={"keys": [old_key_dict]},
+            new_keys_response={"keys": new_keys},
+        )
+        jwks_route = respx.get(JWKS_URL).mock(side_effect=jwks_handler)
+
+        await async_get_cached_jwks(JWKS_URL)
+        assert jwks_route.call_count == 1
+
+        config = TokenValidationConfig(
+            perform_disco=True, audience=None, issuer="https://example.com"
+        )
+
+        async def _validate(i: int) -> dict:
+            kid = f"new-kid-{i}"
+            tok = sign_jwt(
+                new_pems[kid],
+                {"sub": f"user{i}", "iss": "https://example.com"},
+                headers={"kid": kid},
+            )
+            return await async_validate_token(
+                jwt=tok,
+                token_validation_config=config,
+                disco_doc_address=DISCO_URL,
+            )
+
+        results = await asyncio.gather(*[_validate(i) for i in range(N)])
+
+        assert {r["sub"] for r in results} == {f"user{i}" for i in range(N)}
+        assert jwks_route.call_count == KID_MISS_FETCH_BUDGET, (
+            f"Stampede: {jwks_route.call_count} fetches for {N} concurrent distinct "
+            f"unknown kids (expected {KID_MISS_FETCH_BUDGET})"
+        )
+
+
+class TestSyncKidMissStampede:
+    """Concurrent kid-miss validations from threads must produce a single refresh fetch."""
+
+    @respx.mock
+    def test_n_concurrent_unknown_kid_triggers_single_refresh_sync(self):
+        """N threads concurrently validating tokens with the same unknown kid → 2 fetches."""
+        old_key_dict, _ = generate_rsa_keypair()
+        old_key_dict["kid"] = "old-kid"
+        new_key_dict, new_pem = generate_rsa_keypair()
+        new_key_dict["kid"] = "new-kid"
+
+        respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+        _, jwks_handler = _make_rotating_jwks_handler(
+            old_keys_response={"keys": [old_key_dict]},
+            new_keys_response={"keys": [new_key_dict]},
+        )
+        jwks_route = respx.get(JWKS_URL).mock(side_effect=jwks_handler)
+
+        # Prime cache.
+        _get_cached_jwks(JWKS_URL)
+        assert jwks_route.call_count == 1
+
+        token = sign_jwt(
+            new_pem,
+            {"sub": "user1", "iss": "https://example.com"},
+            headers={"kid": "new-kid"},
+        )
+        config = TokenValidationConfig(
+            perform_disco=True, audience=None, issuer="https://example.com"
+        )
+
+        N = 25
+        barrier = threading.Barrier(N, timeout=10)
+        results: list[dict | None] = [None] * N
+        errors: list[Exception | None] = [None] * N
+
+        def worker(idx: int) -> None:
+            try:
+                barrier.wait()
+                results[idx] = validate_token(
+                    jwt=token,
+                    token_validation_config=config,
+                    disco_doc_address=DISCO_URL,
+                )
+            except Exception as exc:
+                errors[idx] = exc
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(N)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=20)
+
+        for err in errors:
+            assert err is None, f"Worker raised: {err}"
+        for r in results:
+            assert r is not None
+            assert r["sub"] == "user1"
+        assert jwks_route.call_count == KID_MISS_FETCH_BUDGET, (
+            f"Stampede: {jwks_route.call_count} fetches for {N} concurrent kid-miss "
+            f"validations (expected {KID_MISS_FETCH_BUDGET})"
+        )

--- a/src/tests/unit/test_cache_stampede.py
+++ b/src/tests/unit/test_cache_stampede.py
@@ -7,6 +7,7 @@ fetch rather than N parallel fetches (thundering herd).
 
 import asyncio
 from collections.abc import Callable
+import logging
 import threading
 import time
 
@@ -35,6 +36,7 @@ from py_identity_model.aio.token_validation import (
 )
 from py_identity_model.core.jwks_cache import DiscoCacheEntry, JwksCacheEntry
 from py_identity_model.core.models import TokenValidationConfig
+from py_identity_model.exceptions import TokenValidationException
 from py_identity_model.sync import token_validation as sync_tv
 from py_identity_model.sync.token_validation import (
     _get_cached_jwks,
@@ -115,7 +117,7 @@ class TestSyncJwksCacheStampede:
     @respx.mock
     def test_jwks_cache_stampede_blocked(self):
         """Multiple threads hitting expired JWKS cache produce only 1 HTTP fetch."""
-        key_dict, _ = generate_rsa_keypair()
+        key_dict = generate_rsa_keypair()[0]
         jwks_route = respx.get(JWKS_URL).mock(
             return_value=httpx.Response(200, json={"keys": [key_dict]})
         )
@@ -150,7 +152,7 @@ class TestSyncStampedeAfterExpiry:
     @respx.mock
     def test_jwks_stampede_after_expiry_blocked(self):
         """After TTL expires, concurrent fetches produce only 1 new HTTP request."""
-        key_dict, _ = generate_rsa_keypair()
+        key_dict = generate_rsa_keypair()[0]
         jwks_route = respx.get(JWKS_URL).mock(
             return_value=httpx.Response(200, json={"keys": [key_dict]})
         )
@@ -254,7 +256,7 @@ class TestAsyncJwksCacheStampede:
     @respx.mock
     async def test_jwks_cache_stampede_blocked_async(self):
         """Multiple coroutines hitting expired JWKS cache produce only 1 HTTP fetch."""
-        key_dict, _ = generate_rsa_keypair()
+        key_dict = generate_rsa_keypair()[0]
         jwks_route = respx.get(JWKS_URL).mock(
             return_value=httpx.Response(200, json={"keys": [key_dict]})
         )
@@ -274,7 +276,7 @@ class TestAsyncStampedeAfterExpiry:
     @respx.mock
     async def test_jwks_stampede_after_expiry_blocked_async(self):
         """After TTL expires, concurrent async fetches produce only 1 new request."""
-        key_dict, _ = generate_rsa_keypair()
+        key_dict = generate_rsa_keypair()[0]
         jwks_route = respx.get(JWKS_URL).mock(
             return_value=httpx.Response(200, json={"keys": [key_dict]})
         )
@@ -332,7 +334,7 @@ class TestSyncRefreshJwksFreshnessGuard:
     @respx.mock
     def test_refresh_skips_fetch_when_already_fresh(self):
         """If cache was refreshed while waiting on lock, return cached entry."""
-        key_dict, _ = generate_rsa_keypair()
+        key_dict = generate_rsa_keypair()[0]
         jwks_route = respx.get(JWKS_URL).mock(
             return_value=httpx.Response(200, json={"keys": [key_dict]})
         )
@@ -359,7 +361,7 @@ class TestSyncRefreshJwksFreshnessGuard:
     @respx.mock
     def test_refresh_fetches_when_cache_stale(self):
         """Normal refresh path: fetch when cache is stale."""
-        key_dict, _ = generate_rsa_keypair()
+        key_dict = generate_rsa_keypair()[0]
         jwks_route = respx.get(JWKS_URL).mock(
             return_value=httpx.Response(200, json={"keys": [key_dict]})
         )
@@ -381,7 +383,7 @@ class TestAsyncRefreshJwksFreshnessGuard:
     @respx.mock
     async def test_refresh_skips_fetch_when_already_fresh_async(self):
         """If cache was refreshed while waiting on lock, return cached entry."""
-        key_dict, _ = generate_rsa_keypair()
+        key_dict = generate_rsa_keypair()[0]
         jwks_route = respx.get(JWKS_URL).mock(
             return_value=httpx.Response(200, json={"keys": [key_dict]})
         )
@@ -406,7 +408,7 @@ class TestAsyncRefreshJwksFreshnessGuard:
     @respx.mock
     async def test_refresh_fetches_when_cache_stale_async(self):
         """Normal refresh path: fetch when cache is stale."""
-        key_dict, _ = generate_rsa_keypair()
+        key_dict = generate_rsa_keypair()[0]
         jwks_route = respx.get(JWKS_URL).mock(
             return_value=httpx.Response(200, json={"keys": [key_dict]})
         )
@@ -468,7 +470,7 @@ class TestAsyncKidMissStampede:
     @respx.mock
     async def test_n_concurrent_unknown_kid_triggers_single_refresh(self):
         """N concurrent validate_token calls with the same unknown kid → 2 fetches total."""
-        old_key_dict, _old_pem = generate_rsa_keypair()
+        old_key_dict = generate_rsa_keypair()[0]
         old_key_dict["kid"] = "old-kid"
         new_key_dict, new_pem = generate_rsa_keypair()
         new_key_dict["kid"] = "new-kid"
@@ -528,7 +530,7 @@ class TestAsyncKidMissStampede:
         isn't present, which is acceptable — what we're guarding here is the
         outbound fetch count).
         """
-        old_key_dict, _ = generate_rsa_keypair()
+        old_key_dict = generate_rsa_keypair()[0]
         old_key_dict["kid"] = "old-kid"
 
         # New JWKS contains every kid the rotated batch might use.
@@ -585,7 +587,7 @@ class TestSyncKidMissStampede:
     @respx.mock
     def test_n_concurrent_unknown_kid_triggers_single_refresh_sync(self):
         """N threads concurrently validating tokens with the same unknown kid → 2 fetches."""
-        old_key_dict, _ = generate_rsa_keypair()
+        old_key_dict = generate_rsa_keypair()[0]
         old_key_dict["kid"] = "old-kid"
         new_key_dict, new_pem = generate_rsa_keypair()
         new_key_dict["kid"] = "new-kid"
@@ -642,4 +644,56 @@ class TestSyncKidMissStampede:
         assert jwks_route.call_count == KID_MISS_FETCH_BUDGET, (
             f"Stampede: {jwks_route.call_count} fetches for {N} concurrent kid-miss "
             f"validations (expected {KID_MISS_FETCH_BUDGET})"
+        )
+
+
+# ============================================================================
+# Diagnostic on still-missing kid after refresh (PR #390 hardening)
+# ============================================================================
+
+
+class TestSyncStillMissingDiagnostic:
+    """A successful refresh that doesn't help should leave a diagnostic log."""
+
+    @respx.mock
+    def test_warning_logged_when_kid_still_absent_after_refresh(self, caplog):
+        """If refresh succeeds but the kid is still not in JWKS, log a warning."""
+        old_key_dict = generate_rsa_keypair()[0]
+        old_key_dict["kid"] = "old-kid"
+        # Refreshed JWKS has a different kid — still doesn't help the request.
+        other_key_dict = generate_rsa_keypair()[0]
+        other_key_dict["kid"] = "some-other-kid"
+
+        respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+        _, jwks_handler = _make_rotating_jwks_handler(
+            old_keys_response={"keys": [old_key_dict]},
+            new_keys_response={"keys": [other_key_dict]},
+        )
+        respx.get(JWKS_URL).mock(side_effect=jwks_handler)
+
+        _get_cached_jwks(JWKS_URL)
+
+        new_pem = generate_rsa_keypair()[1]
+        token = sign_jwt(
+            new_pem,
+            {"sub": "user1", "iss": "https://example.com"},
+            headers={"kid": "still-not-here"},
+        )
+        config = TokenValidationConfig(
+            perform_disco=True, audience=None, issuer="https://example.com"
+        )
+
+        with (
+            caplog.at_level(logging.WARNING),
+            pytest.raises(TokenValidationException),
+        ):
+            validate_token(
+                jwt=token,
+                token_validation_config=config,
+                disco_doc_address=DISCO_URL,
+            )
+        assert any("still absent" in rec.message.lower() for rec in caplog.records), (
+            f"Expected 'still absent' warning, got: {[r.message for r in caplog.records]}"
         )

--- a/src/tests/unit/test_jwks_cache.py
+++ b/src/tests/unit/test_jwks_cache.py
@@ -10,6 +10,7 @@ from py_identity_model.core.jwks_cache import (
     MIN_CACHE_TTL_SECONDS,
     JwksCacheEntry,
     is_cache_expired,
+    is_uncacheable,
     parse_max_age,
     resolve_ttl,
 )
@@ -89,6 +90,37 @@ class TestCacheEntry:
     def test_entry_stores_custom_ttl(self):
         entry = self._make_entry(ttl=7200)
         assert entry.ttl == 7200
+
+
+class TestIsUncacheable:
+    def test_no_store(self):
+        assert is_uncacheable("no-store") is True
+
+    def test_no_cache(self):
+        assert is_uncacheable("no-cache") is True
+
+    def test_no_store_with_max_age(self):
+        """Per RFC 7234 §5.2.2.5, no-store overrides max-age."""
+        assert is_uncacheable("no-store, max-age=600") is True
+
+    def test_no_cache_with_max_age(self):
+        assert is_uncacheable("no-cache, max-age=600") is True
+
+    def test_case_insensitive(self):
+        assert is_uncacheable("No-Store") is True
+        assert is_uncacheable("NO-CACHE") is True
+
+    def test_plain_max_age_is_cacheable(self):
+        assert is_uncacheable("max-age=3600") is False
+
+    def test_public_max_age_is_cacheable(self):
+        assert is_uncacheable("public, max-age=19800") is False
+
+    def test_none_header(self):
+        assert is_uncacheable(None) is False
+
+    def test_empty_string(self):
+        assert is_uncacheable("") is False
 
 
 class TestMultiProviderCacheIsolation:

--- a/src/tests/unit/test_jwks_cache.py
+++ b/src/tests/unit/test_jwks_cache.py
@@ -106,6 +106,10 @@ class TestIsUncacheable:
     def test_no_cache_with_max_age(self):
         assert is_uncacheable("no-cache, max-age=600") is True
 
+    def test_descope_combined_directives(self):
+        """Real-world: Descope sends both no-store and no-cache on JWKS."""
+        assert is_uncacheable("no-store, no-cache") is True
+
     def test_case_insensitive(self):
         assert is_uncacheable("No-Store") is True
         assert is_uncacheable("NO-CACHE") is True

--- a/src/tests/unit/test_kid_miss_cooldown.py
+++ b/src/tests/unit/test_kid_miss_cooldown.py
@@ -1,0 +1,464 @@
+"""
+Proves the kid-miss refresh cooldown bounds DoS amplification.
+
+Threat model: an unauthenticated attacker spams JWTs with random unknown
+``kid`` values against the token-validation endpoint. Each kid-miss triggers
+a forced JWKS refresh from the cache layer. Without a cooldown, the
+amplification factor is 1:1 — attacker controls a per-request JWKS fetch
+against the upstream OP. At ~100 RPS this trivially trips the upstream's
+rate limit and breaks validation for legitimate traffic too.
+
+These tests pin the contract:
+- 1 prime + 1 refresh covers an arbitrary number of attacker requests
+  inside the cooldown window (regardless of distinct kids used).
+- Cooldown does NOT block when the cache has no keys to fall back on.
+- Cooldown does NOT block legitimate tokens with cached kids.
+- Cooldown expires after its window; rotation propagates within one window.
+- The cooldown is per ``jwks_uri`` — an attacker against one OP cannot
+  suppress refreshes for a different OP.
+"""
+
+import asyncio
+import time
+
+import httpx
+import pytest
+import respx
+
+from py_identity_model.aio.token_validation import (
+    _kid_miss_last_attempt as async_kid_miss_last_attempt,
+)
+from py_identity_model.aio.token_validation import (
+    clear_discovery_cache as async_clear_discovery_cache,
+)
+from py_identity_model.aio.token_validation import (
+    clear_jwks_cache as async_clear_jwks_cache,
+)
+from py_identity_model.aio.token_validation import (
+    validate_token as async_validate_token,
+)
+from py_identity_model.core.jwks_cache import (
+    DEFAULT_KID_MISS_REFRESH_COOLDOWN_SECONDS,
+    _reset_env_for_testing,
+    get_kid_miss_cooldown,
+    should_attempt_kid_miss_refresh,
+)
+from py_identity_model.core.models import TokenValidationConfig
+from py_identity_model.exceptions import TokenValidationException
+from py_identity_model.sync.token_validation import (
+    _kid_miss_last_attempt as sync_kid_miss_last_attempt,
+)
+from py_identity_model.sync.token_validation import (
+    clear_discovery_cache,
+    clear_jwks_cache,
+    validate_token,
+)
+
+from .token_validation_helpers import (
+    DISCO_RESPONSE_WITH_JWKS,
+    generate_rsa_keypair,
+    sign_jwt,
+)
+
+
+DISCO_URL = "https://example.com/.well-known/openid-configuration"
+JWKS_URL = "https://example.com/jwks"
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    clear_discovery_cache()
+    clear_jwks_cache()
+    async_clear_discovery_cache()
+    async_clear_jwks_cache()
+    _reset_env_for_testing()
+    yield
+    clear_discovery_cache()
+    clear_jwks_cache()
+    async_clear_discovery_cache()
+    async_clear_jwks_cache()
+    _reset_env_for_testing()
+
+
+def _sign_unknown_kid_token(kid: str) -> str:
+    """Forge a JWT header advertising the given kid but sign with a fresh
+    keypair the verifier will never see — exercises the kid-miss path."""
+    _, pem = generate_rsa_keypair()
+    return sign_jwt(
+        pem,
+        {"sub": "attacker", "iss": "https://example.com"},
+        headers={"kid": kid},
+    )
+
+
+# ============================================================================
+# Pure-function semantics for the gate. Decouples the contract from the
+# sync/async plumbing so a flipped predicate would fail here too.
+# ============================================================================
+
+
+class TestShouldAttemptKidMissRefreshContract:
+    def test_proceeds_when_no_prior_attempt(self):
+        assert should_attempt_kid_miss_refresh(
+            last_attempts={},
+            jwks_uri=JWKS_URL,
+            has_cached_keys=True,
+            now=100.0,
+        )
+
+    def test_proceeds_when_no_cached_keys_even_inside_cooldown(self):
+        recent = {JWKS_URL: 100.0}
+        assert should_attempt_kid_miss_refresh(
+            last_attempts=recent,
+            jwks_uri=JWKS_URL,
+            has_cached_keys=False,
+            now=100.5,
+        )
+
+    def test_blocks_when_recent_attempt_with_cached_keys(self):
+        cooldown = get_kid_miss_cooldown()
+        recent = {JWKS_URL: 100.0}
+        assert not should_attempt_kid_miss_refresh(
+            last_attempts=recent,
+            jwks_uri=JWKS_URL,
+            has_cached_keys=True,
+            now=100.0 + cooldown / 2,
+        )
+
+    def test_proceeds_after_cooldown_elapsed(self):
+        cooldown = get_kid_miss_cooldown()
+        old = {JWKS_URL: 100.0}
+        assert should_attempt_kid_miss_refresh(
+            last_attempts=old,
+            jwks_uri=JWKS_URL,
+            has_cached_keys=True,
+            now=100.0 + cooldown + 0.01,
+        )
+
+    def test_cooldown_is_per_jwks_uri(self):
+        """An attacker against OP-A cannot suppress refreshes for OP-B."""
+        other_uri = "https://other.example/jwks"
+        recent = {JWKS_URL: 100.0}
+        assert should_attempt_kid_miss_refresh(
+            last_attempts=recent,
+            jwks_uri=other_uri,
+            has_cached_keys=True,
+            now=100.0,
+        )
+
+
+# ============================================================================
+# End-to-end: under sustained kid-miss attack, only 1 prime + 1 refresh
+# reach the upstream JWKS endpoint, regardless of attacker request volume.
+# ============================================================================
+
+ATTACKER_REQUEST_COUNT = 25
+EXPECTED_FETCH_COUNT = 2  # 1 prime + 1 refresh inside cooldown window
+
+
+class TestKidMissCooldownBoundsAmplification:
+    @respx.mock
+    def test_sync_cooldown_caps_fetches_under_attack(self):
+        defender_key_dict, _defender_pem = generate_rsa_keypair()
+        defender_key_dict["kid"] = "defender-kid"
+
+        respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+        jwks_route = respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(200, json={"keys": [defender_key_dict]})
+        )
+
+        config = TokenValidationConfig(
+            perform_disco=True, audience=None, issuer="https://example.com"
+        )
+
+        attacker_kids = [f"attacker-kid-{i}" for i in range(ATTACKER_REQUEST_COUNT)]
+        tokens = [_sign_unknown_kid_token(kid) for kid in attacker_kids]
+
+        rejections = 0
+        for token in tokens:
+            try:
+                validate_token(
+                    jwt=token,
+                    token_validation_config=config,
+                    disco_doc_address=DISCO_URL,
+                )
+            except TokenValidationException:
+                rejections += 1
+
+        # Every attacker request must fail (no matching kid).
+        assert rejections == ATTACKER_REQUEST_COUNT
+        # And the upstream JWKS endpoint sees at most 1 prime + 1 refresh,
+        # not one fetch per attacker request.
+        assert jwks_route.call_count == EXPECTED_FETCH_COUNT
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_async_cooldown_caps_fetches_under_attack(self):
+        defender_key_dict, _defender_pem = generate_rsa_keypair()
+        defender_key_dict["kid"] = "defender-kid"
+
+        respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+        jwks_route = respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(200, json={"keys": [defender_key_dict]})
+        )
+
+        config = TokenValidationConfig(
+            perform_disco=True, audience=None, issuer="https://example.com"
+        )
+
+        attacker_kids = [f"attacker-kid-{i}" for i in range(ATTACKER_REQUEST_COUNT)]
+        tokens = [_sign_unknown_kid_token(kid) for kid in attacker_kids]
+
+        async def _try(token: str) -> bool:
+            try:
+                await async_validate_token(
+                    jwt=token,
+                    token_validation_config=config,
+                    disco_doc_address=DISCO_URL,
+                )
+                return False
+            except TokenValidationException:
+                return True
+
+        results = await asyncio.gather(*(_try(t) for t in tokens))
+        assert all(results)
+        assert jwks_route.call_count == EXPECTED_FETCH_COUNT
+
+
+# ============================================================================
+# Cooldown must NOT block legitimate validation: tokens with already-cached
+# kids never trigger the cooldown, and a real key rotation propagates within
+# one cooldown window.
+# ============================================================================
+
+
+class TestCooldownDoesNotBlockLegitimateTraffic:
+    @respx.mock
+    def test_cached_kid_does_not_trip_cooldown(self):
+        """Validating a token whose kid IS in the cache must not consume
+        cooldown budget — kid-miss path never fires."""
+        key_dict, pem = generate_rsa_keypair()
+        key_dict["kid"] = "cached-kid"
+
+        respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+        jwks_route = respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(200, json={"keys": [key_dict]})
+        )
+
+        config = TokenValidationConfig(
+            perform_disco=True, audience=None, issuer="https://example.com"
+        )
+
+        legitimate_token = sign_jwt(
+            pem,
+            {"sub": "user1", "iss": "https://example.com"},
+            headers={"kid": "cached-kid"},
+        )
+
+        for _ in range(10):
+            validate_token(
+                jwt=legitimate_token,
+                token_validation_config=config,
+                disco_doc_address=DISCO_URL,
+            )
+
+        # Single prime fetch, no refreshes, cooldown dict never populated.
+        assert jwks_route.call_count == 1
+        assert JWKS_URL not in sync_kid_miss_last_attempt
+
+    @respx.mock
+    def test_rotation_propagates_after_cooldown_elapses(self):
+        """A real rotation (new key on upstream) must propagate on the very
+        next kid-miss after the cooldown window — proving the cooldown is
+        bounded, not permanent."""
+        old_key_dict, _ = generate_rsa_keypair()
+        old_key_dict["kid"] = "old-kid"
+        new_key_dict, new_pem = generate_rsa_keypair()
+        new_key_dict["kid"] = "new-kid"
+
+        respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+        # First fetch returns old; second fetch returns new (rotation).
+        jwks_route = respx.get(JWKS_URL).mock(
+            side_effect=[
+                httpx.Response(200, json={"keys": [old_key_dict]}),
+                httpx.Response(200, json={"keys": [old_key_dict]}),
+                httpx.Response(200, json={"keys": [new_key_dict]}),
+            ]
+        )
+
+        config = TokenValidationConfig(
+            perform_disco=True, audience=None, issuer="https://example.com"
+        )
+
+        rotation_token = sign_jwt(
+            new_pem,
+            {"sub": "user1", "iss": "https://example.com"},
+            headers={"kid": "new-kid"},
+        )
+
+        # 1st attempt: cache has only old-kid → kid-miss → refresh fires →
+        # upstream still serves old-kid → rotation_token can't validate yet.
+        with pytest.raises(TokenValidationException):
+            validate_token(
+                jwt=rotation_token,
+                token_validation_config=config,
+                disco_doc_address=DISCO_URL,
+            )
+        assert jwks_route.call_count == 2  # noqa: PLR2004
+
+        # 2nd attempt inside cooldown: refresh suppressed, still fails.
+        with pytest.raises(TokenValidationException):
+            validate_token(
+                jwt=rotation_token,
+                token_validation_config=config,
+                disco_doc_address=DISCO_URL,
+            )
+        assert jwks_route.call_count == 2  # noqa: PLR2004
+
+        # Simulate cooldown elapse by backdating the last-attempt timestamp.
+        cooldown = get_kid_miss_cooldown()
+        sync_kid_miss_last_attempt[JWKS_URL] = time.time() - cooldown - 1.0
+
+        # 3rd attempt past cooldown: refresh fires again, upstream now serves
+        # new-kid, rotation_token validates successfully.
+        decoded = validate_token(
+            jwt=rotation_token,
+            token_validation_config=config,
+            disco_doc_address=DISCO_URL,
+        )
+        assert decoded["sub"] == "user1"
+        assert jwks_route.call_count == 3  # noqa: PLR2004
+
+
+# ============================================================================
+# Cooldown is per-URI: an attacker hammering OP-A cannot suppress legitimate
+# rotation refreshes for OP-B.
+# ============================================================================
+
+
+class TestCooldownIsolationAcrossIssuers:
+    @respx.mock
+    def test_per_issuer_cooldown_does_not_cross_contaminate(self):
+        other_disco_url = "https://other.example/.well-known/openid-configuration"
+        other_jwks_url = "https://other.example/jwks"
+        other_disco_response = {
+            "issuer": "https://other.example",
+            "authorization_endpoint": "https://other.example/authorize",
+            "token_endpoint": "https://other.example/token",
+            "response_types_supported": ["code"],
+            "subject_types_supported": ["public"],
+            "id_token_signing_alg_values_supported": ["RS256"],
+            "jwks_uri": other_jwks_url,
+        }
+
+        attacker_key_dict, _ = generate_rsa_keypair()
+        attacker_key_dict["kid"] = "attacker-side-kid"
+        defender_key_dict, defender_pem = generate_rsa_keypair()
+        defender_key_dict["kid"] = "defender-kid"
+
+        respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+        respx.get(other_disco_url).mock(
+            return_value=httpx.Response(200, json=other_disco_response)
+        )
+        attacker_jwks_route = respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(200, json={"keys": [attacker_key_dict]})
+        )
+        defender_jwks_route = respx.get(other_jwks_url).mock(
+            return_value=httpx.Response(200, json={"keys": [defender_key_dict]})
+        )
+
+        config_attacker = TokenValidationConfig(
+            perform_disco=True, audience=None, issuer="https://example.com"
+        )
+        config_defender = TokenValidationConfig(
+            perform_disco=True, audience=None, issuer="https://other.example"
+        )
+
+        # Saturate the attacker-side cooldown.
+        for i in range(ATTACKER_REQUEST_COUNT):
+            with pytest.raises(TokenValidationException):
+                validate_token(
+                    jwt=_sign_unknown_kid_token(f"junk-{i}"),
+                    token_validation_config=config_attacker,
+                    disco_doc_address=DISCO_URL,
+                )
+
+        # Defender-side issuer must NOT be in cooldown — legitimate token
+        # signed by the defender's key validates without interference.
+        defender_token = sign_jwt(
+            defender_pem,
+            {"sub": "legit", "iss": "https://other.example"},
+            headers={"kid": "defender-kid"},
+        )
+        decoded = validate_token(
+            jwt=defender_token,
+            token_validation_config=config_defender,
+            disco_doc_address=other_disco_url,
+        )
+        assert decoded["sub"] == "legit"
+
+        # Attacker JWKS saw exactly 1 prime + 1 refresh; defender JWKS saw 1
+        # prime (legitimate kid hit cache immediately).
+        assert attacker_jwks_route.call_count == EXPECTED_FETCH_COUNT
+        assert defender_jwks_route.call_count == 1
+        # Cooldown state confirms isolation.
+        assert JWKS_URL in sync_kid_miss_last_attempt
+        assert other_jwks_url not in sync_kid_miss_last_attempt
+
+
+# ============================================================================
+# Env override sanity: KID_MISS_REFRESH_COOLDOWN takes effect when set
+# *before* first access. Pins the contract for operators who want to tune.
+# ============================================================================
+
+
+class TestCooldownEnvOverride:
+    def test_env_override_changes_cooldown(self, monkeypatch):
+        monkeypatch.setenv("KID_MISS_REFRESH_COOLDOWN", "42.5")
+        _reset_env_for_testing()
+        assert get_kid_miss_cooldown() == 42.5  # noqa: PLR2004
+
+    def test_default_when_unset(self, monkeypatch):
+        monkeypatch.delenv("KID_MISS_REFRESH_COOLDOWN", raising=False)
+        _reset_env_for_testing()
+        assert get_kid_miss_cooldown() == DEFAULT_KID_MISS_REFRESH_COOLDOWN_SECONDS
+
+
+# Async cooldown state covered for symmetry — most of the integration
+# coverage is via the sync end-to-end test above.
+class TestAsyncCooldownStateMirrorsSync:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_async_cooldown_dict_populated_on_refresh(self):
+        defender_key_dict, _ = generate_rsa_keypair()
+        defender_key_dict["kid"] = "defender-kid"
+
+        respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+        respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(200, json={"keys": [defender_key_dict]})
+        )
+
+        config = TokenValidationConfig(
+            perform_disco=True, audience=None, issuer="https://example.com"
+        )
+
+        with pytest.raises(TokenValidationException):
+            await async_validate_token(
+                jwt=_sign_unknown_kid_token("unknown"),
+                token_validation_config=config,
+                disco_doc_address=DISCO_URL,
+            )
+
+        assert JWKS_URL in async_kid_miss_last_attempt

--- a/src/tests/unit/test_per_uri_locks.py
+++ b/src/tests/unit/test_per_uri_locks.py
@@ -1,0 +1,195 @@
+"""
+Proves the cache uses per-URI locks rather than a single global lock that
+serializes upstream fetches across unrelated issuers.
+
+Pre-fix: a single ``threading.Lock`` (sync) / ``asyncio.Lock`` (async) was
+held *across* the upstream HTTP fetch in ``_get_cached_jwks`` /
+``_get_disco_response`` / ``_refresh_jwks``. A request fetching JWKS from
+``https://idp-a/jwks`` blocked every other request fetching JWKS from any
+*other* address until the first request's network round-trip completed.
+
+In a multi-tenant FastAPI app with multiple issuers and a slow upstream
+(or one with a momentary glitch) this serialized the entire process on the
+slowest fetch, regardless of which issuer the slowness affected.
+
+Post-fix: the cache uses cache-aside with per-URI lock striping (32
+stripes). Fetches for distinct URIs run in parallel; only fetches for the
+*same* URI serialize, which is the actual single-flight contract.
+
+The tests use a slow handler (sleep) to prove parallelism by wall-clock
+total time. We allow a slack margin for scheduling jitter, but the
+serialized vs. parallel times differ by ~2x — well outside any noise.
+"""
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+import threading
+import time
+
+import httpx
+import pytest
+import respx
+
+from py_identity_model.aio.token_validation import (
+    _get_cached_jwks as async_get_cached_jwks,
+)
+from py_identity_model.aio.token_validation import (
+    clear_discovery_cache as async_clear_discovery_cache,
+)
+from py_identity_model.aio.token_validation import (
+    clear_jwks_cache as async_clear_jwks_cache,
+)
+from py_identity_model.sync.token_validation import (
+    _get_cached_jwks,
+    clear_discovery_cache,
+    clear_jwks_cache,
+)
+
+from .token_validation_helpers import generate_rsa_keypair
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    clear_discovery_cache()
+    clear_jwks_cache()
+    async_clear_discovery_cache()
+    async_clear_jwks_cache()
+    yield
+    clear_discovery_cache()
+    clear_jwks_cache()
+    async_clear_discovery_cache()
+    async_clear_jwks_cache()
+
+
+# Per-fetch sleep. Long enough that serialized vs parallel differ by a
+# clear margin even with thread scheduling jitter, short enough to keep
+# the suite fast.
+FETCH_DELAY_SECONDS = 0.4
+# Total elapsed must be < 2x delay (parallel) and clearly < the serial
+# floor of 2x delay. The threshold lets one full delay fit but rejects two.
+PARALLEL_MAX_ELAPSED = FETCH_DELAY_SECONDS * 1.6
+
+
+def _make_jwks_payload() -> dict:
+    key_dict, _ = generate_rsa_keypair()
+    return {"keys": [key_dict]}
+
+
+def _build_slow_handler(payload: dict):
+    """Return a respx side_effect that sleeps before responding."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        time.sleep(FETCH_DELAY_SECONDS)
+        return httpx.Response(200, json=payload)
+
+    return handler
+
+
+def _build_slow_async_handler(payload: dict):
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        await asyncio.sleep(FETCH_DELAY_SECONDS)
+        return httpx.Response(200, json=payload)
+
+    return handler
+
+
+# ============================================================================
+# Sync: distinct URIs fetch in parallel (no global serialization)
+# ============================================================================
+
+
+class TestSyncDistinctUrisParallelizeFetches:
+    @respx.mock
+    def test_two_distinct_uris_fetch_in_parallel(self):
+        url_a = "https://op-a.example/jwks"
+        url_b = "https://op-b.example/jwks"
+        respx.get(url_a).mock(side_effect=_build_slow_handler(_make_jwks_payload()))
+        respx.get(url_b).mock(side_effect=_build_slow_handler(_make_jwks_payload()))
+
+        # Sync the start of both threads via a barrier so we measure
+        # actual concurrent fetch behavior, not staggered start jitter.
+        barrier = threading.Barrier(2)
+
+        def fetch(url: str) -> None:
+            barrier.wait()
+            _get_cached_jwks(url)
+
+        start = time.monotonic()
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            futures = [pool.submit(fetch, url_a), pool.submit(fetch, url_b)]
+            for f in futures:
+                f.result()
+        elapsed = time.monotonic() - start
+
+        # Pre-fix would have serialized to ~2x FETCH_DELAY_SECONDS.
+        assert elapsed < PARALLEL_MAX_ELAPSED, (
+            f"Distinct-URI fetches serialized: elapsed {elapsed:.2f}s, "
+            f"expected < {PARALLEL_MAX_ELAPSED:.2f}s. The cache must use "
+            "per-URI locking, not a single global lock."
+        )
+
+    @respx.mock
+    def test_same_uri_still_single_flight(self):
+        """The fix must not regress single-flight semantics: two concurrent
+        requests for the *same* URI must coalesce into one upstream fetch."""
+        url = "https://op-shared.example/jwks"
+        route = respx.get(url).mock(
+            side_effect=_build_slow_handler(_make_jwks_payload())
+        )
+
+        barrier = threading.Barrier(5)
+
+        def fetch() -> None:
+            barrier.wait()
+            _get_cached_jwks(url)
+
+        with ThreadPoolExecutor(max_workers=5) as pool:
+            futures = [pool.submit(fetch) for _ in range(5)]
+            for f in futures:
+                f.result()
+
+        # Single-flight: 5 concurrent same-URI requests → 1 upstream fetch.
+        assert route.call_count == 1
+
+
+# ============================================================================
+# Async: distinct URIs fetch in parallel
+# ============================================================================
+
+
+class TestAsyncDistinctUrisParallelizeFetches:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_two_distinct_uris_fetch_in_parallel_async(self):
+        url_a = "https://op-a.example/jwks"
+        url_b = "https://op-b.example/jwks"
+        respx.get(url_a).mock(
+            side_effect=_build_slow_async_handler(_make_jwks_payload())
+        )
+        respx.get(url_b).mock(
+            side_effect=_build_slow_async_handler(_make_jwks_payload())
+        )
+
+        start = time.monotonic()
+        await asyncio.gather(
+            async_get_cached_jwks(url_a),
+            async_get_cached_jwks(url_b),
+        )
+        elapsed = time.monotonic() - start
+
+        assert elapsed < PARALLEL_MAX_ELAPSED, (
+            f"Distinct-URI async fetches serialized: elapsed {elapsed:.2f}s, "
+            f"expected < {PARALLEL_MAX_ELAPSED:.2f}s. The async cache must "
+            "use per-URI locks, not a single asyncio.Lock held across await."
+        )
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_same_uri_still_single_flight_async(self):
+        url = "https://op-shared.example/jwks"
+        route = respx.get(url).mock(
+            side_effect=_build_slow_async_handler(_make_jwks_payload())
+        )
+
+        await asyncio.gather(*(async_get_cached_jwks(url) for _ in range(5)))
+        assert route.call_count == 1

--- a/src/tests/unit/test_sync_token_validation.py
+++ b/src/tests/unit/test_sync_token_validation.py
@@ -5,6 +5,7 @@ These tests verify sync-specific token validation logic including
 error handling, TTL-based JWKS caching, and signature retry on key rotation.
 """
 
+import contextlib
 import time
 from unittest.mock import patch
 
@@ -293,6 +294,72 @@ class TestSyncSignatureRetry:
 
         assert decoded["sub"] == "user1"
         assert jwks_route.call_count == JWKS_FETCH_WITH_RETRY  # initial fetch + refresh
+
+    @respx.mock
+    def test_cached_path_refreshes_jwks_when_kid_not_in_cache(self):
+        """Cached JWKS lookup with a kid not in cache forces a refresh.
+
+        OIDC OPs rotate signing keys; when a token arrives with a kid that is
+        not yet in the cached JWKS, the cache is stale. The library must
+        refresh JWKS without waiting for a signature failure on a key it
+        does not have.
+        """
+        old_key_dict, _ = generate_rsa_keypair()
+        old_key_dict["kid"] = "old-kid"
+
+        new_key_dict, new_pem = generate_rsa_keypair()
+        new_key_dict["kid"] = "new-kid"
+
+        token = sign_jwt(
+            new_pem,
+            {"sub": "user1", "iss": "https://example.com"},
+            headers={"kid": "new-kid"},
+        )
+
+        respx.get("https://example.com/.well-known/openid-configuration").mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+
+        # First fetch returns only the old kid; second fetch returns only the new kid.
+        # If the library waits for signature failure to refresh, the second fetch
+        # will not happen because the lookup raises before decode.
+        jwks_route = respx.get("https://example.com/jwks").mock(
+            side_effect=[
+                httpx.Response(200, json={"keys": [old_key_dict]}),
+                httpx.Response(200, json={"keys": [new_key_dict]}),
+            ]
+        )
+
+        config = TokenValidationConfig(
+            perform_disco=True,
+            audience=None,
+            issuer="https://example.com",
+        )
+
+        # Prime the cache by validating a token with the old kid.
+        old_pem_token = sign_jwt(
+            generate_rsa_keypair()[1],  # discard, we just need to populate cache
+            {"sub": "warmup"},
+            headers={"kid": "old-kid"},
+        )
+        # Trigger a cache populate without caring about the validation outcome.
+        with contextlib.suppress(
+            SignatureVerificationException, TokenValidationException
+        ):
+            validate_token(
+                jwt=old_pem_token,
+                token_validation_config=config,
+                disco_doc_address="https://example.com/.well-known/openid-configuration",
+            )
+
+        decoded = validate_token(
+            jwt=token,
+            token_validation_config=config,
+            disco_doc_address="https://example.com/.well-known/openid-configuration",
+        )
+
+        assert decoded["sub"] == "user1"
+        assert jwks_route.call_count == JWKS_FETCH_WITH_RETRY
 
     @respx.mock
     def test_signature_failure_still_raises_after_retry(self):

--- a/src/tests/unit/test_sync_token_validation.py
+++ b/src/tests/unit/test_sync_token_validation.py
@@ -5,7 +5,6 @@ These tests verify sync-specific token validation logic including
 error handling, TTL-based JWKS caching, and signature retry on key rotation.
 """
 
-import contextlib
 import time
 from unittest.mock import patch
 
@@ -21,6 +20,7 @@ from py_identity_model.exceptions import (
 )
 from py_identity_model.sync.managed_client import HTTPClient
 from py_identity_model.sync.token_validation import (
+    _get_cached_jwks,
     _get_disco_response,
     clear_discovery_cache,
     clear_jwks_cache,
@@ -254,7 +254,7 @@ class TestSyncSignatureRetry:
     def test_signature_retry_on_key_rotation(self):
         """When signature fails with cached key, refresh JWKS and retry with new key."""
         # Key 1 (old) — will be cached initially
-        old_key_dict, _old_pem = generate_rsa_keypair()
+        old_key_dict = generate_rsa_keypair()[0]
         old_key_dict["kid"] = "rotated-key"
 
         # Key 2 (new) — token is signed with this
@@ -304,7 +304,7 @@ class TestSyncSignatureRetry:
         refresh JWKS without waiting for a signature failure on a key it
         does not have.
         """
-        old_key_dict, _ = generate_rsa_keypair()
+        old_key_dict = generate_rsa_keypair()[0]
         old_key_dict["kid"] = "old-kid"
 
         new_key_dict, new_pem = generate_rsa_keypair()
@@ -336,21 +336,9 @@ class TestSyncSignatureRetry:
             issuer="https://example.com",
         )
 
-        # Prime the cache by validating a token with the old kid.
-        old_pem_token = sign_jwt(
-            generate_rsa_keypair()[1],  # discard, we just need to populate cache
-            {"sub": "warmup"},
-            headers={"kid": "old-kid"},
-        )
-        # Trigger a cache populate without caring about the validation outcome.
-        with contextlib.suppress(
-            SignatureVerificationException, TokenValidationException
-        ):
-            validate_token(
-                jwt=old_pem_token,
-                token_validation_config=config,
-                disco_doc_address="https://example.com/.well-known/openid-configuration",
-            )
+        # Prime the JWKS cache directly with the old kid (no validate_token, so
+        # the legacy retry path can't accidentally satisfy the assertion below).
+        _get_cached_jwks("https://example.com/jwks")
 
         decoded = validate_token(
             jwt=token,
@@ -359,15 +347,65 @@ class TestSyncSignatureRetry:
         )
 
         assert decoded["sub"] == "user1"
+        # The second fetch can ONLY have come from the new kid-miss refresh path
+        # inside _discover_and_resolve_key (legacy retry never gets a chance —
+        # validate_token only ran once and the kid was missing pre-decode).
         assert jwks_route.call_count == JWKS_FETCH_WITH_RETRY
+
+    @respx.mock
+    def test_no_refresh_when_kid_present_in_cache(self):
+        """Negative regression: when kid IS in cached JWKS, no refresh is issued.
+
+        Pins the predicate sense in the kid-miss check. A future change that
+        flipped `not any(...)` to `any(...)` would silently regress to
+        refreshing JWKS on every request.
+        """
+        key_dict, pem = generate_rsa_keypair()
+        key_dict["kid"] = "present-kid"
+
+        respx.get("https://example.com/.well-known/openid-configuration").mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+        jwks_route = respx.get("https://example.com/jwks").mock(
+            return_value=httpx.Response(200, json={"keys": [key_dict]})
+        )
+
+        token = sign_jwt(
+            pem,
+            {"sub": "user1", "iss": "https://example.com"},
+            headers={"kid": "present-kid"},
+        )
+        config = TokenValidationConfig(
+            perform_disco=True, audience=None, issuer="https://example.com"
+        )
+
+        # First call primes the cache (1 fetch).
+        validate_token(
+            jwt=token,
+            token_validation_config=config,
+            disco_doc_address="https://example.com/.well-known/openid-configuration",
+        )
+        assert jwks_route.call_count == 1
+
+        for _ in range(10):
+            validate_token(
+                jwt=token,
+                token_validation_config=config,
+                disco_doc_address="https://example.com/.well-known/openid-configuration",
+            )
+
+        assert jwks_route.call_count == 1, (
+            f"Predicate regression: {jwks_route.call_count} fetches for 11 "
+            f"validations with cached kid (expected 1)"
+        )
 
     @respx.mock
     def test_signature_failure_still_raises_after_retry(self):
         """When signature fails with both old and new keys, exception is raised."""
         # Both keys are different from the signing key
-        wrong_key1, _ = generate_rsa_keypair()
+        wrong_key1 = generate_rsa_keypair()[0]
         wrong_key1["kid"] = "wrong-key"
-        wrong_key2, _ = generate_rsa_keypair()
+        wrong_key2 = generate_rsa_keypair()[0]
         wrong_key2["kid"] = "wrong-key"
 
         # Sign with a completely different key
@@ -404,7 +442,7 @@ class TestSyncSignatureRetry:
     @respx.mock
     def test_di_path_retries_on_signature_failure(self):
         """DI (injected client) path retries JWKS fetch for key rotation support."""
-        wrong_key, _ = generate_rsa_keypair()
+        wrong_key = generate_rsa_keypair()[0]
         wrong_key["kid"] = "wrong-key"
 
         _, signing_pem = generate_rsa_keypair()


### PR DESCRIPTION
## Summary

Combines and supersedes #391 (kid-miss refresh + stampede pinning) and #392 (HTTP cache headers). Adds five additional fixes from an adversarial review of the cache primitive, every fix with a proving test that fails against the pre-fix code.

**Headline:** PR #392 as drafted introduced a regression — when a refresh response carried `Cache-Control: no-store` or `no-cache` (which Descope sends on JWKS), the fresh response was returned to the caller but the **stale entry was left in the cache**. Every subsequent token validation hit the stale entry, re-triggered the refresh, and hammered the upstream JWKS endpoint until the original 24h TTL expired — the exact DoS the cache exists to prevent. The first commit on this branch (after the two original PR commit chains) fixes that.

## Inherited from #391

- `fix(token-validation): refresh JWKS on cached kid miss` — pre-decode refresh on kid-miss in the cached path
- `test(token-validation): pin kid-miss stampede protection`
- `fix(token-validation): harden kid-miss refresh path with diagnostic, fixed test priming, and negative regression`

## Inherited from #392

- `fix(jwks-cache): respect HTTP cache headers for no-store, no-cache, and failed responses`
- `test(integration): skip caching benchmarks when provider sends no-store/no-cache`

## New on this branch — adversarial-review fixes

### C1 + H3 — `fix(jwks-cache): invalidate stale entry on uncacheable refresh and reject empty keys`

Decision-matrix helper (`apply_jwks_cache_outcome` / `apply_disco_cache_outcome`) in `core/jwks_cache.py`:

- Unsuccessful: retain existing (jose4j's retain-on-error semantics).
- `no-store`/`no-cache`: **pop** existing — fixes the regression that PR #392 introduced.
- Empty `keys: []`: retain existing — empty JWKS is a transient blip, never a valid replacement.
- Successful + cacheable + non-empty: store.

Sync and async share the helper so the failure-mode matrix cannot drift.

### H4 + C3 + C4 — `fix(jwks-cache): cap DoS amplification, clamp env config, bound cache size`

- **H4 kid-miss cooldown** (default 5s, env-tunable `KID_MISS_REFRESH_COOLDOWN`). Bounds the 1:1 amplification PR #391 introduced. Design borrows from Microsoft IdentityModel's `RefreshInterval` and Auth0 `node-jwks-rsa`'s `rateLimit`. Per-jwks_uri so an attacker against OP-A can't suppress refreshes for OP-B. Bypassed when cache is empty (cold start).
- **C3 env TTL clamping**. `JWKS_CACHE_TTL=0` (instantly-expired cache → DoS) and `JWKS_CACHE_TTL=2592000` (silent override of documented 24h ceiling) are now both clamped to `[60s, 86400s]`. Garbage values fall back to default with a warning instead of crashing.
- **C4 bounded LRU**. `JWKS_CACHE_MAX_ENTRIES` (default 64, env-tunable) caps memory under multi-tenant gateway scenarios. FIFO eviction via Python's insertion-ordered dicts; `apply_*_cache_outcome` pop-and-reinsert so refreshed URIs move to newest.

### C2 — `fix(jwks-cache): use per-URI lock striping so distinct issuers fetch in parallel`

Pre-fix: single `threading.Lock`/`asyncio.Lock` held across the upstream HTTP fetch. A fetch to `https://idp-a/jwks` blocked every other fetch to any other address. Under async this was strictly worse — held across `await`, the lock owned the event loop.

Post-fix: cache-aside with 32-stripe per-URI lock hash. Cheap `dict.get()` returns fresh entries with no lock at all. Only the upstream fetch on miss serializes — per URI. Same-URI single-flight semantics preserved.

## Proving tests

Every fix has a test that **fails against pre-fix code** and **passes against the fix**. I verified this for C1/H3 and H4 by stashing the fix and running the test against the pre-fix code:

| Fix | Test file | Proves |
|---|---|---|
| C1 + H3 | `test_cache_http_headers.py` | 17 new tests across 4 classes; refresh-with-uncacheable-response and empty-keys-200 cases. |
| H4 | `test_kid_miss_cooldown.py` | 13 tests: 25-attacker-request amplification, cold-start bypass, rotation-after-cooldown propagation, per-jwks_uri isolation, env override. |
| C3 + C4 | `test_cache_env_and_bounds.py` | 27 tests: 8 parametrized TTL clamp cases × 2 (JWKS + disco), garbage-value fail-safe, max-entries env override, FIFO order preservation across refresh+overflow, end-to-end size cap. |
| C2 | `test_per_uri_locks.py` | 4 tests: distinct-URI parallel (sync + async, ~2x speedup proved by wall-clock), same-URI single-flight preserved. |

## What's deferred (separate PR / follow-up)

- **M2 monotonic clock** — `time.time()` → `time.monotonic()` for cache age math. Real bug under NTP slew but lower impact and bigger blast radius (touches several existing tests).
- **H5 documentation** — README + docstring note that single-flight is per-process; under prefork (gunicorn workers) each worker has its own cache.
- **H6 `http_client` cache bypass** — when callers inject their own client, the cache is bypassed entirely. Documented in docstring; a proper fix means restructuring the cache as a transport wrapper.

These three are tracked but not blockers for this PR.

## How this is safer than #391 + #392 alone

#391 alone shipped a 1:1 DoS amplifier (no cooldown). #392 alone shipped the no-store stale-cache regression (the headline finding above). Both gaps are closed here, plus four structural bugs in the underlying cache primitive (env clamping, bounded growth, per-URI locks, decision-matrix unification).

## Test plan

- [x] `make lint` passes (ruff + ruff format + pyrefly + 80% coverage gate at 95.75%).
- [x] `make test-unit` — 1076 tests pass.
- [ ] Local conformance suite — confirm OIDF Config RP `oidcc-client-test-signing-key-rotation` still PASSes (covered by CI).
- [ ] Integration tests against Descope (CI).

Closes #391
Closes #392

🤖 Generated with [Claude Code](https://claude.com/claude-code)