### PR TITLE
fix(jwks-cache): surface retained cache on empty refresh (#403)

### DIFF
--- a/src/py_identity_model/aio/token_validation.py
+++ b/src/py_identity_model/aio/token_validation.py
@@ -224,7 +224,7 @@ async def _get_cached_jwks(jwks_uri: str) -> JwksResponse:
         return response
 
 
-async def _refresh_jwks(jwks_uri: str) -> JwksResponse:
+async def _refresh_jwks(jwks_uri: str) -> tuple[JwksResponse, bool]:
     """Force re-fetch JWKS and update cache (key rotation).
 
     Uses the per-URI fetch lock to coalesce concurrent refreshes for the
@@ -236,13 +236,18 @@ async def _refresh_jwks(jwks_uri: str) -> JwksResponse:
     a just-released lock cannot observe its own ``request_time`` as older
     than the entry the prior coroutine just wrote (causing a spurious
     re-fetch).
+
+    See sync._refresh_jwks for the ``from_retained_cache`` semantics — a
+    successful-but-empty upstream response is surfaced as the retained
+    cache entry instead of the empty response, and callers must treat the
+    flag as "no new information from upstream" (no cooldown stamp).
     """
     fetch_lock = _get_jwks_fetch_lock(jwks_uri)
     async with fetch_lock:
         request_time = time.monotonic()
         entry = _jwks_cache.get(jwks_uri)
         if entry is not None and entry.cached_at >= request_time:
-            return entry.response
+            return entry.response, False
 
         logger.info("Forcing JWKS refresh for %s (possible key rotation)", jwks_uri)
         response = await get_jwks(JwksRequest(address=jwks_uri))
@@ -254,7 +259,17 @@ async def _refresh_jwks(jwks_uri: str) -> JwksResponse:
                 time.monotonic(),
                 cooldown=_kid_miss_last_attempt,
             )
-        return response
+            if response.is_successful and not response.keys:
+                retained = _jwks_cache.get(jwks_uri)
+                if retained is not None and retained.response.keys:
+                    logger.info(
+                        "JWKS refresh for %s returned 200 with empty keys; "
+                        "falling back to retained cache entry for in-flight "
+                        "validation",
+                        jwks_uri,
+                    )
+                    return retained.response, True
+        return response, False
 
 
 async def clear_jwks_cache() -> None:
@@ -376,15 +391,19 @@ async def _discover_and_resolve_key(
                 kid,
             )
             # See sync._discover_and_resolve_key for the rationale.
-            jwks_response = await _refresh_jwks(jwks_uri)
+            jwks_response, from_retained_cache = await _refresh_jwks(jwks_uri)
             if jwks_response.is_successful:
                 refreshed_keys = jwks_response.keys or []
                 kid_found = any(k.kid == kid for k in refreshed_keys)
-                async with _get_jwks_cache_write_lock():
-                    if kid_found:
-                        _kid_miss_last_attempt.pop(jwks_uri, None)
-                    else:
-                        _kid_miss_last_attempt[jwks_uri] = time.monotonic()
+                # Skip cooldown bookkeeping when refresh degraded to a
+                # retained-cache fallback (empty upstream is not
+                # attacker-amplifiable). Mirror of sync.
+                if not from_retained_cache:
+                    async with _get_jwks_cache_write_lock():
+                        if kid_found:
+                            _kid_miss_last_attempt.pop(jwks_uri, None)
+                        else:
+                            _kid_miss_last_attempt[jwks_uri] = time.monotonic()
             else:
                 kid_found = False
             validate_jwks_response(jwks_response)
@@ -441,7 +460,7 @@ async def _retry_with_refreshed_jwks(
             "Signature verification failed; refresh cooldown active"
         )
 
-    jwks_response = await _refresh_jwks(jwks_uri)
+    jwks_response, from_retained_cache = await _refresh_jwks(jwks_uri)
     # See sync._retry_with_refreshed_jwks — transient failures must not
     # stamp the cooldown.
     validate_jwks_response(jwks_response)
