### PR TITLE
fix(jwks-cache): use monotonic clock and capture request_time inside fetch lock

### DIFF
--- a/src/py_identity_model/aio/token_validation.py
+++ b/src/py_identity_model/aio/token_validation.py
@@ -100,7 +100,9 @@ async def _get_disco_response(
             DiscoveryDocumentRequest(address=disco_doc_address, policy=policy),
         )
         async with _disco_cache_write_lock:
-            apply_disco_cache_outcome(_disco_cache, cache_key, response, time.time())
+            apply_disco_cache_outcome(
+                _disco_cache, cache_key, response, time.monotonic()
+            )
         return response
 
 
@@ -149,7 +151,7 @@ async def _get_cached_jwks(jwks_uri: str) -> JwksResponse:
                 _jwks_cache,
                 jwks_uri,
                 response,
-                time.time(),
+                time.monotonic(),
                 cooldown=_kid_miss_last_attempt,
             )
         return response
@@ -162,10 +164,15 @@ async def _refresh_jwks(jwks_uri: str) -> JwksResponse:
     same URI while leaving unrelated URIs unblocked. The ``request_time``
     guard catches the case where another coroutine for *this* URI completed
     a refresh while we were blocked.
+
+    ``request_time`` is captured *inside* the lock so a coroutine that races
+    a just-released lock cannot observe its own ``request_time`` as older
+    than the entry the prior coroutine just wrote (causing a spurious
+    re-fetch).
     """
-    request_time = time.time()
     fetch_lock = _get_jwks_fetch_lock(jwks_uri)
     async with fetch_lock:
+        request_time = time.monotonic()
         entry = _jwks_cache.get(jwks_uri)
         if entry is not None and entry.cached_at >= request_time:
             return entry.response
@@ -177,7 +184,7 @@ async def _refresh_jwks(jwks_uri: str) -> JwksResponse:
                 _jwks_cache,
                 jwks_uri,
                 response,
-                time.time(),
+                time.monotonic(),
                 cooldown=_kid_miss_last_attempt,
             )
         return response
@@ -242,7 +249,7 @@ async def _discover_and_resolve_key(
             _kid_miss_last_attempt,
             jwks_uri,
             has_cached_keys=bool(cached_keys),
-            now=time.time(),
+            now=time.monotonic(),
         ):
             logger.info(
                 "kid %s not present in cached JWKS; refreshing (possible key rotation)",
@@ -257,7 +264,7 @@ async def _discover_and_resolve_key(
                     if kid_found:
                         _kid_miss_last_attempt.pop(jwks_uri, None)
                     else:
-                        _kid_miss_last_attempt[jwks_uri] = time.time()
+                        _kid_miss_last_attempt[jwks_uri] = time.monotonic()
             else:
                 kid_found = False
             validate_jwks_response(jwks_response)
@@ -304,7 +311,7 @@ async def _retry_with_refreshed_jwks(
         _kid_miss_last_attempt,
         jwks_uri,
         has_cached_keys=True,
-        now=time.time(),
+        now=time.monotonic(),
     ):
         logger.debug(
             "Signature-failure retry suppressed for %s: refresh cooldown active",
@@ -326,7 +333,7 @@ async def _retry_with_refreshed_jwks(
         decoded = decode_with_config(jwt, resolved_config, disco_doc_response.issuer)
     except Exception:
         async with _jwks_cache_write_lock:
-            _kid_miss_last_attempt[jwks_uri] = time.time()
+            _kid_miss_last_attempt[jwks_uri] = time.monotonic()
         raise
     async with _jwks_cache_write_lock:
         _kid_miss_last_attempt.pop(jwks_uri, None)

--- a/src/py_identity_model/core/jwks_cache.py
+++ b/src/py_identity_model/core/jwks_cache.py
@@ -358,13 +358,18 @@ class DiscoCacheEntry:
 def is_cache_expired(entry: JwksCacheEntry | DiscoCacheEntry) -> bool:
     """Check if a cache entry has expired using its own TTL.
 
