### PR TITLE
docs(jwks-cache): document http_client bypass and emit one-shot warning

### DIFF
--- a/src/py_identity_model/aio/token_validation.py
+++ b/src/py_identity_model/aio/token_validation.py
@@ -6,6 +6,7 @@ with automatic cache expiry and forced JWKS refresh on key rotation.
 """
 
 import asyncio
+import threading
 import time
 
 from ..core.discovery_policy import DiscoveryPolicy
@@ -193,6 +194,44 @@ def clear_jwks_cache() -> None:
 # Token validation
 # ============================================================================
 
+# See sync mirror for rationale. Uses ``threading.Lock`` rather than
+# ``asyncio.Lock`` so the once-per-process check is callable from a sync
+# context (the helper itself doesn't await) and works under any event loop.
+_injected_http_client_warning_emitted = False
+_injected_http_client_warning_lock = threading.Lock()
+
+
+def _maybe_warn_injected_http_client() -> None:
+    """Emit a one-shot warning when an injected ``http_client`` is first used.
+
+    Mirror of the sync helper — the warning state is per-module (sync and
+    aio each fire at most once per process) so a deployment that uses both
+    APIs sees at most two warnings, not one per call.
+    """
+    global _injected_http_client_warning_emitted  # noqa: PLW0603
+    if _injected_http_client_warning_emitted:
+        return
+    with _injected_http_client_warning_lock:
+        if _injected_http_client_warning_emitted:
+            return
+        _injected_http_client_warning_emitted = True
+        logger.warning(
+            "validate_token invoked with an injected http_client: discovery "
+            "cache, JWKS cache, kid-miss cooldown, and signature-failure "
+            "cooldown are all bypassed for this code path. Every call "
+            "re-fetches from the upstream provider and an attacker forging "
+            "unknown kids or wrong signatures can drive 1:1 upstream fetches. "
+            "This warning fires once per process; subsequent injected-client "
+            "calls are silent."
+        )
+
+
+def _reset_injected_http_client_warning_for_testing() -> None:
+    """Test helper: clear the one-shot warning flag so a test can re-trigger."""
+    global _injected_http_client_warning_emitted  # noqa: PLW0603
+    with _injected_http_client_warning_lock:
+        _injected_http_client_warning_emitted = False
+
 
 async def _discover_and_resolve_key(
     jwt: str,
@@ -205,6 +244,7 @@ async def _discover_and_resolve_key(
     Returns (key_dict, alg, disco_response, is_cached_path).
     """
     if http_client is not None:
