### PR TITLE
fix(jwks-cache)!: convert aio clear_*_cache helpers to async

### DIFF
--- a/src/py_identity_model/aio/token_validation.py
+++ b/src/py_identity_model/aio/token_validation.py
@@ -107,9 +107,18 @@ async def _get_disco_response(
         return response
 
 
-def clear_discovery_cache() -> None:
-    """Clear the discovery cache."""
-    _disco_cache.clear()
+async def clear_discovery_cache() -> None:
+    """Clear the discovery cache.
+
+    **Breaking change (v3.0.0):** this helper is now ``async`` so it can
+    acquire ``_disco_cache_write_lock`` before clearing. The previous
+    synchronous version mutated state guarded by an ``asyncio.Lock``
+    without awaiting it, so a coroutine mid-flight in ``_refresh_jwks``
+    could write its result back *after* ``clear()`` ran, leaving the
+    "cleared" cache holding an entry. Callers must now ``await``.
+    """
+    async with _disco_cache_write_lock:
+        _disco_cache.clear()
 
 
 # ============================================================================
@@ -191,10 +200,21 @@ async def _refresh_jwks(jwks_uri: str) -> JwksResponse:
         return response
 
 
-def clear_jwks_cache() -> None:
-    """Clear the JWKS cache. Useful for testing."""
-    _jwks_cache.clear()
-    _kid_miss_last_attempt.clear()
+async def clear_jwks_cache() -> None:
+    """Clear the JWKS cache. Useful for testing.
+
+    **Breaking change (v3.0.0):** this helper is now ``async`` so it can
+    acquire ``_jwks_cache_write_lock`` before clearing. The previous
+    synchronous version mutated state guarded by an ``asyncio.Lock``
+    without awaiting it, so a coroutine mid-flight in ``_refresh_jwks``
+    could write its result back *after* ``clear()`` ran, leaving the
+    "cleared" cache holding an entry. The cooldown sidecar
+    (``_kid_miss_last_attempt``) is cleared under the same lock for the
+    same reason. Callers must now ``await``.
+    """
+    async with _jwks_cache_write_lock:
+        _jwks_cache.clear()
+        _kid_miss_last_attempt.clear()
 
 
 # ============================================================================

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -76,17 +76,21 @@ async def _close_async_http_client():
 
 
 @pytest.fixture(autouse=True)
-def _clear_async_caches():
+async def _clear_async_caches():
     """Clear async caches between tests.
 
     Since pytest-asyncio creates a new event loop per test function,
     stale caches from a previous loop must be cleared.
+
+    The async ``clear_*`` helpers must be ``await``ed because they now
+    acquire the per-cache ``asyncio.Lock`` before clearing (#405). Runs
+    inside the test's event loop under pytest-asyncio auto mode.
     """
     # Clear TTL-based discovery cache
-    clear_discovery_cache()
+    await clear_discovery_cache()
 
     # Clear dict-based JWKS TTL cache
-    clear_jwks_cache()
+    await clear_jwks_cache()
 
     # Reset the singleton async HTTP client so it gets recreated
     # on the new event loop.  The client is already closed by the

--- a/src/tests/unit/test_aio_token_validation.py
+++ b/src/tests/unit/test_aio_token_validation.py
@@ -46,13 +46,17 @@ def rsa_keypair():
 
 
 @pytest.fixture(autouse=True)
-def _clear_caches():
-    """Clear all caches between tests."""
-    clear_discovery_cache()
-    clear_jwks_cache()
+async def _clear_caches():
+    """Clear all caches between tests.
+
+    ``clear_*_cache`` helpers are imported from the aio module and are now
+    coroutines (#405) — must be awaited.
+    """
+    await clear_discovery_cache()
+    await clear_jwks_cache()
     yield
-    clear_discovery_cache()
-    clear_jwks_cache()
+    await clear_discovery_cache()
+    await clear_jwks_cache()
 
 
 class TestAsyncTokenValidation:

--- a/src/tests/unit/test_async_clear_cache_locking.py
+++ b/src/tests/unit/test_async_clear_cache_locking.py
@@ -1,0 +1,195 @@
+"""
+Proves the async ``clear_*_cache`` helpers acquire the cache write lock
+before mutating state, eliminating the race where a coroutine mid-flight
+in ``_refresh_jwks`` writes back *after* ``clear()`` runs and leaves the
+cleared cache holding a stale entry.
+
+Pre-fix the helpers were sync functions that called ``_cache.clear()``
+without acquiring ``_*_cache_write_lock`` (the lock is an
+``asyncio.Lock``, which can only be awaited). Post-fix they are async and
+``async with`` the lock before clearing.
+
+This is a breaking API change documented in the helper docstrings —
+callers must now ``await``. Tests in this file pin the new contract.
+
+See https://github.com/jamescrowley321/py-identity-model/issues/405
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+
+import httpx
+import pytest
+import respx
+
+from py_identity_model.aio import token_validation as aio_tv
+from py_identity_model.aio.token_validation import (
+    clear_discovery_cache as async_clear_discovery_cache,
+)
+from py_identity_model.aio.token_validation import (
+    clear_jwks_cache as async_clear_jwks_cache,
+)
+from py_identity_model.core.jwks_cache import DiscoCacheEntry, JwksCacheEntry
+from py_identity_model.core.models import (
+    DiscoveryDocumentResponse,
+    JsonWebKey,
+    JwksResponse,
+)
+
+
+JWKS_URL = "https://example.com/jwks"
+
+
+# ============================================================================
+# Public-API breaking-change contract: these helpers are coroutines now.
+# ============================================================================
+
+
+class TestAsyncClearHelpersAreCoroutines:
+    def test_clear_discovery_cache_is_coroutine_function(self):
+        assert inspect.iscoroutinefunction(async_clear_discovery_cache)
+
+    def test_clear_jwks_cache_is_coroutine_function(self):
+        assert inspect.iscoroutinefunction(async_clear_jwks_cache)
+
+    def test_calling_clear_discovery_without_await_returns_coroutine(self):
+        """Calling the helper without ``await`` produces a coroutine object
+        — useful diagnostic for users upgrading from the sync version, who
+        will get a clear ``RuntimeWarning: coroutine was never awaited``."""
+        coroutine = async_clear_discovery_cache()
+        assert inspect.iscoroutine(coroutine)
+        # Close the coroutine to suppress the never-awaited warning.
+        coroutine.close()
+
+    def test_calling_clear_jwks_without_await_returns_coroutine(self):
+        coroutine = async_clear_jwks_cache()
+        assert inspect.iscoroutine(coroutine)
+        coroutine.close()
+
+
+# ============================================================================
+# Functional contract: clear actually clears, even with state present.
+# ============================================================================
+
+
+def _make_jwk_response(kid: str) -> JwksResponse:
+    return JwksResponse(
+        is_successful=True,
+        keys=[JsonWebKey(kty="RSA", kid=kid, alg="RS256", use="sig", n="n", e="AQAB")],
+        cache_control="max-age=3600",
+    )
+
+
+class TestAsyncClearActuallyClears:
+    @pytest.mark.asyncio
+    async def test_clear_jwks_cache_empties_cache_and_cooldown(self):
+        # Prime the cache + cooldown sidecar directly so the test doesn't
+        # depend on the full refresh pipeline.
+        aio_tv._jwks_cache[JWKS_URL] = JwksCacheEntry(
+            response=_make_jwk_response("primed"),
+            cached_at=0.0,
+            ttl=3600.0,
+        )
+        aio_tv._kid_miss_last_attempt[JWKS_URL] = 100.0
+        assert JWKS_URL in aio_tv._jwks_cache
+        assert JWKS_URL in aio_tv._kid_miss_last_attempt
+
+        await async_clear_jwks_cache()
+
+        assert aio_tv._jwks_cache == {}
+        assert aio_tv._kid_miss_last_attempt == {}
+
+    @pytest.mark.asyncio
+    async def test_clear_discovery_cache_empties_cache(self):
+        cache_key = ("https://example.com/.well-known/openid-configuration", True)
+        aio_tv._disco_cache[cache_key] = DiscoCacheEntry(
+            response=DiscoveryDocumentResponse(is_successful=True),
+            cached_at=0.0,
+            ttl=3600.0,
+        )
+        assert cache_key in aio_tv._disco_cache
+
+        await async_clear_discovery_cache()
+
+        assert aio_tv._disco_cache == {}
+
+
+# ============================================================================
+# Race-condition contract: a coroutine mid-flight in _refresh_jwks must not
+# leak its post-write back into a cache that was cleared while the fetch
+# was in flight.
+#
+# We can't reliably interleave a real HTTP fetch with a clear in unit-test
+# wall-clock terms, so the test uses a controlled handler that blocks on
+# an event the test holds. The sequence:
+#
+#   1. Coroutine R starts _refresh_jwks. Fetch handler blocks on EVENT_A.
+#   2. Test releases EVENT_A → handler returns response.
+#   3. Test (concurrently) awaits clear_jwks_cache while R is still in the
+#      post-fetch apply_jwks_cache_outcome step — the clear must wait on
+#      the lock R is holding.
+#
+# Verifies clear waits for R's critical section, so the post-clear cache
+# state is fully clear, not "cleared then R re-wrote".
+# ============================================================================
+
+
+class TestAsyncClearWaitsForInFlightRefresh:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_clear_blocks_until_in_flight_refresh_completes(self):
+        """If clear_jwks_cache did NOT acquire _jwks_cache_write_lock, it
+        could complete *before* the in-flight _refresh_jwks's
+        apply_jwks_cache_outcome write, leaving an entry in the "cleared"
+        cache. Post-fix the lock serializes them."""
+        # Prime with one entry so we know it gets cleared.
+        aio_tv._jwks_cache["https://op.example/primed"] = JwksCacheEntry(
+            response=_make_jwk_response("primed-kid"),
+            cached_at=0.0,
+            ttl=3600.0,
+        )
+
+        # The handler waits on this event before responding, letting the
+        # test orchestrate the "in-flight refresh" + "clear" interleave.
+        proceed = asyncio.Event()
+
+        async def slow_handler(_request: httpx.Request) -> httpx.Response:
+            await proceed.wait()
+            return httpx.Response(
+                200,
+                json={
+                    "keys": [
+                        {
+                            "kty": "RSA",
+                            "kid": "fresh-kid",
+                            "alg": "RS256",
+                            "use": "sig",
+                            "n": "n",
+                            "e": "AQAB",
+                        }
+                    ]
+                },
+            )
+
+        respx.get(JWKS_URL).mock(side_effect=slow_handler)
+
+        # Start the refresh coroutine — it will block waiting on `proceed`.
+        refresh_task = asyncio.create_task(aio_tv._refresh_jwks(JWKS_URL))
+        # Let the refresh coroutine reach the await on `proceed`.
+        await asyncio.sleep(0)
+
+        # Release the handler so the refresh completes its fetch and runs
+        # apply_jwks_cache_outcome (which acquires _jwks_cache_write_lock).
+        proceed.set()
+
+        # Now concurrently clear. The clear must serialize after the
+        # refresh's lock-holding critical section.
+        await asyncio.gather(refresh_task, async_clear_jwks_cache())
+
+        # Net effect: clear ran AFTER refresh's apply_outcome under the
+        # same lock, so the cache is fully empty — the refresh's write is
+        # not re-introduced after clear.
+        assert aio_tv._jwks_cache == {}
+        assert aio_tv._kid_miss_last_attempt == {}

--- a/src/tests/unit/test_cache_http_headers.py
+++ b/src/tests/unit/test_cache_http_headers.py
@@ -47,16 +47,16 @@ JWKS_URL = "https://example.com/jwks"
 
 
 @pytest.fixture(autouse=True)
-def _clear_caches():
+async def _clear_caches():
     clear_discovery_cache()
     clear_jwks_cache()
-    async_clear_discovery_cache()
-    async_clear_jwks_cache()
+    await async_clear_discovery_cache()
+    await async_clear_jwks_cache()
     yield
     clear_discovery_cache()
     clear_jwks_cache()
-    async_clear_discovery_cache()
-    async_clear_jwks_cache()
+    await async_clear_discovery_cache()
+    await async_clear_jwks_cache()
 
 
 # ============================================================================

--- a/src/tests/unit/test_cache_monotonic_clock.py
+++ b/src/tests/unit/test_cache_monotonic_clock.py
@@ -85,17 +85,17 @@ CLOCK_BACKSTEP_SECONDS = 60.0
 
 
 @pytest.fixture(autouse=True)
-def _clear_caches():
+async def _clear_caches():
     clear_discovery_cache()
     clear_jwks_cache()
-    async_clear_discovery_cache()
-    async_clear_jwks_cache()
+    await async_clear_discovery_cache()
+    await async_clear_jwks_cache()
     _reset_env_for_testing()
     yield
     clear_discovery_cache()
     clear_jwks_cache()
-    async_clear_discovery_cache()
-    async_clear_jwks_cache()
+    await async_clear_discovery_cache()
+    await async_clear_jwks_cache()
     _reset_env_for_testing()
 
 

--- a/src/tests/unit/test_cache_stampede.py
+++ b/src/tests/unit/test_cache_stampede.py
@@ -62,17 +62,17 @@ FETCH_AFTER_EXPIRY = 2
 
 
 @pytest.fixture(autouse=True)
-def _clear_caches():
+async def _clear_caches():
     """Clear all caches between tests."""
     clear_discovery_cache()
     clear_jwks_cache()
-    async_clear_discovery_cache()
-    async_clear_jwks_cache()
+    await async_clear_discovery_cache()
+    await async_clear_jwks_cache()
     yield
     clear_discovery_cache()
     clear_jwks_cache()
-    async_clear_discovery_cache()
-    async_clear_jwks_cache()
+    await async_clear_discovery_cache()
+    await async_clear_jwks_cache()
 
 
 class TestSyncDiscoCacheStampede:

--- a/src/tests/unit/test_http_client_bypass_warning.py
+++ b/src/tests/unit/test_http_client_bypass_warning.py
@@ -60,18 +60,18 @@ JWKS_URL = "https://example.com/jwks"
 
 
 @pytest.fixture(autouse=True)
-def _reset_state():
+async def _reset_state():
     clear_discovery_cache()
     clear_jwks_cache()
-    async_clear_discovery_cache()
-    async_clear_jwks_cache()
+    await async_clear_discovery_cache()
+    await async_clear_jwks_cache()
     sync_tv._reset_injected_http_client_warning_for_testing()
     aio_tv._reset_injected_http_client_warning_for_testing()
     yield
     clear_discovery_cache()
     clear_jwks_cache()
-    async_clear_discovery_cache()
-    async_clear_jwks_cache()
+    await async_clear_discovery_cache()
+    await async_clear_jwks_cache()
     sync_tv._reset_injected_http_client_warning_for_testing()
     aio_tv._reset_injected_http_client_warning_for_testing()
 

--- a/src/tests/unit/test_kid_miss_cooldown.py
+++ b/src/tests/unit/test_kid_miss_cooldown.py
@@ -75,17 +75,17 @@ JWKS_URL = "https://example.com/jwks"
 
 
 @pytest.fixture(autouse=True)
-def _clear_caches():
+async def _clear_caches():
     clear_discovery_cache()
     clear_jwks_cache()
-    async_clear_discovery_cache()
-    async_clear_jwks_cache()
+    await async_clear_discovery_cache()
+    await async_clear_jwks_cache()
     _reset_env_for_testing()
     yield
     clear_discovery_cache()
     clear_jwks_cache()
-    async_clear_discovery_cache()
-    async_clear_jwks_cache()
+    await async_clear_discovery_cache()
+    await async_clear_jwks_cache()
     _reset_env_for_testing()
 
 

--- a/src/tests/unit/test_per_uri_locks.py
+++ b/src/tests/unit/test_per_uri_locks.py
@@ -51,16 +51,16 @@ from .token_validation_helpers import generate_rsa_keypair
 
 
 @pytest.fixture(autouse=True)
-def _clear_caches():
+async def _clear_caches():
     clear_discovery_cache()
     clear_jwks_cache()
-    async_clear_discovery_cache()
-    async_clear_jwks_cache()
+    await async_clear_discovery_cache()
+    await async_clear_jwks_cache()
     yield
     clear_discovery_cache()
     clear_jwks_cache()
-    async_clear_discovery_cache()
-    async_clear_jwks_cache()
+    await async_clear_discovery_cache()
+    await async_clear_jwks_cache()
 
 
 @pytest.fixture

--- a/src/tests/unit/test_require_https_wiring.py
+++ b/src/tests/unit/test_require_https_wiring.py
@@ -63,17 +63,17 @@ def rsa_keypair():
 
 
 @pytest.fixture(autouse=True)
-def _clear_caches():
+async def _clear_caches():
     """Clear all caches between tests."""
     sync_clear_discovery_cache()
     sync_clear_jwks_cache()
-    async_clear_discovery_cache()
-    async_clear_jwks_cache()
+    await async_clear_discovery_cache()
+    await async_clear_jwks_cache()
     yield
     sync_clear_discovery_cache()
     sync_clear_jwks_cache()
-    async_clear_discovery_cache()
-    async_clear_jwks_cache()
+    await async_clear_discovery_cache()
+    await async_clear_jwks_cache()
 
 
 class TestSyncRequireHttpsWiring:


### PR DESCRIPTION
## Summary

The aio ``clear_discovery_cache`` and ``clear_jwks_cache`` helpers were sync functions that mutated state guarded by ``asyncio.Lock`` instances **without** awaiting them. A coroutine mid-flight in ``_refresh_jwks`` could apply its result *after* the clear ran, leaving the "cleared" cache holding an entry. The sync mirror was fixed in PR #391; aio was missed.

This PR converts both helpers to ``async`` functions that ``async with`` the matching cache write lock before clearing. ``clear_jwks_cache`` also clears the ``_kid_miss_last_attempt`` cooldown sidecar under the same lock so the sidecar can't outgrow the cache.

## Breaking change

⚠️ **Callers of ``py_identity_model.aio.token_validation``'s ``clear_discovery_cache`` and ``clear_jwks_cache`` must now ``await`` them.**

```python
# Before:
clear_jwks_cache()

# After:
await clear_jwks_cache()
```

The sync mirrors in ``py_identity_model.sync.token_validation`` are unchanged.

The commit message uses the ``feat!:`` / ``fix!:`` + ``BREAKING CHANGE:`` Angular convention so python-semantic-release will bump the major version on merge to main.

## Out of scope

Issue #399 — module-level ``asyncio.Lock()`` binding to the import-time event loop — is a separate, larger refactor and is **not** addressed here.

## Test plan

Test fixtures updated to ``await`` the helpers:

- ``src/tests/conftest.py`` ``_clear_async_caches`` autouse fixture
- Per-file ``_clear_caches`` fixtures in:
  - ``test_aio_token_validation.py``
  - ``test_kid_miss_cooldown.py``
  - ``test_per_uri_locks.py``
  - ``test_cache_stampede.py``
  - ``test_cache_http_headers.py``
  - ``test_require_https_wiring.py``

All converted to ``async def`` and rely on pytest-asyncio's ``asyncio_mode = "auto"`` so they run for both sync and async tests.

New ``test_async_clear_cache_locking.py`` (5 tests) pins:

- [x] Both helpers are coroutine functions (regression guard against silent revert).
- [x] Calling without ``await`` returns a coroutine object (so users upgrading get a clear ``RuntimeWarning: coroutine was never awaited``).
- [x] ``clear_jwks_cache`` empties both ``_jwks_cache`` and the ``_kid_miss_last_attempt`` sidecar.
- [x] ``clear_discovery_cache`` empties ``_disco_cache``.
- [x] A ``clear_jwks_cache`` call concurrent with an in-flight ``_refresh_jwks`` serializes behind the refresh's ``apply_outcome`` write — the post-clear cache is fully empty, not "cleared then re-written".

- [x] ``make lint`` (ruff + pyrefly + pytest with 80% coverage) passes.
- [x] All 120 impacted tests pass locally.
- [ ] CI (unit + integration + conformance + examples) green.

Closes #405