+    Uses ``time.monotonic`` so cache freshness is robust against wall-clock
+    back-steps (NTP slew, container clock-skew correction). ``cached_at`` is
+    therefore a monotonic timestamp produced by the same clock — never an
+    interpretable wall-clock value.
+
     Args:
         entry: The cache entry to check.
 
     Returns:
         True if the entry is expired.
     """
-    age = time.time() - entry.cached_at
+    age = time.monotonic() - entry.cached_at
     expired = age >= entry.ttl
     if expired:
         logger.debug("Cache entry expired (age=%.1fs, ttl=%.1fs)", age, entry.ttl)

--- a/src/py_identity_model/sync/token_validation.py
+++ b/src/py_identity_model/sync/token_validation.py
@@ -104,7 +104,9 @@ def _get_disco_response(
             DiscoveryDocumentRequest(address=disco_doc_address, policy=policy)
         )
         with _disco_cache_write_lock:
-            apply_disco_cache_outcome(_disco_cache, cache_key, response, time.time())
+            apply_disco_cache_outcome(
+                _disco_cache, cache_key, response, time.monotonic()
+            )
         return response
 
 
@@ -159,7 +161,7 @@ def _get_cached_jwks(jwks_uri: str) -> JwksResponse:
                 _jwks_cache,
                 jwks_uri,
                 response,
-                time.time(),
+                time.monotonic(),
                 cooldown=_kid_miss_last_attempt,
             )
         return response
@@ -172,10 +174,14 @@ def _refresh_jwks(jwks_uri: str) -> JwksResponse:
     the same URI while leaving unrelated URIs unblocked. The ``request_time``
     guard catches the case where another caller for *this* URI completed a
     refresh while we were blocked.
+
+    ``request_time`` is captured *inside* the lock so a thread that races a
+    just-released lock cannot observe its own ``request_time`` as older than
+    the entry that thread A just wrote (causing a spurious re-fetch).
     """
-    request_time = time.time()
     fetch_lock = _get_jwks_fetch_lock(jwks_uri)
     with fetch_lock:
+        request_time = time.monotonic()
         entry = _jwks_cache.get(jwks_uri)
         if entry is not None and entry.cached_at >= request_time:
             return entry.response
@@ -187,7 +193,7 @@ def _refresh_jwks(jwks_uri: str) -> JwksResponse:
                 _jwks_cache,
                 jwks_uri,
                 response,
-                time.time(),
+                time.monotonic(),
                 cooldown=_kid_miss_last_attempt,
             )
         return response