@@ -452,11 +471,15 @@ async def _retry_with_refreshed_jwks(
         resolved_config = build_resolved_config(token_validation_config, key_dict, alg)
         decoded = decode_with_config(jwt, resolved_config, disco_doc_response.issuer)
     except Exception:
-        async with _get_jwks_cache_write_lock():
-            _kid_miss_last_attempt[jwks_uri] = time.monotonic()
+        # Skip cooldown stamp when refresh degraded to a retained-cache
+        # fallback. See sync._retry_with_refreshed_jwks.
+        if not from_retained_cache:
+            async with _get_jwks_cache_write_lock():
+                _kid_miss_last_attempt[jwks_uri] = time.monotonic()
         raise
-    async with _get_jwks_cache_write_lock():
-        _kid_miss_last_attempt.pop(jwks_uri, None)
+    if not from_retained_cache:
+        async with _get_jwks_cache_write_lock():
+            _kid_miss_last_attempt.pop(jwks_uri, None)
     return decoded
 
 

--- a/src/py_identity_model/sync/token_validation.py
+++ b/src/py_identity_model/sync/token_validation.py
@@ -167,7 +167,7 @@ def _get_cached_jwks(jwks_uri: str) -> JwksResponse:
         return response
 
 
-def _refresh_jwks(jwks_uri: str) -> JwksResponse:
+def _refresh_jwks(jwks_uri: str) -> tuple[JwksResponse, bool]:
     """Force re-fetch JWKS and update cache (key rotation).
 
     Uses the per-URI fetch lock to coalesce concurrent refresh requests for
@@ -178,13 +178,25 @@ def _refresh_jwks(jwks_uri: str) -> JwksResponse:
     ``request_time`` is captured *inside* the lock so a thread that races a
     just-released lock cannot observe its own ``request_time`` as older than
     the entry that thread A just wrote (causing a spurious re-fetch).
+
+    Returns:
+        ``(response, from_retained_cache)``. When ``from_retained_cache`` is
+        ``True``, the upstream refresh returned a successful-but-empty body
+        and we surface the retained cache entry instead of the empty
+        response (the cached working keys are sitting there; raising "no
+        keys available" with usable keys in hand is the wrong UX, and
+        stamping the kid-miss cooldown on an empty-but-not-attacker-driven
+        refresh wedges legitimate traffic for the cooldown window). Callers
+        treat this flag as "no new information from upstream" — i.e. do not
+        update the kid-miss cooldown, since the empty response isn't
+        attacker-amplifiable.
     """
     fetch_lock = _get_jwks_fetch_lock(jwks_uri)
     with fetch_lock:
         request_time = time.monotonic()
         entry = _jwks_cache.get(jwks_uri)
         if entry is not None and entry.cached_at >= request_time:
-            return entry.response
+            return entry.response, False
 
         logger.info("Forcing JWKS refresh for %s (possible key rotation)", jwks_uri)
         response = get_jwks(JwksRequest(address=jwks_uri))
@@ -196,7 +208,20 @@ def _refresh_jwks(jwks_uri: str) -> JwksResponse:
                 time.monotonic(),
                 cooldown=_kid_miss_last_attempt,
             )
-        return response
+            # apply_jwks_cache_outcome retains the existing entry on an
+            # empty-successful response. Surface that retained entry so
+            # the in-flight validation has usable keys to work with.
+            if response.is_successful and not response.keys:
+                retained = _jwks_cache.get(jwks_uri)
+                if retained is not None and retained.response.keys:
+                    logger.info(
+                        "JWKS refresh for %s returned 200 with empty keys; "
+                        "falling back to retained cache entry for in-flight "
+                        "validation",
+                        jwks_uri,
+                    )
+                    return retained.response, True
+        return response, False
 
 
 def clear_jwks_cache() -> None:
@@ -310,24 +335,32 @@ def _discover_and_resolve_key(
             # is_successful=False by get_jwks) must not wedge the cooldown,
             # so a single dropped packet does not stretch a rotation outage
             # by the cooldown window.
-            jwks_response = _refresh_jwks(jwks_uri)
+            jwks_response, from_retained_cache = _refresh_jwks(jwks_uri)
             if jwks_response.is_successful:
                 refreshed_keys = jwks_response.keys or []
                 kid_found = any(k.kid == kid for k in refreshed_keys)
-                with _jwks_cache_write_lock:
-                    if kid_found:
-                        # Refresh produced the missing kid — legitimate
-                        # rotation absorbed. Drop the stamp so a back-to-back
-                        # second rotation within the cooldown window can
-                        # still refresh.
-                        _kid_miss_last_attempt.pop(jwks_uri, None)
-                    else:
-                        # Refresh completed and produced a response but the
-                        # kid is still absent — DoS amplifier case (the
-                        # attacker drove an upstream fetch we couldn't
-                        # turn into a successful validation). Stamp the
-                        # cooldown to suppress repeats in the window.
-                        _kid_miss_last_attempt[jwks_uri] = time.monotonic()
+                # Skip the cooldown bookkeeping entirely when the refresh
+                # degraded to a retained-cache fallback. The upstream's
+                # empty response is not attacker-amplifiable, so the
+                # DoS-stamp framing does not apply; and we must not pop
+                # a legitimate prior stamp on what was effectively a
+                # no-op refresh.
+                if not from_retained_cache:
+                    with _jwks_cache_write_lock:
+                        if kid_found:
+                            # Refresh produced the missing kid — legitimate
+                            # rotation absorbed. Drop the stamp so a
+                            # back-to-back second rotation within the
+                            # cooldown window can still refresh.
+                            _kid_miss_last_attempt.pop(jwks_uri, None)
+                        else:
+                            # Refresh completed and produced a response
+                            # but the kid is still absent — DoS amplifier
+                            # case (the attacker drove an upstream fetch
+                            # we couldn't turn into a successful
+                            # validation). Stamp the cooldown to suppress
+                            # repeats in the window.
+                            _kid_miss_last_attempt[jwks_uri] = time.monotonic()
             else:
                 kid_found = False
             validate_jwks_response(jwks_response)
@@ -389,7 +422,7 @@ def _retry_with_refreshed_jwks(
             "Signature verification failed; refresh cooldown active"
         )
 
-    jwks_response = _refresh_jwks(jwks_uri)
+    jwks_response, from_retained_cache = _refresh_jwks(jwks_uri)
     # Transient upstream failures (wrapped as is_successful=False) must not
     # stamp the cooldown — let validate_jwks_response raise naturally so
     # the next attempt can retry once upstream recovers.
@@ -403,14 +436,21 @@ def _retry_with_refreshed_jwks(
     except Exception:
         # Refresh delivered a usable response but the chain (find_key,
         # decode) still failed — DoS amplifier case. Stamp to suppress
-        # retry storms.
-        with _jwks_cache_write_lock:
-            _kid_miss_last_attempt[jwks_uri] = time.monotonic()
+        # retry storms. Skip the stamp when the refresh degraded to a
+        # retained-cache fallback (empty upstream response is not
+        # attacker-amplifiable).
+        if not from_retained_cache:
+            with _jwks_cache_write_lock:
+                _kid_miss_last_attempt[jwks_uri] = time.monotonic()
         raise
     # Refreshed keys verified the JWT — real rotation absorbed. Clear the
-    # stamp so a subsequent legitimate rotation isn't suppressed.
-    with _jwks_cache_write_lock:
-        _kid_miss_last_attempt.pop(jwks_uri, None)
+    # stamp so a subsequent legitimate rotation isn't suppressed. Only do
+    # this for real refreshes; a cache-fallback success would have worked
+    # with the cached keys all along and tells us nothing new about
+    # rotation state.
+    if not from_retained_cache:
+        with _jwks_cache_write_lock:
+            _kid_miss_last_attempt.pop(jwks_uri, None)
     return decoded
 
 

--- a/src/tests/unit/test_cache_http_headers.py
+++ b/src/tests/unit/test_cache_http_headers.py
@@ -376,12 +376,14 @@ class TestSyncRefreshInvalidatesStaleOnUncacheable:
         assert JWKS_URL in sync_tv._jwks_cache
         assert _kids(sync_tv._jwks_cache[JWKS_URL].response) == {"old-kid"}
 
-        refreshed = sync_tv._refresh_jwks(JWKS_URL)
+        refreshed, from_retained_cache = sync_tv._refresh_jwks(JWKS_URL)
         assert refreshed.is_successful is True
         # Fresh response is returned to the caller …
         assert _kids(refreshed) == {"new-kid"}
         # … but the stale entry MUST be popped, not left behind.
         assert JWKS_URL not in sync_tv._jwks_cache
+        # Real refresh (not an empty-fallback) — see #403 contract.
+        assert from_retained_cache is False
 
     @pytest.mark.parametrize("uncacheable_header", REFRESH_UNCACHEABLE_TEST_CASES)
     @respx.mock
@@ -470,10 +472,12 @@ class TestAsyncRefreshInvalidatesStaleOnUncacheable:
         assert JWKS_URL in aio_tv._jwks_cache
         assert _kids(aio_tv._jwks_cache[JWKS_URL].response) == {"old-kid"}
 
-        refreshed = await aio_tv._refresh_jwks(JWKS_URL)
+        refreshed, from_retained_cache = await aio_tv._refresh_jwks(JWKS_URL)
         assert refreshed.is_successful is True
         assert _kids(refreshed) == {"new-kid"}
         assert JWKS_URL not in aio_tv._jwks_cache
+        # Real refresh (not an empty-fallback) — see #403 contract.
+        assert from_retained_cache is False
 
 
 # ============================================================================
@@ -510,11 +514,14 @@ class TestSyncEmptyKeysNotCached:
         primed = _get_cached_jwks(JWKS_URL)
         assert primed.is_successful is True
 
-        refreshed = sync_tv._refresh_jwks(JWKS_URL)
-        # The empty response is returned to the caller (no lying about what
-        # the upstream sent), but the cache retains the last-known-good keys.
+        refreshed, from_retained_cache = sync_tv._refresh_jwks(JWKS_URL)
+        # #403: when upstream returns 200 with empty keys, _refresh_jwks
+        # surfaces the retained cache entry to the caller (not the empty
+        # response) so the in-flight validation has usable keys. The
+        # cache itself is also retained.
         assert refreshed.is_successful is True
-        assert refreshed.keys == []
+        assert _kids(refreshed) == {"retained-kid"}
+        assert from_retained_cache is True
         assert JWKS_URL in sync_tv._jwks_cache
         assert _kids(sync_tv._jwks_cache[JWKS_URL].response) == {"retained-kid"}
 
@@ -560,9 +567,11 @@ class TestAsyncEmptyKeysNotCached:
         respx.get(JWKS_URL).mock(side_effect=handler)
 
         await async_get_cached_jwks(JWKS_URL)
-        refreshed = await aio_tv._refresh_jwks(JWKS_URL)
+        refreshed, from_retained_cache = await aio_tv._refresh_jwks(JWKS_URL)
+        # See sync counterpart — #403 fallback: retained cache surfaced.
         assert refreshed.is_successful is True
-        assert refreshed.keys == []
+        assert _kids(refreshed) == {"retained-kid"}
+        assert from_retained_cache is True
         assert JWKS_URL in aio_tv._jwks_cache
         assert _kids(aio_tv._jwks_cache[JWKS_URL].response) == {"retained-kid"}
 
@@ -606,6 +615,8 @@ class TestEmptyKeysWithUncacheableHeaderRetains:
         respx.get(JWKS_URL).mock(side_effect=handler)
 
         _get_cached_jwks(JWKS_URL)
+        # Return is now a tuple — discard both halves; the test pins cache
+        # state, not what _refresh_jwks surfaces to the caller.
         sync_tv._refresh_jwks(JWKS_URL)
         assert JWKS_URL in sync_tv._jwks_cache
         assert _kids(sync_tv._jwks_cache[JWKS_URL].response) == {"retained-kid"}
@@ -638,6 +649,8 @@ class TestEmptyKeysWithUncacheableHeaderRetains:
         respx.get(JWKS_URL).mock(side_effect=handler)
 
         await async_get_cached_jwks(JWKS_URL)
+        # Return is now a tuple — discard both halves; the test pins cache
+        # state, not what _refresh_jwks surfaces to the caller.
         await aio_tv._refresh_jwks(JWKS_URL)
         assert JWKS_URL in aio_tv._jwks_cache
         assert _kids(aio_tv._jwks_cache[JWKS_URL].response) == {"retained-kid"}
@@ -671,8 +684,10 @@ class TestRetainOnError:
         respx.get(JWKS_URL).mock(side_effect=handler)
 
         _get_cached_jwks(JWKS_URL)
-        refreshed = sync_tv._refresh_jwks(JWKS_URL)
+        refreshed, from_retained_cache = sync_tv._refresh_jwks(JWKS_URL)
         assert refreshed.is_successful is False
+        # Failed refresh does not trigger the empty-keys fallback.
+        assert from_retained_cache is False
         assert JWKS_URL in sync_tv._jwks_cache
         assert _kids(sync_tv._jwks_cache[JWKS_URL].response) == {"retained-kid"}
 
@@ -695,7 +710,9 @@ class TestRetainOnError:
         respx.get(JWKS_URL).mock(side_effect=handler)
 
         await async_get_cached_jwks(JWKS_URL)
-        refreshed = await aio_tv._refresh_jwks(JWKS_URL)
+        refreshed, from_retained_cache = await aio_tv._refresh_jwks(JWKS_URL)
         assert refreshed.is_successful is False
+        # Failed refresh does not trigger the empty-keys fallback.
+        assert from_retained_cache is False
         assert JWKS_URL in aio_tv._jwks_cache
         assert _kids(aio_tv._jwks_cache[JWKS_URL].response) == {"retained-kid"}

--- a/src/tests/unit/test_cache_stampede.py
+++ b/src/tests/unit/test_cache_stampede.py
@@ -353,8 +353,11 @@ class TestSyncRefreshJwksFreshnessGuard:
         )
 
         # _refresh_jwks should see the fresh entry and skip the HTTP fetch
-        result = _refresh_jwks(JWKS_URL)
+        result, from_retained_cache = _refresh_jwks(JWKS_URL)
         assert result is not None
+        # The freshness-guard short-circuit returns the cached entry without
+        # touching upstream, so this is not the #403 empty-fallback path.
+        assert from_retained_cache is False
         # No new fetch — still just the 1 from priming
         assert jwks_route.call_count == 1
 
@@ -371,8 +374,9 @@ class TestSyncRefreshJwksFreshnessGuard:
         assert jwks_route.call_count == 1
 
         # Call _refresh_jwks — cached_at is in the past relative to request_time
-        result = _refresh_jwks(JWKS_URL)
+        result, from_retained_cache = _refresh_jwks(JWKS_URL)
         assert result is not None
+        assert from_retained_cache is False
         assert jwks_route.call_count == FETCH_AFTER_EXPIRY
 
 
@@ -400,8 +404,9 @@ class TestAsyncRefreshJwksFreshnessGuard:
             ttl=entry.ttl,
         )
 
