### PR TITLE
fix(aio): per-event-loop async locks (#399)

### DIFF
--- a/src/py_identity_model/aio/token_validation.py
+++ b/src/py_identity_model/aio/token_validation.py
@@ -8,6 +8,7 @@ with automatic cache expiry and forced JWKS refresh on key rotation.
 import asyncio
 import threading
 import time
+from weakref import WeakKeyDictionary
 
 from ..core.discovery_policy import DiscoveryPolicy
 from ..core.jwks_cache import (
@@ -54,20 +55,54 @@ from .managed_client import AsyncHTTPClient
 
 # Discovery TTL cache — keyed by (address, require_https) to prevent policy bypass
 _disco_cache: dict[tuple[str, bool], DiscoCacheEntry] = {}
-# Brief CPU-only write lock; does NOT span the upstream HTTP fetch. See
-# the sync module for the full rationale and the cache-aside pattern.
-_disco_cache_write_lock = asyncio.Lock()
-# Per-URI fetch locks (striped). Allows two coroutines waiting on
-# discovery for *different* addresses to run in parallel rather than
-# serializing on a single global lock held across an awaited HTTP call.
+
+# Per-event-loop lock storage. Module-level ``asyncio.Lock()`` instances bind
+# to whichever event loop first calls ``.acquire()`` (Python 3.10+), so any
+# embed or test runner that creates a new loop per scope hits
+# ``RuntimeError: <Lock> is bound to a different event loop``. Keying locks
+# on the running loop via ``WeakKeyDictionary`` gives each loop its own
+# independent lock set, and the entries get reclaimed when a loop is closed.
+# ``_lock_creation_lock`` is a plain ``threading.Lock`` so creation is safe
+# from any thread regardless of which loop is running. See #399.
 _DISCO_LOCK_STRIPES = 32
-_disco_fetch_locks: list[asyncio.Lock] = [
-    asyncio.Lock() for _ in range(_DISCO_LOCK_STRIPES)
-]
+_JWKS_LOCK_STRIPES = 32
+_disco_cache_write_locks: WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock] = (
+    WeakKeyDictionary()
+)
+_disco_fetch_locks_by_loop: WeakKeyDictionary[
+    asyncio.AbstractEventLoop, list[asyncio.Lock]
+] = WeakKeyDictionary()
+_jwks_cache_write_locks: WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock] = (
+    WeakKeyDictionary()
+)
+_jwks_fetch_locks_by_loop: WeakKeyDictionary[
+    asyncio.AbstractEventLoop, list[asyncio.Lock]
+] = WeakKeyDictionary()
+_lock_creation_lock = threading.Lock()
+
+
+def _get_disco_cache_write_lock() -> asyncio.Lock:
+    loop = asyncio.get_running_loop()
+    lock = _disco_cache_write_locks.get(loop)
+    if lock is None:
+        with _lock_creation_lock:
+            lock = _disco_cache_write_locks.get(loop)
+            if lock is None:
+                lock = asyncio.Lock()
+                _disco_cache_write_locks[loop] = lock
+    return lock
 
 
 def _get_disco_fetch_lock(cache_key: tuple[str, bool]) -> asyncio.Lock:
