### PR TITLE
security(jwks): URL scheme pre-flight + escape conformance HTML (#380, #381)

### DIFF
--- a/conformance/app.py
+++ b/conformance/app.py
@@ -7,6 +7,7 @@ using py-identity-model's public API to exercise all RP conformance tests.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import html
 import logging
 import os
 import secrets
@@ -360,7 +361,7 @@ def _fetch_and_validate_discovery(
         session.result["error"] = f"discovery_failed: {disco.error}"
         _store_test_result(session)
         return HTMLResponse(
-            content=f"<h1>Discovery Failed</h1><p>{disco.error}</p>",
+            content=f"<h1>Discovery Failed</h1><p>{html.escape(str(disco.error))}</p>",
             status_code=502,
         )
 
@@ -372,7 +373,7 @@ def _fetch_and_validate_discovery(
         session.result["error"] = f"missing_issuer: {error_msg}"
         _store_test_result(session)
         return HTMLResponse(
-            content=f"<h1>Missing Issuer</h1><p>{error_msg}</p>",
+            content=f"<h1>Missing Issuer</h1><p>{html.escape(error_msg)}</p>",
             status_code=502,
         )
     if disco.issuer != issuer:
@@ -385,7 +386,7 @@ def _fetch_and_validate_discovery(
         session.result["error"] = f"issuer_mismatch: {error_msg}"
         _store_test_result(session)
         return HTMLResponse(
-            content=f"<h1>Issuer Mismatch</h1><p>{error_msg}</p>",
+            content=f"<h1>Issuer Mismatch</h1><p>{html.escape(error_msg)}</p>",
             status_code=502,
         )
 
@@ -424,7 +425,10 @@ def _handle_callback(request_url: str) -> HTMLResponse | JSONResponse:
         session.result["error"] = f"state_validation: {state_result.result.value}"
         _store_test_result(session)
         return HTMLResponse(
-            content=f"<h1>State Validation Failed</h1><p>{state_result.result.value}</p>",
+            content=(
+                "<h1>State Validation Failed</h1>"
+                f"<p>{html.escape(state_result.result.value)}</p>"
+            ),
             status_code=400,
         )
 
@@ -435,7 +439,11 @@ def _handle_callback(request_url: str) -> HTMLResponse | JSONResponse:
         session.result["error_description"] = cb_response.error_description
         _store_test_result(session)
         return HTMLResponse(
-            content=f"<h1>OP Error</h1><p>{cb_response.error}: {cb_response.error_description}</p>",
+            content=(
+                "<h1>OP Error</h1>"
+                f"<p>{html.escape(str(cb_response.error))}: "
+                f"{html.escape(str(cb_response.error_description))}</p>"
+            ),
             status_code=400,
         )
 
@@ -479,7 +487,10 @@ def _handle_callback(request_url: str) -> HTMLResponse | JSONResponse:
         session.result["error"] = f"token_exchange: {token_response.error}"
         _store_test_result(session)
         return HTMLResponse(
-            content=f"<h1>Token Exchange Failed</h1><p>{token_response.error}</p>",
+            content=(
+                "<h1>Token Exchange Failed</h1>"
+                f"<p>{html.escape(str(token_response.error))}</p>"
+            ),
             status_code=400,
         )
 
@@ -532,7 +543,10 @@ def _handle_callback(request_url: str) -> HTMLResponse | JSONResponse:
             session.result["error"] = f"id_token_validation: {exc.message}"
             _store_test_result(session)
             return HTMLResponse(
-                content=f"<h1>ID Token Validation Failed</h1><p>{exc.message}</p>",
+                content=(
+                    "<h1>ID Token Validation Failed</h1>"
+                    f"<p>{html.escape(str(exc.message))}</p>"
+                ),
                 status_code=400,
             )
 
@@ -545,8 +559,11 @@ def _handle_callback(request_url: str) -> HTMLResponse | JSONResponse:
             )
             _store_test_result(session)
             return HTMLResponse(
-                content=f"<h1>Nonce Mismatch</h1>"
-                f"<p>Expected: {session.nonce}, Got: {token_nonce}</p>",
+                content=(
+                    "<h1>Nonce Mismatch</h1>"
+                    f"<p>Expected: {html.escape(str(session.nonce))}, "
+                    f"Got: {html.escape(str(token_nonce))}</p>"
+                ),
                 status_code=400,
             )
 
@@ -574,7 +591,10 @@ def _handle_callback(request_url: str) -> HTMLResponse | JSONResponse:
                 session.result["error"] = f"userinfo_validation: {error_msg}"
                 _store_test_result(session)
                 return HTMLResponse(
-                    content=f"<h1>UserInfo Validation Failed</h1><p>{error_msg}</p>",
+                    content=(
+                        "<h1>UserInfo Validation Failed</h1>"
+                        f"<p>{html.escape(str(error_msg))}</p>"
+                    ),
                     status_code=400,
                 )
         except PyIdentityModelException as exc:
@@ -593,15 +613,19 @@ def _handle_callback(request_url: str) -> HTMLResponse | JSONResponse:
     )
 
     # Build response body with ID token and UserInfo claims so the conformance
-    # suite can verify the RP fetched and displayed them.
+    # suite can verify the RP fetched and displayed them. All interpolated
+    # values originate from the IdP (claims, error messages) and must be
+    # HTML-escaped before rendering — see #381.
     claim_lines = [
-        f"<p>Subject: {claims.get('sub', 'N/A')}</p>",
-        f"<p>Issuer: {claims.get('iss', 'N/A')}</p>",
+        f"<p>Subject: {html.escape(str(claims.get('sub', 'N/A')))}</p>",
+        f"<p>Issuer: {html.escape(str(claims.get('iss', 'N/A')))}</p>",
     ]
     if userinfo_claims:
         claim_lines.append("<h2>UserInfo Claims</h2>")
         for key, value in userinfo_claims.items():
-            claim_lines.append(f"<p>{key}: {value}</p>")
+            claim_lines.append(
+                f"<p>{html.escape(str(key))}: {html.escape(str(value))}</p>"
+            )
 
     return HTMLResponse(
         content="<h1>Authentication Successful</h1>" + "\n".join(claim_lines),

--- a/conformance/tests/test_html_escaping.py
+++ b/conformance/tests/test_html_escaping.py
@@ -1,0 +1,296 @@
+"""Tests for HTML escaping in the conformance harness error/success responses.
+
+Regression coverage for #381: the harness rendered IdP-controlled error
+messages and claim values straight into HTMLResponse bodies via f-strings,
+yielding reflected XSS in any branch that interpolated upstream data.
+Every interpolation must now flow through ``html.escape``.
+
+These tests exercise the branches that surface IdP-controlled data and
+are reachable in the normal callback flow:
+
+- Discovery Failed (line ~363)
+- ID Token Validation Failed (line ~534)
+- UserInfo Validation Failed (line ~577)
+- Success body — UserInfo claim rendering (line ~604)
+
+The other HTMLResponse branches either return static content (no
+interpolation) or are guarded behind earlier validation that prevents
+IdP data from reaching them (e.g. the OP Error branch at line ~437 is
+gated by ``validate_authorize_callback_state`` returning
+``ERROR_RESPONSE`` for callbacks that carry ``error=``).
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+from unittest.mock import patch
+
+import app as harness_app
+from fastapi.testclient import TestClient
+
+# Importing the real exception class so the harness's `except` clause matches.
+from py_identity_model.exceptions import TokenValidationException
+
+
+XSS_PAYLOAD = "<script>alert(1)</script>"
+XSS_ESCAPED = "&lt;script&gt;alert(1)&lt;/script&gt;"
+QUOTE_PAYLOAD = '" onmouseover="alert(1)'
+HTTP_OK = 200
+HTTP_BAD_REQUEST = 400
+HTTP_BAD_GATEWAY = 502
+EXPECTED_KEY_VALUE_ESCAPES = 2
+
+
+def _make_session(state: str = "test-state", nonce: str = "match-nonce"):
+    """Register a session in the harness so /callback can resolve it."""
+    session = harness_app.AuthSession(
+        issuer="https://op.example.com",
+        state=state,
+        nonce=nonce,
+        client_id="test-client",
+        redirect_uri="http://localhost:8888/callback",
+    )
+    harness_app.sessions[state] = session
+    return session
+
+
+def _clear_state() -> None:
+    harness_app.sessions.clear()
+    harness_app.test_results.clear()
+
+
+class _Disco:
+    """Minimal stand-in for a successful DiscoveryDocumentResponse."""
+
+    is_successful = True
+    error = None
+    issuer = "https://op.example.com"
+    token_endpoint = "https://op.example.com/token"
+    userinfo_endpoint = "https://op.example.com/userinfo"
+    authorization_endpoint = "https://op.example.com/auth"
+    jwks_uri = "https://op.example.com/jwks"
+
+
+class _DiscoEndpoint:
+    url = "https://op.example.com"
+    authority = "https://op.example.com"
+
+
+class _TokenRespOk:
+    is_successful = True
+    token: ClassVar[dict[str, str]] = {
+        "id_token": "fake.jwt.token",
+        "access_token": "fake-access",
+    }
+    error = None
+
+
+class TestDiscoveryFailedEscaping:
+    """Discovery error message must be HTML-escaped (line ~363)."""
+
+    def teardown_method(self) -> None:
+        _clear_state()
+
+    def test_discovery_failure_escapes_script_payload(self) -> None:
+        _make_session(state="state-disco")
+
+        class _FailedDisco:
+            is_successful = False
+            error = XSS_PAYLOAD
+
+        with patch.object(
+            harness_app, "get_discovery_document", return_value=_FailedDisco()
+        ):
+            client = TestClient(harness_app.app)
+            response = client.get(
+                "/callback", params={"state": "state-disco", "code": "abc"}
+            )
+
+        assert response.status_code == HTTP_BAD_GATEWAY
+        body = response.text
+        assert XSS_PAYLOAD not in body, "raw <script> reached the rendered body"
+        assert XSS_ESCAPED in body
+        assert "<h1>Discovery Failed</h1>" in body
+
+
+class TestIdTokenValidationFailedEscaping:
+    """TokenValidationException.message must be HTML-escaped (line ~534)."""
+
+    def teardown_method(self) -> None:
+        _clear_state()
+
+    def test_id_token_validation_failure_escapes_script_payload(self) -> None:
+        _make_session(state="state-idtok")
+
+        with (
+            patch.object(harness_app, "get_discovery_document", return_value=_Disco()),
+            patch.object(
+                harness_app, "parse_discovery_url", return_value=_DiscoEndpoint()
+            ),
+            patch.object(
+                harness_app,
+                "request_authorization_code_token",
+                return_value=_TokenRespOk(),
+            ),
+            patch.object(
+                harness_app,
+                "validate_token",
+                side_effect=TokenValidationException(XSS_PAYLOAD),
+            ),
+        ):
+            client = TestClient(harness_app.app)
+            response = client.get(
+                "/callback", params={"state": "state-idtok", "code": "abc"}
+            )
+
+        assert response.status_code == HTTP_BAD_REQUEST
+        body = response.text
+        assert XSS_PAYLOAD not in body
+        assert XSS_ESCAPED in body
+        assert "<h1>ID Token Validation Failed</h1>" in body
+
+
+class TestUserInfoValidationFailedEscaping:
+    """UserInfo error string must be HTML-escaped (line ~577)."""
+
+    def teardown_method(self) -> None:
+        _clear_state()
+
+    def test_userinfo_failure_escapes_script_payload(self) -> None:
+        _make_session(state="state-ui-err", nonce="match-nonce")
+
+        class _UserInfoFail:
+            is_successful = False
+            claims = None
+            error = XSS_PAYLOAD
+
+        with (
+            patch.object(harness_app, "get_discovery_document", return_value=_Disco()),
+            patch.object(
+                harness_app, "parse_discovery_url", return_value=_DiscoEndpoint()
+            ),
+            patch.object(
+                harness_app,
+                "request_authorization_code_token",
+                return_value=_TokenRespOk(),
+            ),
+            patch.object(
+                harness_app,
+                "validate_token",
+                return_value={
+                    "sub": "user-1",
+                    "iss": _Disco.issuer,
+                    "nonce": "match-nonce",
+                },
+            ),
+            patch.object(harness_app, "get_userinfo", return_value=_UserInfoFail()),
+        ):
+            client = TestClient(harness_app.app)
+            response = client.get(
+                "/callback", params={"state": "state-ui-err", "code": "abc"}
+            )
+
+        assert response.status_code == HTTP_BAD_REQUEST
+        body = response.text
+        assert XSS_PAYLOAD not in body
+        assert XSS_ESCAPED in body
+        assert "<h1>UserInfo Validation Failed</h1>" in body
+
+
+class TestSuccessBodyClaimEscaping:
+    """UserInfo claims rendered into the success body must be HTML-escaped (line ~604).
+
+    This is the most concerning branch from the issue: claim keys AND values
+    are IdP-supplied. The payload is placed as both the key and the value
+    so the assertion verifies escape on both halves of ``<p>{key}: {value}</p>``.
+    """
+
+    def teardown_method(self) -> None:
+        _clear_state()
+
+    def test_userinfo_claim_value_escapes_script_payload(self) -> None:
+        _make_session(state="state-success", nonce="match-nonce")
+
+        class _UserInfoResp:
+            is_successful = True
+            claims: ClassVar[dict[str, str]] = {XSS_PAYLOAD: XSS_PAYLOAD}
+            error = None
+
+        with (
+            patch.object(harness_app, "get_discovery_document", return_value=_Disco()),
+            patch.object(
+                harness_app, "parse_discovery_url", return_value=_DiscoEndpoint()
+            ),
+            patch.object(
+                harness_app,
+                "request_authorization_code_token",
+                return_value=_TokenRespOk(),
+            ),
+            patch.object(
+                harness_app,
+                "validate_token",
+                return_value={
+                    "sub": "user-1",
+                    "iss": _Disco.issuer,
+                    "nonce": "match-nonce",
+                },
+            ),
+            patch.object(harness_app, "get_userinfo", return_value=_UserInfoResp()),
+        ):
+            client = TestClient(harness_app.app)
+            response = client.get(
+                "/callback", params={"state": "state-success", "code": "abc"}
+            )
+
+        assert response.status_code == HTTP_OK
+        body = response.text
+        assert XSS_PAYLOAD not in body, "raw <script> reached the success body"
+        # Both key and value get rendered, so escaped form appears at least twice.
+        assert body.count(XSS_ESCAPED) >= EXPECTED_KEY_VALUE_ESCAPES
+        assert "<h1>Authentication Successful</h1>" in body
+
+    def test_id_token_sub_claim_with_quote_payload_is_escaped(self) -> None:
+        """The Subject line interpolates claims.get('sub') directly.
+
+        A malicious IdP could return a `sub` containing attribute-breakout
+        characters. html.escape with the default quote=True must encode
+        double quotes as &quot; so attribute injection is blocked.
+        """
+        _make_session(state="state-sub-attr", nonce="match-nonce")
+
+        with (
+            patch.object(harness_app, "get_discovery_document", return_value=_Disco()),
+            patch.object(
+                harness_app, "parse_discovery_url", return_value=_DiscoEndpoint()
+            ),
+            patch.object(
+                harness_app,
+                "request_authorization_code_token",
+                return_value=_TokenRespOk(),
+            ),
+            patch.object(
+                harness_app,
+                "validate_token",
+                return_value={
+                    "sub": QUOTE_PAYLOAD,
+                    "iss": _Disco.issuer,
+                    "nonce": "match-nonce",
+                },
+            ),
+            patch.object(
+                harness_app,
+                "get_userinfo",
+                return_value=type(
+                    "_Empty", (), {"is_successful": True, "claims": {}, "error": None}
+                )(),
+            ),
+        ):
+            client = TestClient(harness_app.app)
+            response = client.get(
+                "/callback", params={"state": "state-sub-attr", "code": "abc"}
+            )
+
+        assert response.status_code == HTTP_OK
+        body = response.text
+        assert QUOTE_PAYLOAD not in body
+        assert "&quot;" in body

--- a/src/py_identity_model/aio/jwks.py
+++ b/src/py_identity_model/aio/jwks.py
@@ -6,6 +6,7 @@ This module provides asynchronous HTTP layer for fetching JSON Web Key Sets.
 
 import httpx
 
+from ..core.discovery_policy import DiscoveryPolicy, validate_url_scheme
 from ..core.error_handlers import handle_jwks_error
 from ..core.jwks_logic import log_jwks_request, process_jwks_response
 from ..core.models import (
@@ -49,6 +50,14 @@ async def get_jwks(
     log_jwks_request(jwks_request)
     response = None
     try:
+        # Pre-flight: validate URL scheme BEFORE making the HTTP request to
+        # prevent ftp://, file://, etc. and (per policy) plaintext HTTP to
+        # non-loopback hosts. JWKS validation is part of the public API and
+        # accepts caller-supplied URLs, so we cannot rely on the discovery
+        # document's scheme check having already vetted the address.
+        policy = jwks_request.policy or DiscoveryPolicy()
+        validate_url_scheme(jwks_request.address, policy)
+
         client = http_client.client if http_client else get_async_http_client()
         response = await _fetch_jwks(client, jwks_request.address)
         return process_jwks_response(response)

--- a/src/py_identity_model/aio/token_validation.py
+++ b/src/py_identity_model/aio/token_validation.py
@@ -197,7 +197,7 @@ def _get_jwks_fetch_lock(jwks_uri: str) -> asyncio.Lock:
     return stripes[hash(jwks_uri) % _JWKS_LOCK_STRIPES]
 
 
-async def _get_cached_jwks(jwks_uri: str) -> JwksResponse:
+async def _get_cached_jwks(jwks_uri: str, require_https: bool = True) -> JwksResponse:
     """Return cached JWKS response if fresh, otherwise fetch and cache.
 
     Cache-aside with per-URI single-flight (see ``_get_disco_response``).
@@ -212,7 +212,11 @@ async def _get_cached_jwks(jwks_uri: str) -> JwksResponse:
         if entry is not None and not is_cache_expired(entry):
             return entry.response
 
-        response = await get_jwks(JwksRequest(address=jwks_uri))
+        # The jwks_uri was already vetted against this policy when the
+        # discovery document was processed; thread it through so the
+        # pre-flight scheme check inside get_jwks() does not double-reject.
+        policy = DiscoveryPolicy(require_https=require_https)
+        response = await get_jwks(JwksRequest(address=jwks_uri, policy=policy))
         async with _get_jwks_cache_write_lock():
             apply_jwks_cache_outcome(
                 _jwks_cache,
@@ -224,7 +228,9 @@ async def _get_cached_jwks(jwks_uri: str) -> JwksResponse:
         return response
 
 
-async def _refresh_jwks(jwks_uri: str) -> tuple[JwksResponse, bool]:
+async def _refresh_jwks(
+    jwks_uri: str, require_https: bool = True
+) -> tuple[JwksResponse, bool]:
     """Force re-fetch JWKS and update cache (key rotation).
 
     Uses the per-URI fetch lock to coalesce concurrent refreshes for the
@@ -250,7 +256,8 @@ async def _refresh_jwks(jwks_uri: str) -> tuple[JwksResponse, bool]:
             return entry.response, False
 
         logger.info("Forcing JWKS refresh for %s (possible key rotation)", jwks_uri)
-        response = await get_jwks(JwksRequest(address=jwks_uri))
+        policy = DiscoveryPolicy(require_https=require_https)
+        response = await get_jwks(JwksRequest(address=jwks_uri, policy=policy))
         async with _get_jwks_cache_write_lock():
             apply_jwks_cache_outcome(
                 _jwks_cache,
@@ -359,7 +366,7 @@ async def _discover_and_resolve_key(
         validate_disco_response(disco_doc_response)
         jwks_uri = validate_jwks_uri(disco_doc_response)
         jwks_response = await get_jwks(
-            JwksRequest(address=jwks_uri), http_client=http_client
+            JwksRequest(address=jwks_uri, policy=policy), http_client=http_client
         )
         validate_jwks_response(jwks_response)
         kid, jwt_alg = extract_jwt_header_fields(jwt)
@@ -370,7 +377,7 @@ async def _discover_and_resolve_key(
     disco_doc_response = await _get_disco_response(disco_doc_address, require_https)
     validate_disco_response(disco_doc_response)
     jwks_uri = validate_jwks_uri(disco_doc_response)
-    jwks_response = await _get_cached_jwks(jwks_uri)
+    jwks_response = await _get_cached_jwks(jwks_uri, require_https=require_https)
     validate_jwks_response(jwks_response)
     kid, jwt_alg = extract_jwt_header_fields(jwt)
     # OP key rotation: if the JWT's kid is not in the cached JWKS, the cache
@@ -391,7 +398,9 @@ async def _discover_and_resolve_key(
                 kid,
             )
             # See sync._discover_and_resolve_key for the rationale.
-            jwks_response, from_retained_cache = await _refresh_jwks(jwks_uri)
+            jwks_response, from_retained_cache = await _refresh_jwks(
+                jwks_uri, require_https=require_https
+            )
             if jwks_response.is_successful:
                 refreshed_keys = jwks_response.keys or []
                 kid_found = any(k.kid == kid for k in refreshed_keys)
@@ -436,9 +445,10 @@ async def _retry_with_refreshed_jwks(
     """
     logger.warning("Signature verification failed; retrying with refreshed keys")
     jwks_uri = validate_jwks_uri(disco_doc_response)
+    policy = DiscoveryPolicy(require_https=token_validation_config.require_https)
     if http_client is not None:
         jwks_response = await get_jwks(
-            JwksRequest(address=jwks_uri), http_client=http_client
+            JwksRequest(address=jwks_uri, policy=policy), http_client=http_client
         )
         validate_jwks_response(jwks_response)
         kid, jwt_alg = extract_jwt_header_fields(jwt)
@@ -460,7 +470,9 @@ async def _retry_with_refreshed_jwks(
             "Signature verification failed; refresh cooldown active"
         )
 
-    jwks_response, from_retained_cache = await _refresh_jwks(jwks_uri)
+    jwks_response, from_retained_cache = await _refresh_jwks(
+        jwks_uri, require_https=token_validation_config.require_https
+    )
     # See sync._retry_with_refreshed_jwks — transient failures must not
     # stamp the cooldown.
     validate_jwks_response(jwks_response)

--- a/src/py_identity_model/core/error_handlers.py
+++ b/src/py_identity_model/core/error_handlers.py
@@ -86,6 +86,14 @@ def handle_jwks_error(e: Exception) -> JwksResponse:
     Returns:
         JwksResponse: Error response
     """
+    if isinstance(e, ConfigurationException):
+        error_msg = f"Invalid JWKS endpoint URL: {e!s}"
+        logger.error(error_msg)
+        return JwksResponse(
+            is_successful=False,
+            error=error_msg,
+        )
+
     if isinstance(e, httpx.RequestError):
         error_msg = f"Network error during JWKS request: {e!s}"
         logger.error(error_msg, exc_info=True)

--- a/src/py_identity_model/core/models.py
+++ b/src/py_identity_model/core/models.py
@@ -534,7 +534,12 @@ class JwksRequest(BaseRequest):
 
     Attributes:
         address: The JWKS endpoint URL (typically from ``DiscoveryDocumentResponse.jwks_uri``).
+        policy: Optional discovery policy for pre-flight URL scheme
+            validation. When ``None``, strict defaults apply
+            (HTTPS required outside loopback).
     """
+
+    policy: DiscoveryPolicy | None = None
 
 
 @dataclass(repr=False, eq=False)

--- a/src/py_identity_model/sync/jwks.py
+++ b/src/py_identity_model/sync/jwks.py
@@ -6,6 +6,7 @@ This module provides synchronous HTTP layer for fetching JSON Web Key Sets.
 
 import httpx
 
+from ..core.discovery_policy import DiscoveryPolicy, validate_url_scheme
 from ..core.error_handlers import handle_jwks_error
 from ..core.jwks_logic import log_jwks_request, process_jwks_response
 from ..core.models import (
@@ -49,6 +50,14 @@ def get_jwks(
     log_jwks_request(jwks_request)
     response = None
     try:
+        # Pre-flight: validate URL scheme BEFORE making the HTTP request to
+        # prevent ftp://, file://, etc. and (per policy) plaintext HTTP to
+        # non-loopback hosts. JWKS validation is part of the public API and
+        # accepts caller-supplied URLs, so we cannot rely on the discovery
+        # document's scheme check having already vetted the address.
+        policy = jwks_request.policy or DiscoveryPolicy()
+        validate_url_scheme(jwks_request.address, policy)
+
         client = http_client.client if http_client else get_http_client()
         response = _fetch_jwks(client, jwks_request.address)
         return process_jwks_response(response)

--- a/src/py_identity_model/sync/token_validation.py
+++ b/src/py_identity_model/sync/token_validation.py
@@ -140,7 +140,7 @@ def _get_jwks_fetch_lock(jwks_uri: str) -> threading.Lock:
     return _jwks_fetch_locks[hash(jwks_uri) % _JWKS_LOCK_STRIPES]
 
 
-def _get_cached_jwks(jwks_uri: str) -> JwksResponse:
+def _get_cached_jwks(jwks_uri: str, require_https: bool = True) -> JwksResponse:
     """Return cached JWKS response if fresh, otherwise fetch and cache.
 
     Cache-aside with per-URI single-flight (see ``_get_disco_response``).
@@ -155,7 +155,11 @@ def _get_cached_jwks(jwks_uri: str) -> JwksResponse:
         if entry is not None and not is_cache_expired(entry):
             return entry.response
 
-        response = get_jwks(JwksRequest(address=jwks_uri))
+        # The jwks_uri was already vetted against this policy when the
+        # discovery document was processed; thread it through so the
+        # pre-flight scheme check inside get_jwks() does not double-reject.
+        policy = DiscoveryPolicy(require_https=require_https)
+        response = get_jwks(JwksRequest(address=jwks_uri, policy=policy))
         with _jwks_cache_write_lock:
             apply_jwks_cache_outcome(
                 _jwks_cache,
@@ -167,7 +171,9 @@ def _get_cached_jwks(jwks_uri: str) -> JwksResponse:
         return response
 
 
-def _refresh_jwks(jwks_uri: str) -> tuple[JwksResponse, bool]:
+def _refresh_jwks(
+    jwks_uri: str, require_https: bool = True
+) -> tuple[JwksResponse, bool]:
     """Force re-fetch JWKS and update cache (key rotation).
 
     Uses the per-URI fetch lock to coalesce concurrent refresh requests for
@@ -199,7 +205,8 @@ def _refresh_jwks(jwks_uri: str) -> tuple[JwksResponse, bool]:
             return entry.response, False
 
         logger.info("Forcing JWKS refresh for %s (possible key rotation)", jwks_uri)
-        response = get_jwks(JwksRequest(address=jwks_uri))
+        policy = DiscoveryPolicy(require_https=require_https)
+        response = get_jwks(JwksRequest(address=jwks_uri, policy=policy))
         with _jwks_cache_write_lock:
             apply_jwks_cache_outcome(
                 _jwks_cache,
@@ -300,7 +307,10 @@ def _discover_and_resolve_key(
         )
         validate_disco_response(disco_doc_response)
         jwks_uri = validate_jwks_uri(disco_doc_response)
-        jwks_response = get_jwks(JwksRequest(address=jwks_uri), http_client=http_client)
+        jwks_response = get_jwks(
+            JwksRequest(address=jwks_uri, policy=policy),
+            http_client=http_client,
+        )
         validate_jwks_response(jwks_response)
         kid, jwt_alg = extract_jwt_header_fields(jwt)
         key_dict, alg = find_key_by_kid(kid, jwks_response.keys or [], jwt_alg=jwt_alg)
@@ -310,7 +320,7 @@ def _discover_and_resolve_key(
     disco_doc_response = _get_disco_response(disco_doc_address, require_https)
     validate_disco_response(disco_doc_response)
     jwks_uri = validate_jwks_uri(disco_doc_response)
-    jwks_response = _get_cached_jwks(jwks_uri)
+    jwks_response = _get_cached_jwks(jwks_uri, require_https=require_https)
     validate_jwks_response(jwks_response)
     kid, jwt_alg = extract_jwt_header_fields(jwt)
     # OP key rotation: if the JWT's kid is not in the cached JWKS, the cache
@@ -335,7 +345,9 @@ def _discover_and_resolve_key(
             # is_successful=False by get_jwks) must not wedge the cooldown,
             # so a single dropped packet does not stretch a rotation outage
             # by the cooldown window.
-            jwks_response, from_retained_cache = _refresh_jwks(jwks_uri)
+            jwks_response, from_retained_cache = _refresh_jwks(
+                jwks_uri, require_https=require_https
+            )
             if jwks_response.is_successful:
                 refreshed_keys = jwks_response.keys or []
                 kid_found = any(k.kid == kid for k in refreshed_keys)
@@ -400,8 +412,12 @@ def _retry_with_refreshed_jwks(
     """
     logger.warning("Signature verification failed; retrying with refreshed keys")
     jwks_uri = validate_jwks_uri(disco_doc_response)
+    policy = DiscoveryPolicy(require_https=token_validation_config.require_https)
     if http_client is not None:
-        jwks_response = get_jwks(JwksRequest(address=jwks_uri), http_client=http_client)
+        jwks_response = get_jwks(
+            JwksRequest(address=jwks_uri, policy=policy),
+            http_client=http_client,
+        )
         validate_jwks_response(jwks_response)
         kid, jwt_alg = extract_jwt_header_fields(jwt)
         key_dict, alg = find_key_by_kid(kid, jwks_response.keys or [], jwt_alg=jwt_alg)
@@ -422,7 +438,9 @@ def _retry_with_refreshed_jwks(
             "Signature verification failed; refresh cooldown active"
         )
 
-    jwks_response, from_retained_cache = _refresh_jwks(jwks_uri)
+    jwks_response, from_retained_cache = _refresh_jwks(
+        jwks_uri, require_https=token_validation_config.require_https
+    )
     # Transient upstream failures (wrapped as is_successful=False) must not
     # stamp the cooldown — let validate_jwks_response raise naturally so
     # the next attempt can retry once upstream recovers.

--- a/src/tests/integration/test_json_web_key.py
+++ b/src/tests/integration/test_json_web_key.py
@@ -203,15 +203,13 @@ def test_get_jwks_failure():
 
 def test_get_jwks_network_error():
     """Test get_jwks with network errors"""
-    # Test with malformed URL
+    # Test with malformed URL — rejected by the URL scheme pre-flight before
+    # any network call (see DiscoveryPolicy.validate_url_scheme).
     jwks_request = JwksRequest(address="not-a-valid-url")
     jwks_response = get_jwks(jwks_request)
 
     assert jwks_response.is_successful is False
     assert jwks_response.error is not None
-    assert (
-        "Network error during JWKS request" in jwks_response.error
-        or "Unhandled exception during JWKS request" in jwks_response.error
-    )
+    assert "Invalid JWKS endpoint URL" in jwks_response.error
     with pytest.raises(FailedResponseAccessError):
         _ = jwks_response.keys

--- a/src/tests/unit/test_aio_jwks.py
+++ b/src/tests/unit/test_aio_jwks.py
@@ -5,6 +5,7 @@ import pytest
 import respx
 
 from py_identity_model.aio.jwks import JwksRequest, get_jwks
+from py_identity_model.core.discovery_policy import DiscoveryPolicy
 from py_identity_model.exceptions import FailedResponseAccessError
 
 
@@ -83,3 +84,64 @@ class TestAsyncJwks:
         assert result.is_successful is False
         assert result.error is not None
         assert "Network error" in result.error
+
+
+@pytest.mark.asyncio
+class TestAsyncGetJwksSchemeValidation:
+    """Async mirror of the sync scheme-validation regression coverage for #380."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "ftp://example.com/jwks",
+            "file:///etc/passwd",
+            "data:application/json,{}",
+            "javascript:alert(1)",
+        ],
+    )
+    @respx.mock(assert_all_called=False)
+    async def test_rejects_non_http_schemes(self, url):
+        result = await get_jwks(JwksRequest(address=url))
+
+        assert result.is_successful is False
+        assert result.error is not None
+        assert "Invalid JWKS endpoint URL" in result.error
+
+    @respx.mock
+    async def test_https_is_accepted(self):
+        url = "https://example.com/jwks"
+        respx.get(url).mock(
+            return_value=httpx.Response(200, json={"keys": []}),
+        )
+        result = await get_jwks(JwksRequest(address=url))
+        assert result.is_successful is True
+
+    @respx.mock(assert_all_called=False)
+    async def test_http_rejected_under_default_policy(self):
+        url = "http://example.com/jwks"
+        route = respx.get(url)
+        result = await get_jwks(JwksRequest(address=url))
+
+        assert result.is_successful is False
+        assert result.error is not None
+        assert "HTTPS is required" in result.error
+        assert route.call_count == 0
+
+    @respx.mock
+    async def test_http_loopback_allowed_under_default_policy(self):
+        url = "http://127.0.0.1:8080/jwks"
+        respx.get(url).mock(
+            return_value=httpx.Response(200, json={"keys": []}),
+        )
+        result = await get_jwks(JwksRequest(address=url))
+        assert result.is_successful is True
+
+    @respx.mock
+    async def test_http_allowed_when_policy_disables_require_https(self):
+        url = "http://example.com/jwks"
+        respx.get(url).mock(
+            return_value=httpx.Response(200, json={"keys": []}),
+        )
+        policy = DiscoveryPolicy(require_https=False)
+        result = await get_jwks(JwksRequest(address=url, policy=policy))
+        assert result.is_successful is True

--- a/src/tests/unit/test_jwks.py
+++ b/src/tests/unit/test_jwks.py
@@ -4,6 +4,7 @@ import httpx
 import pytest
 import respx
 
+from py_identity_model.core.discovery_policy import DiscoveryPolicy
 from py_identity_model.exceptions import (
     ConfigurationException,
     FailedResponseAccessError,
@@ -690,3 +691,75 @@ class TestGetJwks:
             _ = result.keys
         assert result.error is not None
         assert "Unhandled exception during JWKS request" in result.error
+
+
+class TestGetJwksSchemeValidation:
+    """get_jwks() must reject non-HTTP(S) schemes before issuing a request.
+
+    Regression coverage for #380: prior to scheme pre-flight, calling
+    get_jwks() with ftp://, file://, javascript:, etc. would either hit
+    the HTTP client (SSRF surface) or fail with an opaque error. The
+    public API now mirrors discovery's pre-flight check.
+    """
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "ftp://example.com/jwks",
+            "file:///etc/passwd",
+            "data:application/json,{}",
+            "javascript:alert(1)",
+        ],
+    )
+    @respx.mock(assert_all_called=False)
+    def test_rejects_non_http_schemes(self, url):
+        # respx.mock with assert_all_called=False intercepts every network
+        # call. The pre-flight check must reject the URL before any HTTP
+        # request, so there's nothing for respx to route — the absence of
+        # an unhandled-call error confirms no network egress happened.
+        result = get_jwks(JwksRequest(address=url))
+
+        assert result.is_successful is False
+        assert result.error is not None
+        assert "Invalid JWKS endpoint URL" in result.error
+
+    @respx.mock
+    def test_https_is_accepted(self):
+        url = "https://example.com/jwks"
+        respx.get(url).mock(
+            return_value=httpx.Response(200, json={"keys": []}),
+        )
+        result = get_jwks(JwksRequest(address=url))
+        assert result.is_successful is True
+
+    @respx.mock(assert_all_called=False)
+    def test_http_rejected_under_default_policy(self):
+        # Default DiscoveryPolicy requires HTTPS off loopback. example.com is
+        # not loopback, so http:// must be rejected before any request goes out.
+        url = "http://example.com/jwks"
+        route = respx.get(url)
+        result = get_jwks(JwksRequest(address=url))
+
+        assert result.is_successful is False
+        assert result.error is not None
+        assert "HTTPS is required" in result.error
+        assert route.call_count == 0
+
+    @respx.mock
+    def test_http_loopback_allowed_under_default_policy(self):
+        url = "http://127.0.0.1:8080/jwks"
+        respx.get(url).mock(
+            return_value=httpx.Response(200, json={"keys": []}),
+        )
+        result = get_jwks(JwksRequest(address=url))
+        assert result.is_successful is True
+
+    @respx.mock
+    def test_http_allowed_when_policy_disables_require_https(self):
+        url = "http://example.com/jwks"
+        respx.get(url).mock(
+            return_value=httpx.Response(200, json={"keys": []}),
+        )
+        policy = DiscoveryPolicy(require_https=False)
+        result = get_jwks(JwksRequest(address=url, policy=policy))
+        assert result.is_successful is True


### PR DESCRIPTION
## Summary

Bundles the two T20x security-tail fixes into one PR (per the conformance-testing cluster plan).

- **#380** — `get_jwks()` (sync + aio) now validates URL scheme via `DiscoveryPolicy.validate_url_scheme` before issuing the HTTP request, matching the existing pattern in `get_discovery_document`. `JwksRequest` gains an optional `policy` field; token-validation paths thread `require_https` through so a disco-doc-derived `jwks_uri` is vetted under the same policy used for discovery.
- **#381** — Every f-string interpolation that flows IdP- or user-controlled data into an `HTMLResponse` body in `conformance/app.py` is now wrapped in `html.escape()`.

The most concerning XSS surface — UserInfo claim keys/values rendered in the success body — is now escaped on both halves of `<p>{key}: {value}</p>`. Other reachable branches (Discovery Failed, ID Token Validation Failed, UserInfo Validation Failed) and currently-unreachable-but-still-present branches (OP Error, State Validation Failed, Token Exchange Failed, Nonce Mismatch) are also escaped defensively.

`handle_jwks_error` now surfaces `ConfigurationException` with a clean `Invalid JWKS endpoint URL` prefix instead of the generic unhandled-exception path.

## Test plan
- [x] `make lint` — green (ruff, ruff format, pyrefly, pytest with 80% coverage gate)
- [x] `make conformance-test-harness` — 23 tests green including 5 new HTML escaping tests
- [x] 16 new sync+aio scheme-validation tests cover ftp/file/data/javascript rejection, https accepted, http rejected under default policy, loopback http allowed, and http allowed under `require_https=False`
- [x] Existing `test_require_https_wiring` tests continue to pass (they validate the `require_https=False` flow that now plumbs through the JWKS pre-flight)
- [ ] CI: unit, integration (Ory + Descope + node-oidc), conformance, examples

Closes #380
Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)