-        result = await async_refresh_jwks(JWKS_URL)
+        result, from_retained_cache = await async_refresh_jwks(JWKS_URL)
         assert result is not None
+        assert from_retained_cache is False
         assert jwks_route.call_count == 1
 
     @pytest.mark.asyncio
@@ -416,8 +421,9 @@ class TestAsyncRefreshJwksFreshnessGuard:
         await async_get_cached_jwks(JWKS_URL)
         assert jwks_route.call_count == 1
 
-        result = await async_refresh_jwks(JWKS_URL)
+        result, from_retained_cache = await async_refresh_jwks(JWKS_URL)
         assert result is not None
+        assert from_retained_cache is False
         assert jwks_route.call_count == FETCH_AFTER_EXPIRY
 
 

--- a/src/tests/unit/test_kid_miss_cooldown.py
+++ b/src/tests/unit/test_kid_miss_cooldown.py
@@ -26,6 +26,9 @@ import pytest
 import respx
 
 from py_identity_model.aio.token_validation import (
+    _jwks_cache as async_jwks_cache,
+)
+from py_identity_model.aio.token_validation import (
     _kid_miss_last_attempt as async_kid_miss_last_attempt,
 )
 from py_identity_model.aio.token_validation import (
@@ -55,7 +58,13 @@ from py_identity_model.exceptions import (
     TokenValidationException,
 )
 from py_identity_model.sync.token_validation import (
+    _jwks_cache as sync_jwks_cache,
+)
+from py_identity_model.sync.token_validation import (
     _kid_miss_last_attempt as sync_kid_miss_last_attempt,
+)
+from py_identity_model.sync.token_validation import (
+    _refresh_jwks as sync_refresh_jwks,
 )
 from py_identity_model.sync.token_validation import (
     clear_discovery_cache,
@@ -915,3 +924,157 @@ class TestSignatureFailureRetryGatedByCooldown:
         assert decoded["sub"] == "user1"
         # Real rotation absorbed; cooldown must be clear.
         assert JWKS_URL not in sync_kid_miss_last_attempt
+
+
+# ============================================================================
+# #403: a kid-miss refresh that returns 200 with empty keys (transient
+# upstream blip) must NOT stamp the cooldown. Pre-fix behavior:
+#   1. apply_jwks_cache_outcome retains the populated cache entry.
+#   2. _refresh_jwks returned the empty response to the caller.
+#   3. The caller saw kid_found=False, stamped the cooldown.
+#   4. Subsequent kid-miss requests for the same URI were suppressed for
+#      one cooldown window, even though working cached keys were available.
+#
+# Post-fix:
+#   - _refresh_jwks surfaces the retained cache entry (from_retained_cache=True).
+#   - Caller skips the cooldown stamp because the empty upstream response
+#     is not attacker-amplifiable (returning empty regardless of attacker
+#     input).
+#   - validate_jwks_response succeeds (it sees the retained keys).
+#   - find_key_by_kid raises "no matching kid" — accurate, informative.
+# ============================================================================
+
+
+class TestEmptyRefreshDoesNotStampCooldown:
+    @respx.mock
+    def test_sync_empty_refresh_keeps_cooldown_clear(self):
+        old_key_dict, _ = generate_rsa_keypair()
+        old_key_dict["kid"] = "old-kid"
+
+        respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+
+        call_log: list[int] = []
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            call_log.append(1)
+            if len(call_log) == 1:
+                # Prime: working keys.
+                return httpx.Response(200, json={"keys": [old_key_dict]})
+            # Refresh: 200 with empty keys (transient blip).
+            return httpx.Response(200, json={"keys": []})
+
+        respx.get(JWKS_URL).mock(side_effect=handler)
+
+        config = TokenValidationConfig(
+            perform_disco=True, audience=None, issuer="https://example.com"
+        )
+
+        with pytest.raises(TokenValidationException):
+            validate_token(
+                jwt=_sign_unknown_kid_token("new-kid"),
+                token_validation_config=config,
+                disco_doc_address=DISCO_URL,
+            )
+
+        # The cache MUST still hold the primed working keys (apply_jwks_cache_outcome
+        # retains the entry on an empty-successful response).
+        assert JWKS_URL in sync_jwks_cache
+        cached_kids = {k.kid for k in sync_jwks_cache[JWKS_URL].response.keys or []}
+        assert cached_kids == {"old-kid"}
+
+        # And the cooldown stamp must NOT be set — the empty refresh is
+        # treated as a no-op (not an attacker-amplifiable event), so
+        # subsequent kid-miss requests in the cooldown window are not wedged.
+        assert JWKS_URL not in sync_kid_miss_last_attempt
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_async_empty_refresh_keeps_cooldown_clear(self):
+        old_key_dict, _ = generate_rsa_keypair()
+        old_key_dict["kid"] = "old-kid"
+
+        respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+
+        call_log: list[int] = []
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            call_log.append(1)
+            if len(call_log) == 1:
+                return httpx.Response(200, json={"keys": [old_key_dict]})
+            return httpx.Response(200, json={"keys": []})
+
+        respx.get(JWKS_URL).mock(side_effect=handler)
+
+        config = TokenValidationConfig(
+            perform_disco=True, audience=None, issuer="https://example.com"
+        )
+
+        with pytest.raises(TokenValidationException):
+            await async_validate_token(
+                jwt=_sign_unknown_kid_token("new-kid"),
+                token_validation_config=config,
+                disco_doc_address=DISCO_URL,
+            )
+
+        assert JWKS_URL in async_jwks_cache
+        cached_kids = {k.kid for k in async_jwks_cache[JWKS_URL].response.keys or []}
+        assert cached_kids == {"old-kid"}
+        assert JWKS_URL not in async_kid_miss_last_attempt
+
+    @respx.mock
+    def test_sync_kid_present_in_retained_cache_decodes(self):
+        """If the refresh returns empty but the cached keys happen to contain
+        the requested kid (e.g. a different thread populated the cache between
+        the kid-miss check and the refresh), validation should succeed using
+        the retained cache.
+
+        This case is rare in practice but the fix should still produce the
+        right outcome — the test pins the contract.
+        """
+        # Use _refresh_jwks directly to exercise the surface, then assert
+        # the returned response has the cached kid and from_retained_cache=True.
+        cached_key_dict, _ = generate_rsa_keypair()
+        cached_key_dict["kid"] = "cached-kid"
+
+        call_log: list[int] = []
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            call_log.append(1)
+            if len(call_log) == 1:
+                return httpx.Response(200, json={"keys": [cached_key_dict]})
+            return httpx.Response(200, json={"keys": []})
+
+        respx.get(JWKS_URL).mock(side_effect=handler)
+
+        # Manually seed the cache so the refresh path uses retained-cache
+        # fallback. (Going through _get_cached_jwks first would set
+        # cached_at = now, and _refresh_jwks's freshness guard would
+        # short-circuit without re-fetching.)
+        cached_jwk = JsonWebKey(
+            kty=cached_key_dict["kty"],
+            kid=cached_key_dict["kid"],
+            n=cached_key_dict["n"],
+            e=cached_key_dict["e"],
+            alg=cached_key_dict.get("alg"),
+            use=cached_key_dict.get("use", "sig"),
+        )
+        sync_jwks_cache[JWKS_URL] = JwksCacheEntry(
+            response=JwksResponse(is_successful=True, keys=[cached_jwk]),
+            cached_at=time.monotonic() - 10.0,  # stale enough to trigger refresh
+            ttl=0.001,
+        )
+
+        # Now trigger refresh — upstream returns empty. Pre-fill call_log so
+        # the handler returns the empty-response branch on this first call.
+        call_log.append(1)
+        response, from_retained_cache = sync_refresh_jwks(JWKS_URL)
+
+        # The retained cache had the kid; the caller gets the retained response.
+        assert from_retained_cache is True
+        assert response.is_successful is True
+        kids = {k.kid for k in response.keys or []}
+        assert kids == {"cached-kid"}


### PR DESCRIPTION
## Summary

PR 2 of the conformance-testing cluster. Closes the M-5 finding from the PR #394 second adversarial review: a 200-with-empty-keys response from upstream wedged every kid-miss request for one cooldown window even though working cached keys were available.

\`_refresh_jwks\` now returns \`(JwksResponse, from_retained_cache: bool)\`:
- When upstream is successful-but-empty AND the cache holds a populated entry, the helper surfaces the retained response and signals \`from_retained_cache=True\`.
- Callers (\`_discover_and_resolve_key\`, \`_retry_with_refreshed_jwks\` in both sync and aio) skip the kid-miss cooldown stamp when \`from_retained_cache=True\` — an empty upstream is not attacker-amplifiable, so the DoS-stamp framing doesn't apply.

Net effect: a transient empty blip from the OP no longer suppresses kid-miss refreshes for the next cooldown window. \`validate_jwks_response\` now succeeds with the retained keys; \`find_key_by_kid\` raises the more informative \`no matching kid\` instead of \`no keys available\`.

## Test plan
- [x] \`make lint\` — green
- [x] Existing empty-keys retention tests updated to assert the new contract (retained cache surfaced)
- [x] 3 new regression tests in \`test_kid_miss_cooldown.py::TestEmptyRefreshDoesNotStampCooldown\`:
  - sync: empty refresh after prime → cache retains primed keys + cooldown stays clear
  - aio: same
  - sync: \`_refresh_jwks\` surface contract — retained cache returned + \`from_retained_cache=True\`
- [x] All \`_refresh_jwks\` call sites in tests updated to unpack the tuple (\`test_cache_http_headers\`, \`test_cache_stampede\`)
- [ ] CI: unit, integration, conformance, examples

Closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)