@@ -251,7 +257,7 @@ def _discover_and_resolve_key(
             _kid_miss_last_attempt,
             jwks_uri,
             has_cached_keys=bool(cached_keys),
-            now=time.time(),
+            now=time.monotonic(),
         ):
             logger.info(
                 "kid %s not present in cached JWKS; refreshing (possible key rotation)",
@@ -279,7 +285,7 @@ def _discover_and_resolve_key(
                         # attacker drove an upstream fetch we couldn't
                         # turn into a successful validation). Stamp the
                         # cooldown to suppress repeats in the window.
-                        _kid_miss_last_attempt[jwks_uri] = time.time()
+                        _kid_miss_last_attempt[jwks_uri] = time.monotonic()
             else:
                 kid_found = False
             validate_jwks_response(jwks_response)
@@ -331,7 +337,7 @@ def _retry_with_refreshed_jwks(
         _kid_miss_last_attempt,
         jwks_uri,
         has_cached_keys=True,
-        now=time.time(),
+        now=time.monotonic(),
     ):
         logger.debug(
             "Signature-failure retry suppressed for %s: refresh cooldown active",
@@ -357,7 +363,7 @@ def _retry_with_refreshed_jwks(
         # decode) still failed — DoS amplifier case. Stamp to suppress
         # retry storms.
         with _jwks_cache_write_lock:
-            _kid_miss_last_attempt[jwks_uri] = time.time()
+            _kid_miss_last_attempt[jwks_uri] = time.monotonic()
         raise
     # Refreshed keys verified the JWT — real rotation absorbed. Clear the
     # stamp so a subsequent legitimate rotation isn't suppressed.

--- a/src/tests/unit/test_aio_token_validation.py
+++ b/src/tests/unit/test_aio_token_validation.py
@@ -222,9 +222,9 @@ class TestAsyncJwksCacheTTL:
         )
         assert jwks_route.call_count == 1
 
-        # Simulate TTL expiry
+        # Simulate TTL expiry via monotonic clock advance.
         with patch("py_identity_model.core.jwks_cache.time") as mock_time:
-            mock_time.time.return_value = time.time() + 86401
+            mock_time.monotonic.return_value = time.monotonic() + 86401
 
             await validate_token(
                 jwt=token,

--- a/src/tests/unit/test_cache_env_and_bounds.py
+++ b/src/tests/unit/test_cache_env_and_bounds.py
@@ -242,7 +242,7 @@ class TestBoundedCacheSize:
                 cache,
                 jwks_uri=f"https://op-{i}.example/jwks",
                 response=_make_jwks_response(f"kid-{i}"),
-                now=time.time(),
+                now=time.monotonic(),
             )
 
         assert len(cache) == 5  # noqa: PLR2004
@@ -265,7 +265,7 @@ class TestBoundedCacheSize:
                 cache,
                 jwks_uri=f"https://op-{i}.example/jwks",
                 response=_make_jwks_response(f"kid-{i}"),
-                now=time.time(),
+                now=time.monotonic(),
             )
         assert list(cache.keys()) == [
             "https://op-0.example/jwks",
@@ -278,7 +278,7 @@ class TestBoundedCacheSize:
             cache,
             jwks_uri="https://op-0.example/jwks",
             response=_make_jwks_response("kid-0-rotated"),
-            now=time.time(),
+            now=time.monotonic(),
         )
         assert list(cache.keys()) == [
             "https://op-1.example/jwks",
@@ -292,7 +292,7 @@ class TestBoundedCacheSize:
             cache,
             jwks_uri="https://op-3.example/jwks",
             response=_make_jwks_response("kid-3"),
-            now=time.time(),
+            now=time.monotonic(),
         )
         assert set(cache.keys()) == {
             "https://op-2.example/jwks",

--- a/src/tests/unit/test_cache_http_headers.py
+++ b/src/tests/unit/test_cache_http_headers.py
@@ -9,6 +9,8 @@ Covers three correctness fixes:
    simplest correct behavior is to skip caching.
 """
 
+import time
+
 import httpx
 import pytest
 import respx
@@ -419,10 +421,16 @@ class TestSyncRefreshInvalidatesStaleOnUncacheable:
         assert cache_key in sync_tv._disco_cache
 
         # Manually expire the entry without removing it — this is the state
-        # the cache lands in when the entry's TTL elapses naturally.
+        # the cache lands in when the entry's TTL elapses naturally. Backdate
+        # cached_at past the TTL boundary on the monotonic clock (post-#400
+        # the cache compares ages via time.monotonic, not time.time, so a
+        # literal 0.0 is just process-startup time and may still be fresh in
+        # short-running tests).
         stale_entry = sync_tv._disco_cache[cache_key]
         sync_tv._disco_cache[cache_key] = type(stale_entry)(
-            response=stale_entry.response, cached_at=0.0, ttl=stale_entry.ttl
+            response=stale_entry.response,
+            cached_at=time.monotonic() - stale_entry.ttl - 1,
+            ttl=stale_entry.ttl,
         )
 
         _get_disco_response(DISCO_URL)

--- a/src/tests/unit/test_cache_monotonic_clock.py
+++ b/src/tests/unit/test_cache_monotonic_clock.py
@@ -1,0 +1,406 @@
+"""
+Proves the JWKS/discovery cache and the kid-miss cooldown use ``time.monotonic``
+for all interval arithmetic, so wall-clock back-steps (NTP slew, container
+clock-skew correction, manual sysadmin action) cannot:
+
+- Leave a cache entry permanently "fresh" because ``time.time() - cached_at``
+  goes negative.
+- Wedge the kid-miss cooldown so a single dropped fetch suppresses every
+  subsequent refresh attempt for the cooldown window.
+
+Also pins the lock-ordering fix in ``_refresh_jwks``: ``request_time`` must be
+captured *inside* the per-URI fetch lock so the ``cached_at >= request_time``
+comparison reflects "now in the critical section" rather than "the moment
+the caller decided to refresh, captured outside the lock and stale by the
+time the lock was acquired."
+
+See:
+- https://github.com/jamescrowley321/py-identity-model/issues/400 (monotonic)
+- https://github.com/jamescrowley321/py-identity-model/issues/404 (request_time race)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+import respx
+
+from py_identity_model.aio import token_validation as aio_tv
+from py_identity_model.aio.token_validation import (
+    _kid_miss_last_attempt as async_kid_miss_last_attempt,
+)
+from py_identity_model.aio.token_validation import (
+    _refresh_jwks as async_refresh_jwks,
+)
+from py_identity_model.aio.token_validation import (
+    clear_discovery_cache as async_clear_discovery_cache,
+)
+from py_identity_model.aio.token_validation import (
+    clear_jwks_cache as async_clear_jwks_cache,
+)
+from py_identity_model.aio.token_validation import (
+    validate_token as async_validate_token,
+)
+from py_identity_model.core.jwks_cache import (
+    DiscoCacheEntry,
+    JwksCacheEntry,
+    _reset_env_for_testing,
+    get_kid_miss_cooldown,
+    is_cache_expired,
+)
+from py_identity_model.core.models import (
+    DiscoveryDocumentResponse,
+    TokenValidationConfig,
+)
+from py_identity_model.exceptions import TokenValidationException
+from py_identity_model.sync import token_validation as sync_tv
+from py_identity_model.sync.token_validation import (
+    _kid_miss_last_attempt as sync_kid_miss_last_attempt,
+)
+from py_identity_model.sync.token_validation import (
+    _refresh_jwks as sync_refresh_jwks,
+)
+from py_identity_model.sync.token_validation import (
+    clear_discovery_cache,
+    clear_jwks_cache,
+    validate_token,
+)
+
+from .token_validation_helpers import (
+    DISCO_RESPONSE_WITH_JWKS,
+    generate_rsa_keypair,
+    sign_jwt,
+)
+
+
+JWKS_URL = "https://example.com/jwks"
+DISCO_URL = "https://example.com/.well-known/openid-configuration"
+CLOCK_BACKSTEP_SECONDS = 60.0
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    clear_discovery_cache()
+    clear_jwks_cache()
+    async_clear_discovery_cache()
+    async_clear_jwks_cache()
+    _reset_env_for_testing()
+    yield
+    clear_discovery_cache()
+    clear_jwks_cache()
+    async_clear_discovery_cache()
+    async_clear_jwks_cache()
+    _reset_env_for_testing()
+
+
+# ============================================================================
+# is_cache_expired uses time.monotonic, not time.time.
+#
+# Pre-fix: ``time.time() - cached_at`` could go negative under NTP back-step,
+# making the entry appear permanently fresh. Post-fix: ``time.monotonic()``
+# is unaffected by wall-clock manipulation.
+# ============================================================================
+
+
+class TestCacheExpiryUsesMonotonicClock:
+    def test_jwks_entry_expires_via_monotonic_when_walltime_steps_back(self):
+        """Pre-fix this test would have failed: ``cached_at`` is a wall-clock
+        timestamp, ``time.time()`` steps back by 60s, and ``age = time.time() -
+        cached_at`` is negative for the remainder of the window — entry never
+        appears expired. Post-fix: ``cached_at`` is monotonic; ``time.time()``
+        manipulation is decoupled from expiry."""
+        # Anchor a monotonic instant; the entry's TTL is 60s and we'll
+        # advance only the monotonic clock past it.
+        monotonic_base = time.monotonic()
+        entry = JwksCacheEntry(
+            response=MagicMock(),
+            cached_at=monotonic_base,
+            ttl=60.0,
+        )
+
+        # Step wall-clock backward by 60s — the kind of NTP slew that broke
+        # the pre-fix logic. Independently advance monotonic past the TTL.
+        walltime_back = time.time() - CLOCK_BACKSTEP_SECONDS
+        with patch("py_identity_model.core.jwks_cache.time") as mock_time:
+            mock_time.time.return_value = walltime_back
+            mock_time.monotonic.return_value = monotonic_base + 61.0
+            assert is_cache_expired(entry) is True
+
+    def test_jwks_entry_stays_fresh_when_only_walltime_advances(self):
+        """The dual of the test above: wall-clock can race forward to past
+        the TTL boundary while monotonic stays put, and the entry must NOT
+        be considered expired — proving wall-clock is not consulted."""
+        monotonic_base = time.monotonic()
+        entry = JwksCacheEntry(
+            response=MagicMock(),
+            cached_at=monotonic_base,
+            ttl=60.0,
+        )
+
+        with patch("py_identity_model.core.jwks_cache.time") as mock_time:
+            mock_time.time.return_value = time.time() + 86400.0
+            mock_time.monotonic.return_value = monotonic_base + 30.0
+            assert is_cache_expired(entry) is False
+
+    def test_disco_entry_obeys_monotonic(self):
+        """Symmetric coverage for ``DiscoCacheEntry`` since both share
+        ``is_cache_expired``."""
+        monotonic_base = time.monotonic()
+        entry = DiscoCacheEntry(
+            response=MagicMock(spec=DiscoveryDocumentResponse),
+            cached_at=monotonic_base,
+            ttl=300.0,
+        )
+
+        with patch("py_identity_model.core.jwks_cache.time") as mock_time:
+            mock_time.time.return_value = time.time() - 600.0
+            mock_time.monotonic.return_value = monotonic_base + 301.0
+            assert is_cache_expired(entry) is True
+
+
+# ============================================================================
+# Kid-miss cooldown uses monotonic, not wall-clock.
+#
+# Pre-fix: ``now - last`` after an NTP back-step is negative, so
+# ``(now - last) >= cooldown`` is False forever (until wall-clock catches up).
+# Post-fix: both ``now`` and ``last`` come from ``time.monotonic`` — back-step
+# does not affect interval arithmetic.
+# ============================================================================
+
+
+class TestCooldownUsesMonotonicClock:
+    @respx.mock
+    def test_sync_cooldown_elapses_despite_wall_clock_backstep(self):
+        """Stamp the cooldown via the real refresh path; then step wall-clock
+        backward and advance monotonic past the cooldown window. The next
+        kid-miss must refresh — pre-fix it would have been suppressed for
+        the entire interval that wall-clock spent catching back up."""
+        defender_kd, _ = generate_rsa_keypair()
+        defender_kd["kid"] = "defender-kid"
+        respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+        jwks_route = respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(200, json={"keys": [defender_kd]})
+        )
+        config = TokenValidationConfig(
+            perform_disco=True, audience=None, issuer="https://example.com"
+        )
+
+        # Forge an unknown kid → triggers kid-miss → refresh → stamps cooldown
+        # (because the refreshed JWKS still lacks the unknown kid).
+        _, attacker_pem = generate_rsa_keypair()
+        attacker_token = sign_jwt(
+            attacker_pem,
+            {"sub": "attacker", "iss": "https://example.com"},
+            headers={"kid": "ghost-kid"},
+        )
+        with pytest.raises(TokenValidationException):
+            validate_token(
+                jwt=attacker_token,
+                token_validation_config=config,
+                disco_doc_address=DISCO_URL,
+            )
+        assert JWKS_URL in sync_kid_miss_last_attempt
+        # 1 prime + 1 kid-miss refresh.
+        baseline_fetches = 2
+        assert jwks_route.call_count == baseline_fetches
+
+        cooldown = get_kid_miss_cooldown()
+
+        # Wall-clock back-step paired with monotonic advance past cooldown.
+        # The cooldown stamp itself was set with time.monotonic, so simulate
+        # the elapse by mutating the stamp dict directly (it's just a float).
+        sync_kid_miss_last_attempt[JWKS_URL] = time.monotonic() - cooldown - 1.0
+        with patch("py_identity_model.sync.token_validation.time") as mock_time:
+            mock_time.time.return_value = time.time() - CLOCK_BACKSTEP_SECONDS
+            mock_time.monotonic.side_effect = time.monotonic
+
+            with pytest.raises(TokenValidationException):
+                validate_token(
+                    jwt=attacker_token,
+                    token_validation_config=config,
+                    disco_doc_address=DISCO_URL,
+                )
+
+        # A second refresh must have fired despite the wall-clock back-step,
+        # because the cooldown elapsed on the monotonic clock.
+        cooldown_elapsed_fetches = 3
+        assert jwks_route.call_count == cooldown_elapsed_fetches
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_async_cooldown_elapses_despite_wall_clock_backstep(self):
+        defender_kd, _ = generate_rsa_keypair()
+        defender_kd["kid"] = "defender-kid"
+        respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+        jwks_route = respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(200, json={"keys": [defender_kd]})
+        )
+        config = TokenValidationConfig(
+            perform_disco=True, audience=None, issuer="https://example.com"
+        )
+
+        _, attacker_pem = generate_rsa_keypair()
+        attacker_token = sign_jwt(
+            attacker_pem,
+            {"sub": "attacker", "iss": "https://example.com"},
+            headers={"kid": "ghost-kid"},
+        )
+        with pytest.raises(TokenValidationException):
+            await async_validate_token(
+                jwt=attacker_token,
+                token_validation_config=config,
+                disco_doc_address=DISCO_URL,
+            )
+        assert JWKS_URL in async_kid_miss_last_attempt
+        baseline_fetches = 2
+        assert jwks_route.call_count == baseline_fetches
+
+        cooldown = get_kid_miss_cooldown()
+        async_kid_miss_last_attempt[JWKS_URL] = time.monotonic() - cooldown - 1.0
+
+        with patch("py_identity_model.aio.token_validation.time") as mock_time:
+            mock_time.time.return_value = time.time() - CLOCK_BACKSTEP_SECONDS
+            mock_time.monotonic.side_effect = time.monotonic
+
+            with pytest.raises(TokenValidationException):
+                await async_validate_token(
+                    jwt=attacker_token,
+                    token_validation_config=config,
+                    disco_doc_address=DISCO_URL,
+                )
+
+        cooldown_elapsed_fetches = 3
+        assert jwks_route.call_count == cooldown_elapsed_fetches
+
+
+# ============================================================================
+# _refresh_jwks captures request_time INSIDE the fetch lock.
+#
+# Pre-fix: ``request_time = time.time()`` was captured before the lock
+# acquisition, so under contention the comparison ``cached_at >= request_time``
+# was evaluated against a stale timestamp. Post-fix: ``request_time`` is
+# captured after lock acquisition so the comparison is well-defined relative
+# to the current critical section.
+#
+# Strategy: wrap the per-URI fetch lock so its acquisition appends an event;
+# wrap ``time.monotonic`` so its calls append events too. Assert the first
+# ``time.monotonic`` call inside ``_refresh_jwks`` happens AFTER the lock
+# was acquired.
+# ============================================================================
+
+
+class _EventRecorder:
+    def __init__(self) -> None:
+        self.events: list[str] = []
+        self._sync_event_lock = threading.Lock()
+
+    def append(self, event: str) -> None:
+        with self._sync_event_lock:
+            self.events.append(event)
+
+
+class _TrackedSyncLock:
+    """Context-manager-only lock wrapper — production code uses ``with
+    fetch_lock:`` so explicit acquire/release pass-throughs aren't needed."""
+
+    def __init__(self, recorder: _EventRecorder) -> None:
+        self._lock = threading.Lock()
+        self._recorder = recorder
+
+    def __enter__(self) -> Any:
+        self._lock.acquire()
+        self._recorder.append("lock_acquired")
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._recorder.append("lock_released")
+        self._lock.release()
+
+
+class _TrackedAsyncLock:
+    def __init__(self, recorder: _EventRecorder) -> None:
+        self._lock = asyncio.Lock()
+        self._recorder = recorder
+
+    async def __aenter__(self) -> Any:
+        await self._lock.acquire()
+        self._recorder.append("lock_acquired")
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        self._recorder.append("lock_released")
+        self._lock.release()
+
+
+class TestRefreshJwksRequestTimeInsideLock:
+    @respx.mock
+    def test_sync_request_time_captured_after_lock_acquired(self, monkeypatch):
+        """The first ``time.monotonic`` call from inside ``_refresh_jwks``
+        must follow lock acquisition. Pre-fix the call was emitted BEFORE
+        ``with fetch_lock:`` and this assertion would have failed."""
+        key_dict = generate_rsa_keypair()[0]
+        respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(200, json={"keys": [key_dict]})
+        )
+
+        recorder = _EventRecorder()
+        tracked_lock = _TrackedSyncLock(recorder)
+        monkeypatch.setattr(sync_tv, "_get_jwks_fetch_lock", lambda _uri: tracked_lock)
+
+        real_monotonic = time.monotonic
+
+        def recording_monotonic() -> float:
+            recorder.append("monotonic_called")
+            return real_monotonic()
+
+        monkeypatch.setattr(sync_tv.time, "monotonic", recording_monotonic)
+
+        sync_refresh_jwks(JWKS_URL)
+
+        # The very first lock_acquired event must precede the first
+        # monotonic_called event.
+        first_lock = recorder.events.index("lock_acquired")
+        first_monotonic = recorder.events.index("monotonic_called")
+        assert first_lock < first_monotonic, (
+            "request_time must be captured inside the fetch lock; observed "
+            f"event order: {recorder.events}"
+        )
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_async_request_time_captured_after_lock_acquired(self, monkeypatch):
+        key_dict = generate_rsa_keypair()[0]
+        respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(200, json={"keys": [key_dict]})
+        )
+
+        recorder = _EventRecorder()
+        tracked_lock = _TrackedAsyncLock(recorder)
+        monkeypatch.setattr(aio_tv, "_get_jwks_fetch_lock", lambda _uri: tracked_lock)
+
+        real_monotonic = time.monotonic
+
+        def recording_monotonic() -> float:
+            recorder.append("monotonic_called")
+            return real_monotonic()
+
+        monkeypatch.setattr(aio_tv.time, "monotonic", recording_monotonic)
+
+        await async_refresh_jwks(JWKS_URL)
+
+        first_lock = recorder.events.index("lock_acquired")
+        first_monotonic = recorder.events.index("monotonic_called")
+        assert first_lock < first_monotonic, (
+            "request_time must be captured inside the fetch lock; observed "
+            f"event order: {recorder.events}"
+        )