+        _maybe_warn_injected_http_client()
         if disco_doc_address is None:
             raise ConfigurationException(
                 "disco_doc_address is required when perform_disco is True"
@@ -346,9 +386,28 @@ async def validate_token(
         jwt: The JWT token to validate
         token_validation_config: Token validation configuration
         disco_doc_address: Discovery document address (required if perform_disco=True)
-        http_client: Optional managed HTTP client.  When ``None``, uses the
-            module-level singleton with response caching.  When provided,
-            caching is bypassed and the injected client is used directly.
+        http_client: Optional managed HTTP client. When ``None`` (the default),
+            uses the module-level singleton with the full TTL cache + cooldown
+            stack. When provided, **all of the following are bypassed**:
+
+            - **Discovery document cache** — every call re-fetches the
+              ``.well-known/openid-configuration`` document.
+            - **JWKS cache** — every call re-fetches the JWKS.
+            - **Kid-miss cooldown** — an attacker forging tokens with unknown
+              ``kid`` headers drives 1:1 upstream JWKS fetches with no rate
+              limit.
+            - **Signature-failure cooldown** — an attacker forging signatures
+              against cached kids drives 1:1 upstream JWKS fetches on the
+              retry path with no rate limit.
+
+            The injected-client path is appropriate for one-off validations
+            (CLI tooling, tests) and for callers that have implemented their
+            own caching layer over the HTTP client. It is **not** appropriate
+            for high-volume request paths exposed to untrusted JWTs.
+
+            A ``logger.warning`` is emitted the first time an injected client
+            is used in the process so accidental opt-out is detectable in
+            production logs.
 
     Returns:
         dict: Decoded token claims

--- a/src/py_identity_model/sync/token_validation.py
+++ b/src/py_identity_model/sync/token_validation.py
@@ -204,6 +204,47 @@ def clear_jwks_cache() -> None:
 # Token validation
 # ============================================================================
 
+# Tracks whether the injected-``http_client`` bypass warning has already been
+# emitted in this process. Guarded by ``_injected_http_client_warning_lock``
+# so the warning fires exactly once per process even under concurrent first
+# use. Reset via ``_reset_injected_http_client_warning_for_testing``.
+_injected_http_client_warning_emitted = False
+_injected_http_client_warning_lock = threading.Lock()
+
+
+def _maybe_warn_injected_http_client() -> None:
+    """Emit a one-shot warning when an injected ``http_client`` is first used.
+
+    The injected-client code path bypasses the discovery cache, the JWKS
+    cache, the kid-miss cooldown, and the signature-failure cooldown. The
+    docstring documents this; the runtime warning lets operators detect
+    accidental opt-out (e.g., a middleware that forwards an ambient client
+    into every call) without reading the docs.
+    """
+    global _injected_http_client_warning_emitted  # noqa: PLW0603
+    if _injected_http_client_warning_emitted:
+        return
+    with _injected_http_client_warning_lock:
+        if _injected_http_client_warning_emitted:
+            return
+        _injected_http_client_warning_emitted = True
+        logger.warning(
+            "validate_token invoked with an injected http_client: discovery "
+            "cache, JWKS cache, kid-miss cooldown, and signature-failure "
+            "cooldown are all bypassed for this code path. Every call "
+            "re-fetches from the upstream provider and an attacker forging "
+            "unknown kids or wrong signatures can drive 1:1 upstream fetches. "
+            "This warning fires once per process; subsequent injected-client "
+            "calls are silent."
+        )
+
+
+def _reset_injected_http_client_warning_for_testing() -> None:
+    """Test helper: clear the one-shot warning flag so a test can re-trigger."""
+    global _injected_http_client_warning_emitted  # noqa: PLW0603
+    with _injected_http_client_warning_lock:
+        _injected_http_client_warning_emitted = False
+
 
 def _discover_and_resolve_key(
     jwt: str,
@@ -216,6 +257,7 @@ def _discover_and_resolve_key(
     Returns (key_dict, alg, disco_response, is_cached_path).
     """
     if http_client is not None:
+        _maybe_warn_injected_http_client()
         if disco_doc_address is None:
             raise ConfigurationException(
                 "disco_doc_address is required when perform_disco is True"
@@ -379,9 +421,28 @@ def validate_token(
         jwt: The JWT token to validate
         token_validation_config: Token validation configuration
         disco_doc_address: Discovery document address (required if perform_disco=True)
-        http_client: Optional managed HTTP client.  When ``None``, uses the
-            thread-local default with response caching.  When provided,
-            caching is bypassed and the injected client is used directly.
+        http_client: Optional managed HTTP client. When ``None`` (the default),
+            uses the thread-local default with the full TTL cache + cooldown
+            stack. When provided, **all of the following are bypassed**:
+
+            - **Discovery document cache** — every call re-fetches the
+              ``.well-known/openid-configuration`` document.
+            - **JWKS cache** — every call re-fetches the JWKS.
+            - **Kid-miss cooldown** — an attacker forging tokens with unknown
+              ``kid`` headers drives 1:1 upstream JWKS fetches with no rate
+              limit.
+            - **Signature-failure cooldown** — an attacker forging signatures
+              against cached kids drives 1:1 upstream JWKS fetches on the
+              retry path with no rate limit.
+
+            The injected-client path is appropriate for one-off validations
+            (CLI tooling, tests) and for callers that have implemented their
+            own caching layer over the HTTP client. It is **not** appropriate
+            for high-volume request paths exposed to untrusted JWTs.
+
+            A ``logger.warning`` is emitted the first time an injected client
+            is used in the process so accidental opt-out is detectable in
+            production logs.
 
     Returns:
         dict: Decoded token claims

--- a/src/tests/unit/test_http_client_bypass_warning.py
+++ b/src/tests/unit/test_http_client_bypass_warning.py
@@ -1,0 +1,260 @@
+"""
+Proves the one-shot ``logger.warning`` for the injected-``http_client`` bypass
+path so operators can detect accidental cache opt-out in production logs.
+
+The ``http_client`` parameter on ``validate_token`` skips the discovery cache,
+the JWKS cache, the kid-miss cooldown, and the signature-failure cooldown
+(see PR #395 C-1 — cooldown is gated only on the cached path). A caller who
+expects "I'm just controlling the HTTP client" gets a silent DoS amplifier
+unless the bypass is surfaced at runtime.
+
+Pinned contract:
+- A warning is emitted the first time ``validate_token`` is called with an
+  injected client.
+- Subsequent calls in the same process do NOT emit the warning.
+- The cached-path (no injected client) never emits the warning.
+- Sync and aio modules each have their own one-shot flag, so a process that
+  uses both APIs sees at most two warnings.
+
+See https://github.com/jamescrowley321/py-identity-model/issues/402
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch
+
+import httpx
+import pytest
+import respx
+
+from py_identity_model.aio import token_validation as aio_tv
+from py_identity_model.aio.managed_client import AsyncHTTPClient
+from py_identity_model.aio.token_validation import (
+    clear_discovery_cache as async_clear_discovery_cache,
+)
+from py_identity_model.aio.token_validation import (
+    clear_jwks_cache as async_clear_jwks_cache,
+)
+from py_identity_model.aio.token_validation import (
+    validate_token as async_validate_token,
+)
+from py_identity_model.core.models import TokenValidationConfig
+from py_identity_model.sync import token_validation as sync_tv
+from py_identity_model.sync.managed_client import HTTPClient
+from py_identity_model.sync.token_validation import (
+    clear_discovery_cache,
+    clear_jwks_cache,
+    validate_token,
+)
+
+from .token_validation_helpers import (
+    DISCO_RESPONSE_WITH_JWKS,
+    generate_rsa_keypair,
+    sign_jwt,
+)
+
+
+DISCO_URL = "https://example.com/.well-known/openid-configuration"
+JWKS_URL = "https://example.com/jwks"
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    clear_discovery_cache()
+    clear_jwks_cache()
+    async_clear_discovery_cache()
+    async_clear_jwks_cache()
+    sync_tv._reset_injected_http_client_warning_for_testing()
+    aio_tv._reset_injected_http_client_warning_for_testing()
+    yield
+    clear_discovery_cache()
+    clear_jwks_cache()
+    async_clear_discovery_cache()
+    async_clear_jwks_cache()
+    sync_tv._reset_injected_http_client_warning_for_testing()
+    aio_tv._reset_injected_http_client_warning_for_testing()
+
+
+def _make_validation_setup() -> tuple[str, dict, TokenValidationConfig]:
+    key_dict, pem = generate_rsa_keypair()
+    key_dict["kid"] = "test-kid"
+    token = sign_jwt(
+        pem,
+        {"sub": "user1", "iss": "https://example.com"},
+        headers={"kid": "test-kid"},
+    )
+    config = TokenValidationConfig(
+        perform_disco=True, audience=None, issuer="https://example.com"
+    )
+    return token, key_dict, config
+
+
+def _mock_disco_and_jwks(key_dict: dict) -> None:
+    respx.get(DISCO_URL).mock(
+        return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+    )
+    respx.get(JWKS_URL).mock(
+        return_value=httpx.Response(200, json={"keys": [key_dict]})
+    )
+
+
+def _count_bypass_warnings(records: list[logging.LogRecord]) -> int:
+    return sum(
+        1
+        for r in records
+        if r.levelno == logging.WARNING and "injected http_client" in r.getMessage()
+    )
+
+
+# ============================================================================
+# Sync: warning fires exactly once across multiple injected-client calls;
+# never fires on the cached path.
+# ============================================================================
+
+
+class TestSyncInjectedClientWarning:
+    @respx.mock
+    def test_warning_emitted_on_first_injected_client_call(self, caplog):
+        token, key_dict, config = _make_validation_setup()
+        _mock_disco_and_jwks(key_dict)
+
+        with (
+            caplog.at_level(logging.WARNING, logger="py_identity_model"),
+            HTTPClient() as client,
+        ):
+            validate_token(
+                jwt=token,
+                token_validation_config=config,
+                disco_doc_address=DISCO_URL,
+                http_client=client,
+            )
+
+        assert _count_bypass_warnings(caplog.records) == 1
+
+    @respx.mock
+    def test_warning_emitted_only_once_across_repeated_calls(self, caplog):
+        token, key_dict, config = _make_validation_setup()
+        _mock_disco_and_jwks(key_dict)
+
+        with (
+            caplog.at_level(logging.WARNING, logger="py_identity_model"),
+            HTTPClient() as client,
+        ):
+            for _ in range(5):
+                validate_token(
+                    jwt=token,
+                    token_validation_config=config,
+                    disco_doc_address=DISCO_URL,
+                    http_client=client,
+                )
+
+        assert _count_bypass_warnings(caplog.records) == 1
+
+    @respx.mock
+    def test_warning_not_emitted_on_cached_path(self, caplog):
+        """The default (no http_client) path must never log the bypass
+        warning — it's specifically for the injected-client opt-out."""
+        token, key_dict, config = _make_validation_setup()
+        _mock_disco_and_jwks(key_dict)
+
+        with caplog.at_level(logging.WARNING, logger="py_identity_model"):
+            for _ in range(3):
+                validate_token(
+                    jwt=token,
+                    token_validation_config=config,
+                    disco_doc_address=DISCO_URL,
+                )
+
+        assert _count_bypass_warnings(caplog.records) == 0
+
+
+# ============================================================================
+# Async mirror: same contract on the aio API.
+# ============================================================================
+
+
+class TestAsyncInjectedClientWarning:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_warning_emitted_on_first_injected_client_call(self, caplog):
+        token, key_dict, config = _make_validation_setup()
+        _mock_disco_and_jwks(key_dict)
+
+        with caplog.at_level(logging.WARNING, logger="py_identity_model"):
+            async with AsyncHTTPClient() as client:
+                await async_validate_token(
+                    jwt=token,
+                    token_validation_config=config,
+                    disco_doc_address=DISCO_URL,
+                    http_client=client,
+                )
+
+        assert _count_bypass_warnings(caplog.records) == 1
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_warning_emitted_only_once_across_repeated_calls(self, caplog):
+        token, key_dict, config = _make_validation_setup()
+        _mock_disco_and_jwks(key_dict)
+
+        with caplog.at_level(logging.WARNING, logger="py_identity_model"):
+            async with AsyncHTTPClient() as client:
+                for _ in range(5):
+                    await async_validate_token(
+                        jwt=token,
+                        token_validation_config=config,
+                        disco_doc_address=DISCO_URL,
+                        http_client=client,
+                    )
+
+        assert _count_bypass_warnings(caplog.records) == 1
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_warning_not_emitted_on_cached_path(self, caplog):
+        token, key_dict, config = _make_validation_setup()
+        _mock_disco_and_jwks(key_dict)
+
+        with caplog.at_level(logging.WARNING, logger="py_identity_model"):
+            for _ in range(3):
+                await async_validate_token(
+                    jwt=token,
+                    token_validation_config=config,
+                    disco_doc_address=DISCO_URL,
+                )
+
+        assert _count_bypass_warnings(caplog.records) == 0
+
+
+# ============================================================================
+# The warning helper directly: race-free first-emit guarantee under the
+# threading.Lock + flag combination, independent of the validate_token plumbing.
+# ============================================================================
+
+
+class TestWarningHelperContract:
+    def test_sync_helper_emits_once_on_repeated_calls(self):
+        sync_tv._reset_injected_http_client_warning_for_testing()
+        with patch.object(sync_tv, "logger") as mock_logger:
+            for _ in range(10):
+                sync_tv._maybe_warn_injected_http_client()
+            assert mock_logger.warning.call_count == 1
+
+    def test_async_helper_emits_once_on_repeated_calls(self):
+        aio_tv._reset_injected_http_client_warning_for_testing()
+        with patch.object(aio_tv, "logger") as mock_logger:
+            for _ in range(10):
+                aio_tv._maybe_warn_injected_http_client()
+            assert mock_logger.warning.call_count == 1
+
+    def test_sync_reset_helper_reactivates_warning(self):
+        warnings_after_reset = 2
+        sync_tv._reset_injected_http_client_warning_for_testing()
+        with patch.object(sync_tv, "logger") as mock_logger:
+            sync_tv._maybe_warn_injected_http_client()
+            sync_tv._maybe_warn_injected_http_client()
+            assert mock_logger.warning.call_count == 1
+            sync_tv._reset_injected_http_client_warning_for_testing()
+            sync_tv._maybe_warn_injected_http_client()
+            assert mock_logger.warning.call_count == warnings_after_reset


### PR DESCRIPTION
## Summary

When a caller passes ``http_client`` to ``validate_token``, the code path skips the cached discovery + cached JWKS path, AND the cooldown gate in ``_retry_with_refreshed_jwks`` (see PR #395 C-1 — the cooldown gate is only on the cached path). The existing docstring said "caching is bypassed" but understated the operational cost — a caller who thought they were just controlling the HTTP client was silently opting out of the DoS-amplification protections.

This PR addresses #402 with the smallest-scope change:

1. **Expanded docstrings** on ``validate_token`` (sync + aio) that explicitly list everything bypassed: discovery cache, JWKS cache, kid-miss cooldown, signature-failure cooldown — plus when the injected-client path is appropriate vs not.

2. **One-shot ``logger.warning``** emitted the first time an injected client is used per process, so accidental opt-out is surfaced in production logs without requiring docstring archaeology. The warning is guarded by ``threading.Lock`` + flag so it fires exactly once even under concurrent first use.

Out of scope (tracked separately): making cache + cooldown opt-in for the injected-client path is a larger design change.

## Test plan

New ``test_http_client_bypass_warning.py`` (9 tests) pins:

- [x] First injected-client call emits a warning (sync + aio).
- [x] Repeated injected-client calls emit only one warning (sync + aio).
- [x] Cached path never emits the warning (sync + aio).
- [x] Helper-level contract: ``_maybe_warn_injected_http_client`` emits exactly once across 10 direct calls.
- [x] Helper-level contract: ``_reset_injected_http_client_warning_for_testing`` re-arms the warning.

- [x] ``make lint`` (ruff + pyrefly + pytest with 80% coverage) passes.
- [ ] CI (unit + integration + conformance + examples) green.

Closes #402