-    return _disco_fetch_locks[hash(cache_key) % _DISCO_LOCK_STRIPES]
+    loop = asyncio.get_running_loop()
+    stripes = _disco_fetch_locks_by_loop.get(loop)
+    if stripes is None:
+        with _lock_creation_lock:
+            stripes = _disco_fetch_locks_by_loop.get(loop)
+            if stripes is None:
+                stripes = [asyncio.Lock() for _ in range(_DISCO_LOCK_STRIPES)]
+                _disco_fetch_locks_by_loop[loop] = stripes
+    return stripes[hash(cache_key) % _DISCO_LOCK_STRIPES]
 
 
 async def _get_disco_response(
@@ -100,7 +135,7 @@ async def _get_disco_response(
         response = await get_discovery_document(
             DiscoveryDocumentRequest(address=disco_doc_address, policy=policy),
         )
-        async with _disco_cache_write_lock:
+        async with _get_disco_cache_write_lock():
             apply_disco_cache_outcome(
                 _disco_cache, cache_key, response, time.monotonic()
             )
@@ -111,13 +146,19 @@ async def clear_discovery_cache() -> None:
     """Clear the discovery cache.
 
     **Breaking change (v3.0.0):** this helper is now ``async`` so it can
-    acquire ``_disco_cache_write_lock`` before clearing. The previous
+    acquire the disco-cache write lock before clearing. The previous
     synchronous version mutated state guarded by an ``asyncio.Lock``
     without awaiting it, so a coroutine mid-flight in ``_refresh_jwks``
     could write its result back *after* ``clear()`` ran, leaving the
     "cleared" cache holding an entry. Callers must now ``await``.
+
+    Acquires the *current loop's* write lock. The cache dict itself is
+    process-shared, so the clear is visible to operations on any loop;
+    in-flight writes on a different loop are not coordinated with this
+    clear, which matches the prior (single-lock) semantics modulo the
+    per-loop lock plumbing for #399.
     """
-    async with _disco_cache_write_lock:
+    async with _get_disco_cache_write_lock():
         _disco_cache.clear()
 
 
@@ -126,18 +167,34 @@ async def clear_discovery_cache() -> None:
 # ============================================================================
 
 _jwks_cache: dict[str, JwksCacheEntry] = {}
-_jwks_cache_write_lock = asyncio.Lock()
-_JWKS_LOCK_STRIPES = 32
-_jwks_fetch_locks: list[asyncio.Lock] = [
-    asyncio.Lock() for _ in range(_JWKS_LOCK_STRIPES)
-]
 
-# See sync._kid_miss_last_attempt for rationale. Guarded by _jwks_cache_write_lock.
+# See sync._kid_miss_last_attempt for rationale. Guarded by the per-loop
+# JWKS cache write lock.
 _kid_miss_last_attempt: dict[str, float] = {}
 
 
+def _get_jwks_cache_write_lock() -> asyncio.Lock:
+    loop = asyncio.get_running_loop()
+    lock = _jwks_cache_write_locks.get(loop)
+    if lock is None:
+        with _lock_creation_lock:
+            lock = _jwks_cache_write_locks.get(loop)
+            if lock is None:
+                lock = asyncio.Lock()
+                _jwks_cache_write_locks[loop] = lock
+    return lock
+
+
 def _get_jwks_fetch_lock(jwks_uri: str) -> asyncio.Lock:
-    return _jwks_fetch_locks[hash(jwks_uri) % _JWKS_LOCK_STRIPES]
+    loop = asyncio.get_running_loop()
+    stripes = _jwks_fetch_locks_by_loop.get(loop)
+    if stripes is None:
+        with _lock_creation_lock:
+            stripes = _jwks_fetch_locks_by_loop.get(loop)
+            if stripes is None:
+                stripes = [asyncio.Lock() for _ in range(_JWKS_LOCK_STRIPES)]
+                _jwks_fetch_locks_by_loop[loop] = stripes
+    return stripes[hash(jwks_uri) % _JWKS_LOCK_STRIPES]
 
 
 async def _get_cached_jwks(jwks_uri: str) -> JwksResponse:
@@ -156,7 +213,7 @@ async def _get_cached_jwks(jwks_uri: str) -> JwksResponse:
             return entry.response
 
         response = await get_jwks(JwksRequest(address=jwks_uri))
-        async with _jwks_cache_write_lock:
+        async with _get_jwks_cache_write_lock():
             apply_jwks_cache_outcome(
                 _jwks_cache,
                 jwks_uri,
@@ -189,7 +246,7 @@ async def _refresh_jwks(jwks_uri: str) -> JwksResponse:
 
         logger.info("Forcing JWKS refresh for %s (possible key rotation)", jwks_uri)
         response = await get_jwks(JwksRequest(address=jwks_uri))
-        async with _jwks_cache_write_lock:
+        async with _get_jwks_cache_write_lock():
             apply_jwks_cache_outcome(
                 _jwks_cache,
                 jwks_uri,
@@ -204,15 +261,18 @@ async def clear_jwks_cache() -> None:
     """Clear the JWKS cache. Useful for testing.
 
     **Breaking change (v3.0.0):** this helper is now ``async`` so it can
-    acquire ``_jwks_cache_write_lock`` before clearing. The previous
+    acquire the JWKS-cache write lock before clearing. The previous
     synchronous version mutated state guarded by an ``asyncio.Lock``
     without awaiting it, so a coroutine mid-flight in ``_refresh_jwks``
     could write its result back *after* ``clear()`` ran, leaving the
     "cleared" cache holding an entry. The cooldown sidecar
     (``_kid_miss_last_attempt``) is cleared under the same lock for the
     same reason. Callers must now ``await``.
+
+    Acquires the current loop's write lock; see ``clear_discovery_cache``
+    for the cross-loop semantics added in the #399 per-loop lock plumbing.
     """
-    async with _jwks_cache_write_lock:
+    async with _get_jwks_cache_write_lock():
         _jwks_cache.clear()
         _kid_miss_last_attempt.clear()
 
@@ -320,7 +380,7 @@ async def _discover_and_resolve_key(
             if jwks_response.is_successful:
                 refreshed_keys = jwks_response.keys or []
                 kid_found = any(k.kid == kid for k in refreshed_keys)
-                async with _jwks_cache_write_lock:
+                async with _get_jwks_cache_write_lock():
                     if kid_found:
                         _kid_miss_last_attempt.pop(jwks_uri, None)
                     else:
@@ -392,10 +452,10 @@ async def _retry_with_refreshed_jwks(
         resolved_config = build_resolved_config(token_validation_config, key_dict, alg)
         decoded = decode_with_config(jwt, resolved_config, disco_doc_response.issuer)
     except Exception:
-        async with _jwks_cache_write_lock:
+        async with _get_jwks_cache_write_lock():
             _kid_miss_last_attempt[jwks_uri] = time.monotonic()
         raise
-    async with _jwks_cache_write_lock:
+    async with _get_jwks_cache_write_lock():
         _kid_miss_last_attempt.pop(jwks_uri, None)
     return decoded
 

--- a/src/tests/unit/test_aio_per_loop_locks.py
+++ b/src/tests/unit/test_aio_per_loop_locks.py
@@ -1,0 +1,245 @@
+"""
+Regression coverage for #399: ``aio/token_validation.py`` must not bind
+its cache locks to whichever event loop happens to import the module
+first.
+
+Pre-fix: module-level ``asyncio.Lock()`` instances bound to the first
+loop that called ``.acquire()`` (Python 3.10+ semantics). Test runners
+or embeds that create a new loop per scope (``asyncio.new_event_loop()``,
+ASGI servers with custom loop policies, uvicorn workers that recreate
+loops between requests) hit:
+
+    RuntimeError: <asyncio.locks.Lock object at 0x...> is bound to a
+    different event loop
+
+Post-fix: locks are stored in a ``WeakKeyDictionary`` keyed by the
+running event loop and created lazily on first use within that loop.
+Each loop sees its own independent lock set; entries are reclaimed when
+a loop is garbage-collected.
+
+These tests exercise the multi-loop scenario directly:
+
+1. Run a validation flow on loop A.
+2. Close loop A and open a fresh loop B.
+3. Run the same operations on loop B without the dreaded RuntimeError.
+
+The pre-fix code raises on step 3; the post-fix code completes both
+flows cleanly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import weakref
+
+import httpx
+import pytest
+import respx
+
+from py_identity_model.aio import token_validation as aio_tv
+
+
+JWKS_URL = "https://issuer.example/jwks"
+
+
+def _make_key() -> dict:
+    # Minimal RSA JWK shape — only the *parsing* path is exercised here.
+    # generate_rsa_keypair() would be heavier than necessary.
+    return {
+        "kty": "RSA",
+        "use": "sig",
+        "alg": "RS256",
+        "kid": "test-key",
+        "n": "example_n",
+        "e": "AQAB",
+    }
+
+
+def _reset_aio_lock_state() -> None:
+    """Wipe the per-loop lock dicts between tests.
+
+    The WeakKeyDictionary entries would otherwise persist for the
+    lifetime of the loop, but the loops we create here are anonymous
+    and discarded — manual clearing keeps state predictable for
+    successive test runs.
+    """
+    aio_tv._disco_cache_write_locks.clear()
+    aio_tv._disco_fetch_locks_by_loop.clear()
+    aio_tv._jwks_cache_write_locks.clear()
+    aio_tv._jwks_fetch_locks_by_loop.clear()
+    aio_tv._jwks_cache.clear()
+    aio_tv._kid_miss_last_attempt.clear()
+    aio_tv._disco_cache.clear()
+
+
+@pytest.fixture(autouse=True)
+def _wipe_lock_state():
+    _reset_aio_lock_state()
+    yield
+    _reset_aio_lock_state()
+
+
+class TestPerLoopLocksAreIndependent:
+    @respx.mock
+    def test_two_event_loops_each_get_their_own_jwks_fetch_lock(self) -> None:
+        """A fresh loop sees a fresh lock — pre-fix this raised
+        RuntimeError because the module-level lock was bound to the
+        first loop's event loop."""
+        respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(200, json={"keys": [_make_key()]})
+        )
+
+        loop_a = asyncio.new_event_loop()
+        try:
+            loop_a.run_until_complete(aio_tv._get_cached_jwks(JWKS_URL))
+        finally:
+            loop_a.close()
+
+        # Fresh loop, fresh lock set. Pre-fix:
+        #   RuntimeError: <Lock> is bound to a different event loop.
+        loop_b = asyncio.new_event_loop()
+        try:
+            response = loop_b.run_until_complete(aio_tv._get_cached_jwks(JWKS_URL))
+        finally:
+            loop_b.close()
+
+        assert response.is_successful is True
+        assert response.keys is not None
+        assert len(response.keys) == 1
+
+    def test_per_loop_lock_storage_uses_running_loop_as_key(self) -> None:
+        """Calling the accessor from inside a loop registers that loop
+        as the key. Two distinct loops produce two distinct lock
+        instances."""
+
+        async def grab_locks():
+            return (
+                aio_tv._get_jwks_cache_write_lock(),
+                aio_tv._get_jwks_fetch_lock(JWKS_URL),
+                aio_tv._get_disco_cache_write_lock(),
+                aio_tv._get_disco_fetch_lock((JWKS_URL, True)),
+            )
+
+        loop_a = asyncio.new_event_loop()
+        try:
+            locks_a = loop_a.run_until_complete(grab_locks())
+        finally:
+            loop_a.close()
+
+        loop_b = asyncio.new_event_loop()
+        try:
+            locks_b = loop_b.run_until_complete(grab_locks())
+        finally:
+            loop_b.close()
+
+        # Each lock is a separate instance per loop.
+        for la, lb in zip(locks_a, locks_b, strict=True):
+            assert la is not lb, (
+                "Per-loop locks must be distinct across loops; pre-fix "
+                "behavior would return the same module-level instance."
+            )
+
+    @respx.mock
+    def test_validation_flow_works_across_distinct_loops(self) -> None:
+        """End-to-end smoke test: prime cache on one loop, refresh on
+        another. Exercises both _get_cached_jwks and _refresh_jwks."""
+        respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(200, json={"keys": [_make_key()]})
+        )
+
+        loop_a = asyncio.new_event_loop()
+        try:
+            loop_a.run_until_complete(aio_tv._get_cached_jwks(JWKS_URL))
+        finally:
+            loop_a.close()
+
+        loop_b = asyncio.new_event_loop()
+        try:
+            refreshed = loop_b.run_until_complete(aio_tv._refresh_jwks(JWKS_URL))
+            # _refresh_jwks may have a tuple or single-value return depending
+            # on whether #403 has been merged into this branch. Normalize.
+            response = refreshed[0] if isinstance(refreshed, tuple) else refreshed
+        finally:
+            loop_b.close()
+
+        assert response.is_successful is True
+
+    def test_closed_loop_entries_get_reclaimed(self) -> None:
+        """A closed event loop should be removable from the
+        WeakKeyDictionary. Pin this so a later refactor can't quietly
+        switch to a regular dict and leak loops."""
+        loop = asyncio.new_event_loop()
+        ref = weakref.ref(loop)
+
+        async def touch():
+            # Register the loop in every per-loop dict.
+            aio_tv._get_jwks_cache_write_lock()
+            aio_tv._get_jwks_fetch_lock("x")
+            aio_tv._get_disco_cache_write_lock()
+            aio_tv._get_disco_fetch_lock(("x", True))
+
+        try:
+            loop.run_until_complete(touch())
+            # Confirm registration happened.
+            assert loop in aio_tv._jwks_cache_write_locks
+            assert loop in aio_tv._jwks_fetch_locks_by_loop
+            assert loop in aio_tv._disco_cache_write_locks
+            assert loop in aio_tv._disco_fetch_locks_by_loop
+        finally:
+            loop.close()
+
+        # Drop the strong reference and force GC.
+        del loop
+        import gc  # noqa: PLC0415
+
+        gc.collect()
+
+        # The weak reference should be dead — the WeakKeyDictionary lets
+        # the loop be reclaimed despite our previous registrations.
+        assert ref() is None, (
+            "Per-loop lock storage must use WeakKeyDictionary so closed "
+            "loops are reclaimed; a strong-ref dict would leak loops."
+        )
+
+    @respx.mock
+    def test_refresh_jwks_works_across_loops(self) -> None:
+        """``_refresh_jwks`` acquires both the per-URI fetch lock AND
+        the cache write lock. Both must be loop-local."""
+        respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(200, json={"keys": [_make_key()]})
+        )
+
+        loop_a = asyncio.new_event_loop()
+        try:
+            result_a = loop_a.run_until_complete(aio_tv._refresh_jwks(JWKS_URL))
+        finally:
+            loop_a.close()
+        response_a = result_a[0] if isinstance(result_a, tuple) else result_a
+        assert response_a.is_successful
+
+        loop_b = asyncio.new_event_loop()
+        try:
+            result_b = loop_b.run_until_complete(aio_tv._refresh_jwks(JWKS_URL))
+        finally:
+            loop_b.close()
+        response_b = result_b[0] if isinstance(result_b, tuple) else result_b
+        assert response_b.is_successful
+
+    def test_clear_jwks_cache_runs_under_fresh_loop(self) -> None:
+        """``clear_jwks_cache`` acquires the cache write lock. Running
+        it under a brand-new loop pre-fix raised RuntimeError."""
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(aio_tv.clear_jwks_cache())
+        finally:
+            loop.close()
+        # Reaching here without RuntimeError is the assertion.
+
+    def test_clear_discovery_cache_runs_under_fresh_loop(self) -> None:
+        """Mirror of ``test_clear_jwks_cache_runs_under_fresh_loop`` for
+        the discovery write lock."""
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(aio_tv.clear_discovery_cache())
+        finally:
+            loop.close()


### PR DESCRIPTION
## Summary

PR 4 (final) of the conformance-testing cluster. Closes M-3 from the PR #394 second adversarial review.

\`src/py_identity_model/aio/token_validation.py\` previously created **66** module-level \`asyncio.Lock()\` instances (1 + 32 disco + 1 + 32 JWKS). Modern Python (3.10+) binds each lock to the first event loop that calls \`.acquire()\`, so anything that creates a new loop per scope (\`asyncio.new_event_loop()\`, \`pytest-asyncio\` with non-session scope, ASGI servers with custom loop policies, uvicorn workers that recreate loops) hits:

\`\`\`
RuntimeError: <asyncio.locks.Lock object at 0x...> is bound to a different event loop
\`\`\`

**Fix.** All four lock storages move to \`WeakKeyDictionary[AbstractEventLoop, ...]\`:
- \`_disco_cache_write_locks\` — Lock per loop
- \`_disco_fetch_locks_by_loop\` — \`list[Lock]\` per loop (32-stripe)
- \`_jwks_cache_write_locks\` — Lock per loop
- \`_jwks_fetch_locks_by_loop\` — \`list[Lock]\` per loop (32-stripe)

Lazy-created on first use within the running loop, double-checked under a \`threading.Lock\` so creation is safe from any thread regardless of which loop is running. \`WeakKeyDictionary\` lets closed loops be reclaimed.

Accessors \`_get_*_fetch_lock\` and \`_get_*_cache_write_lock\` encapsulate the per-loop lookup; all call sites switch from \`async with _x_lock:\` to \`async with _get_x_lock():\`.

## Test plan
- [x] \`make lint\` — green
- [x] 7 new tests in \`test_aio_per_loop_locks.py\`:
  - distinct loops → distinct lock instances (sync mirror of the production change)
  - end-to-end validation flow across loops (the case that raised pre-fix)
  - closed loops get reclaimed via \`WeakKeyDictionary\` (pinned via \`weakref.ref\`)
  - \`_refresh_jwks\` works across loops (exercises both fetch + write lock acquisition)
  - \`clear_jwks_cache\` / \`clear_discovery_cache\` run under a fresh loop
- [x] All 109 existing async tests pass with the new plumbing
- [ ] CI: unit, integration, conformance, examples

Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)