--- a/src/tests/unit/test_cache_stampede.py
+++ b/src/tests/unit/test_cache_stampede.py
@@ -164,7 +164,7 @@ class TestSyncStampedeAfterExpiry:
         # Expire the entry by setting cached_at far in the past
         sync_tv._jwks_cache[JWKS_URL] = JwksCacheEntry(
             response=sync_tv._jwks_cache[JWKS_URL].response,
-            cached_at=time.time() - 86401,
+            cached_at=time.monotonic() - 86401,
             ttl=86400.0,
         )
 
@@ -204,7 +204,7 @@ class TestSyncStampedeAfterExpiry:
         cache_key = (DISCO_URL, True)
         sync_tv._disco_cache[cache_key] = DiscoCacheEntry(
             response=sync_tv._disco_cache[cache_key].response,
-            cached_at=time.time() - 3601,
+            cached_at=time.monotonic() - 3601,
             ttl=3600.0,
         )
 
@@ -288,7 +288,7 @@ class TestAsyncStampedeAfterExpiry:
         # Expire the entry
         aio_tv._jwks_cache[JWKS_URL] = JwksCacheEntry(
             response=aio_tv._jwks_cache[JWKS_URL].response,
-            cached_at=time.time() - 86401,
+            cached_at=time.monotonic() - 86401,
             ttl=86400.0,
         )
 
@@ -316,7 +316,7 @@ class TestAsyncStampedeAfterExpiry:
         cache_key = (DISCO_URL, True)
         aio_tv._disco_cache[cache_key] = DiscoCacheEntry(
             response=aio_tv._disco_cache[cache_key].response,
-            cached_at=time.time() - 3601,
+            cached_at=time.monotonic() - 3601,
             ttl=3600.0,
         )
 
@@ -348,7 +348,7 @@ class TestSyncRefreshJwksFreshnessGuard:
         entry = sync_tv._jwks_cache[JWKS_URL]
         sync_tv._jwks_cache[JWKS_URL] = JwksCacheEntry(
             response=entry.response,
-            cached_at=time.time() + 100,
+            cached_at=time.monotonic() + 100,
             ttl=entry.ttl,
         )
 
@@ -396,7 +396,7 @@ class TestAsyncRefreshJwksFreshnessGuard:
         entry = aio_tv._jwks_cache[JWKS_URL]
         aio_tv._jwks_cache[JWKS_URL] = JwksCacheEntry(
             response=entry.response,
-            cached_at=time.time() + 100,
+            cached_at=time.monotonic() + 100,
             ttl=entry.ttl,
         )
 

--- a/src/tests/unit/test_cache_ttl.py
+++ b/src/tests/unit/test_cache_ttl.py
@@ -44,7 +44,7 @@ class TestDiscoCacheTTL:
         response = MagicMock(spec=DiscoveryDocumentResponse)
         entry = DiscoCacheEntry(
             response=response,
-            cached_at=time.time() - 3700,  # 3700s ago, default TTL is 3600
+            cached_at=time.monotonic() - 3700,  # 3700s ago, default TTL is 3600
             ttl=DEFAULT_DISCO_CACHE_TTL_SECONDS,
         )
         assert is_cache_expired(entry) is True
@@ -54,7 +54,7 @@ class TestDiscoCacheTTL:
         response = MagicMock(spec=DiscoveryDocumentResponse)
         entry = DiscoCacheEntry(
             response=response,
-            cached_at=time.time(),
+            cached_at=time.monotonic(),
             ttl=DEFAULT_DISCO_CACHE_TTL_SECONDS,
         )
         assert is_cache_expired(entry) is False

--- a/src/tests/unit/test_jwks_cache.py
+++ b/src/tests/unit/test_jwks_cache.py
@@ -71,7 +71,7 @@ class TestCacheEntry:
         mock_response = MagicMock()
         return JwksCacheEntry(
             response=mock_response,
-            cached_at=time.time() - age_seconds,
+            cached_at=time.monotonic() - age_seconds,
             ttl=ttl,
         )
 
@@ -136,10 +136,10 @@ class TestMultiProviderCacheIsolation:
         auth0_ttl = resolve_ttl("max-age=3600")
 
         google_entry = JwksCacheEntry(
-            response=MagicMock(), cached_at=time.time(), ttl=google_ttl
+            response=MagicMock(), cached_at=time.monotonic(), ttl=google_ttl
         )
         auth0_entry = JwksCacheEntry(
-            response=MagicMock(), cached_at=time.time(), ttl=auth0_ttl
+            response=MagicMock(), cached_at=time.monotonic(), ttl=auth0_ttl
         )
 
         assert google_entry.ttl == 19800.0
@@ -149,7 +149,7 @@ class TestMultiProviderCacheIsolation:
 
     def test_one_provider_expired_other_not(self):
         """Provider with short TTL expires while long-TTL provider stays cached."""
-        now = time.time()
+        now = time.monotonic()
         short_entry = JwksCacheEntry(response=MagicMock(), cached_at=now - 120, ttl=60)
         long_entry = JwksCacheEntry(response=MagicMock(), cached_at=now - 120, ttl=3600)
 

--- a/src/tests/unit/test_kid_miss_cooldown.py
+++ b/src/tests/unit/test_kid_miss_cooldown.py
@@ -332,9 +332,10 @@ class TestCooldownDoesNotBlockLegitimateTraffic:
             )
         assert jwks_route.call_count == 2  # noqa: PLR2004
 
-        # Simulate cooldown elapse by backdating the last-attempt timestamp.
+        # Simulate cooldown elapse by backdating the last-attempt timestamp
+        # on the same monotonic clock the production code uses.
         cooldown = get_kid_miss_cooldown()
-        sync_kid_miss_last_attempt[JWKS_URL] = time.time() - cooldown - 1.0
+        sync_kid_miss_last_attempt[JWKS_URL] = time.monotonic() - cooldown - 1.0
 
         # 3rd attempt past cooldown: refresh fires again, upstream now serves
         # new-kid, rotation_token validates successfully.
@@ -481,9 +482,9 @@ class TestCooldownEvictedWithCache:
                 cache_control="max-age=3600",
             )
             apply_jwks_cache_outcome(
-                cache, url, response, time.time(), cooldown=cooldown
+                cache, url, response, time.monotonic(), cooldown=cooldown
             )
-            cooldown[url] = time.time()
+            cooldown[url] = time.monotonic()
 
         assert set(cache.keys()) == set(urls)
         assert set(cooldown.keys()) == set(urls)
@@ -508,7 +509,7 @@ class TestCooldownEvictedWithCache:
                 keys=[overflow_jwk],
                 cache_control="max-age=3600",
             ),
-            time.time(),
+            time.monotonic(),
             cooldown=cooldown,
         )
 
@@ -540,10 +541,10 @@ class TestCooldownEvictedWithCache:
             cache,
             url,
             JwksResponse(is_successful=True, keys=[jwk], cache_control="max-age=3600"),
-            time.time(),
+            time.monotonic(),
             cooldown=cooldown,
         )
-        cooldown[url] = time.time()
+        cooldown[url] = time.monotonic()
         assert url in cache
         assert url in cooldown
 
@@ -562,7 +563,7 @@ class TestCooldownEvictedWithCache:
             cache,
             url,
             JwksResponse(is_successful=True, keys=[new_jwk], cache_control="no-cache"),
-            time.time(),
+            time.monotonic(),
             cooldown=cooldown,
         )
         assert url not in cache

--- a/src/tests/unit/test_sync_token_validation.py
+++ b/src/tests/unit/test_sync_token_validation.py
@@ -233,9 +233,10 @@ class TestSyncJwksCacheTTL:
         )
         assert jwks_route.call_count == 1
 
-        # Simulate TTL expiry by shifting cached_at into the past
+        # Simulate TTL expiry by shifting the monotonic clock forward past
+        # the default 24h JWKS TTL.
         with patch("py_identity_model.core.jwks_cache.time") as mock_time:
-            mock_time.time.return_value = time.time() + 86401  # past 24h default TTL
+            mock_time.monotonic.return_value = time.monotonic() + 86401
 
             validate_token(
                 jwt=token,


### PR DESCRIPTION
## Summary

Two related thread-safety hardenings for the JWKS/discovery cache, bundled because they touch the same lock boundary and share rebase pain otherwise.

### #400 — Monotonic clock for cache + cooldown interval arithmetic

All cache freshness and cooldown timestamps now flow through ``time.monotonic`` instead of ``time.time``:

- ``is_cache_expired`` (``core/jwks_cache.py``)
- ``apply_*_cache_outcome(..., now=...)`` calls in sync + aio
- ``_refresh_jwks`` ``request_time`` capture
- ``should_attempt_kid_miss_refresh(..., now=...)`` in both signatures
- ``_kid_miss_last_attempt[uri] = ...`` cooldown stamps in both sync + aio paths

Wall-clock back-step (NTP slew, container clock-skew correction, manual sysadmin action) previously broke two ways:

- ``age = time.time() - cached_at`` went negative → entries appeared permanently fresh until wall-clock caught up.
- ``(now - last) >= cooldown`` evaluated False forever → cooldown never elapsed.

``cached_at`` is now a monotonic timestamp — an interval anchor, never an interpretable wall-clock value. The dataclass surface is unchanged; this is internal-only.

### #404 — ``request_time`` captured inside the per-URI fetch lock

In ``_refresh_jwks`` (both sync ``token_validation.py`` and aio mirror) the ``request_time`` was captured *before* acquiring the per-URI ``fetch_lock``:

```python
request_time = time.time()  # outside lock
fetch_lock = _get_jwks_fetch_lock(jwks_uri)
with fetch_lock:
    entry = _jwks_cache.get(jwks_uri)
    if entry is not None and entry.cached_at >= request_time:
        return entry.response
```

Under contention, ``request_time`` was stale relative to the critical section by the time the lock was acquired, breaking the single-flight semantics in the just-released-lock window. Post-fix the capture is inside the lock, so the comparison is well-defined.

## Test plan

New ``test_cache_monotonic_clock.py`` pins:

- [x] ``is_cache_expired`` follows monotonic, ignoring wall-clock advance / back-step (JWKS + disco).
- [x] Kid-miss cooldown elapses on monotonic clock despite wall-clock back-step (sync + aio end-to-end).
- [x] ``request_time`` is captured after lock acquisition in ``_refresh_jwks`` (sync + aio), proven via an event-recording lock wrapper.

Updated existing tests (test_cache_ttl, test_cache_stampede, test_jwks_cache, test_kid_miss_cooldown, test_cache_env_and_bounds, test_sync_token_validation, test_aio_token_validation) to use ``time.monotonic`` for cache-entry timestamps so they continue to exercise the production path.

- [x] ``make lint`` (ruff + pyrefly + pytest with 80% coverage) passes.
- [x] All 187 cache-related tests pass locally.
- [ ] CI (unit + integration + conformance + examples) green.

Closes #400
Closes #404