### PR TITLE
ci+fix: cert submission readiness — OIDF image, JWKS cache policy, integration test rate-limit fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,14 @@ on:
     branches: [main]
   pull_request:
 
+# Cancel any in-progress Build run on the same PR ref when a new commit
+# lands. Without this, rapid pushes to a PR stack multiple full CI runs
+# against the same provider endpoints (Ory in particular), compounding
+# rate-limit pressure. Main pushes are never cancelled.
+concurrency:
+  group: build-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ on:
         required: false
         type: boolean
         default: false
+      run-ory-integration:
+        description: 'Run Ory integration tests (skip in duplicate-call workflows to avoid upstream rate limits)'
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   lint:
@@ -83,6 +88,7 @@ jobs:
         run: make test-unit
 
   integration-tests-ory:
+    if: inputs.run-ory-integration
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/conformance-hosted.yml
+++ b/.github/workflows/conformance-hosted.yml
@@ -64,6 +64,16 @@ jobs:
             --output conformance/results/hosted/config-rp-latest.json \
             --verbose
 
+      - name: Run Form Post Basic RP conformance tests
+        env:
+          CONFORMANCE_SERVER: https://www.certification.openid.net/
+          CONFORMANCE_TOKEN: ${{ secrets.CONFORMANCE_TOKEN }}
+        run: |
+          python conformance/run_tests.py \
+            --plan form-post-basic-rp \
+            --output conformance/results/hosted/form-post-basic-rp-latest.json \
+            --verbose
+
       - name: Upload conformance results
         uses: actions/upload-artifact@v7
         if: always()

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -10,6 +10,12 @@ permissions:
   contents: write
   pull-requests: write
 
+# Cancel any in-progress Publish Pre-release run on the same PR ref
+# when a new commit lands. Avoids stacked CI runs on rapid pushes.
+concurrency:
+  group: publish-prerelease-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     uses: ./.github/workflows/ci.yml
@@ -17,6 +23,11 @@ jobs:
       run-descope-integration: true
       run-example-tests: true
       run-build: true
+      # Ory integration runs in build.yml on the same push; skipping it
+      # here eliminates duplicate concurrent hits to Ory's rate-limited
+      # discovery/JWKS endpoints, which was the dominant cause of
+      # integration-tests-ory 429s on PRs.
+      run-ory-integration: false
     secrets: inherit
 
   publish-prerelease:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,9 +36,15 @@ py-identity-model is a production-grade OIDC/OAuth2.0 helper library for Python 
    make pre-push    # Runs: lint + node-oidc integration + conformance harness + examples
    ```
 
-4. **Use conventional commits** — commit messages must follow the Angular convention (see Git Workflow section below). Commits to `main` trigger semantic-release version bumps.
+4. **Always run integration tests locally before pushing changes to `src/tests/integration/conftest.py`, any test fixture, or shared test utilities.** `make lint` only covers unit tests; `pytest --collect-only` only imports fixtures and does NOT exercise fixture network code paths or cross-worker xdist behavior. Use the credentials-free local fixture:
+   ```bash
+   make test-integration-node-oidc   # Local Docker fixture, no credentials needed
+   ```
+   For changes that affect provider-specific behavior, also run `make test-integration-ory` and/or `make test-integration-descope`. Do NOT push fixture/conftest changes solely on the strength of lint passing — relying on CI to catch fixture regressions wastes a review cycle.
 
-5. **Create a PR for all changes** — push the feature branch and open a PR against `main`. PR titles **must** follow conventional commit format (e.g., `feat(discovery): add metadata support`, `fix: handle missing kid`, `ci: update actions`).
+5. **Use conventional commits** — commit messages must follow the Angular convention (see Git Workflow section below). Commits to `main` trigger semantic-release version bumps.
+
+6. **Create a PR for all changes** — push the feature branch and open a PR against `main`. PR titles **must** follow conventional commit format (e.g., `feat(discovery): add metadata support`, `fix: handle missing kid`, `ci: update actions`).
 
 ## Architecture
 

--- a/Makefile
+++ b/Makefile
@@ -149,10 +149,12 @@ conformance-test: $(if $(HOSTED),,conformance-up) ## Run conformance tests (HOST
 ifdef HOSTED
 	uv run python conformance/run_tests.py --plan basic-rp --suite-url "$(CONFORMANCE_SERVER)" --output conformance/results/hosted/basic-rp-latest.json --verbose
 	uv run python conformance/run_tests.py --plan config-rp --suite-url "$(CONFORMANCE_SERVER)" --output conformance/results/hosted/config-rp-latest.json --verbose
+	uv run python conformance/run_tests.py --plan form-post-basic-rp --suite-url "$(CONFORMANCE_SERVER)" --output conformance/results/hosted/form-post-basic-rp-latest.json --verbose
 	@echo "Hosted conformance tests complete. Results in conformance/results/hosted/"
 else
 	uv run python conformance/run_tests.py --plan basic-rp --output conformance/results/basic-rp-latest.json --verbose
 	uv run python conformance/run_tests.py --plan config-rp --output conformance/results/config-rp-latest.json --verbose
+	uv run python conformance/run_tests.py --plan form-post-basic-rp --output conformance/results/form-post-basic-rp-latest.json --verbose
 	@echo "Conformance tests complete. Results in conformance/results/"
 endif
 

--- a/conformance/docker-compose.yml
+++ b/conformance/docker-compose.yml
@@ -37,12 +37,15 @@ services:
         condition: service_healthy
 
   server:
-    image: authelia/openid-connect-conformance-suite:latest
+    image: registry.gitlab.com/openid/conformance-suite:latest
     environment:
-      - JAVA_EXTRA_ARGS=-Dspring.data.mongodb.uri=mongodb://mongodb:27017/test_suite -Dfintechlabs.devmode=true -Dfintechlabs.startredir=false -Dfintechlabs.base_url=https://localhost.emobix.co.uk:8443
-      - CONFORMANCE_SERVER_BASE_URL=https://localhost.emobix.co.uk:8443
-      - SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_GITLAB_CLIENT_ID=dummy
-      - SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_GITLAB_CLIENT_SECRET=dummy
+      - BASE_URL=https://localhost.emobix.co.uk:8443
+      - MONGODB_HOST=mongodb
+      - SPRING_PROFILES_ACTIVE=dev
+      - OIDC_GOOGLE_CLIENTID=dummy
+      - OIDC_GOOGLE_SECRET=dummy
+      - OIDC_GITLAB_CLIENTID=dummy
+      - OIDC_GITLAB_SECRET=dummy
     depends_on:
       - mongodb
     healthcheck:

--- a/src/py_identity_model/core/jwks_cache.py
+++ b/src/py_identity_model/core/jwks_cache.py
@@ -281,12 +281,56 @@ def is_uncacheable(cache_control: str | None) -> bool:
     Honors RFC 7234 §5.2.2.5 (``no-store``) and §5.2.2.4 (``no-cache``).
     ``no-cache`` requires revalidation before use; the simplest correct
     behavior is to skip caching so the next call re-fetches.
+
+    Used for response types whose contents are per-user or sensitive
+    (token responses, discovery documents). For JWKS, see
+    :func:`is_uncacheable_for_jwks` — JWKS responses contain public
+    signing keys, and strict ``no-cache``/``no-store`` honoring causes
+    a self-DoS against the upstream issuer at any meaningful traffic
+    level (see issue #396).
     """
     if not cache_control:
         return False
     return bool(
         _NO_STORE_RE.search(cache_control) or _NO_CACHE_RE.search(cache_control)
     )
+
+
+def is_uncacheable_for_jwks(cache_control: str | None) -> bool:  # noqa: ARG001
+    """Return True only when JWKS caching is genuinely forbidden.
+
+    JWKS responses contain *public* signing keys that the issuer
+    publishes for every relying party to fetch and reuse. The standard
+    Cache-Control directives are interpreted accordingly:
+
+    - ``no-cache`` (RFC 7234 §5.2.2.4): means "revalidate before use,"
+      not "do not cache." A strict implementation would issue ETag /
+      If-None-Match conditional GETs. As a practical compromise, we
+      cache for the resolved TTL (``max-age`` if present, else the
+      configured floor). This is the dominant industry behavior — see
+      e.g. Auth0, Keycloak, and ``jose`` adapters.
+
+    - ``no-store`` (RFC 7234 §5.2.2.5): means "MUST NOT store." On
+      sensitive responses (tokens, user data) this matters. On JWKS —
+      public material the issuer publicly advertises — the directive
+      provides no confidentiality benefit and creates an operational
+      hazard: at 100 token validations / second, strictly honoring
+      ``no-store`` produces 100 JWKS fetches / second against the
+      issuer, which self-DoSes the upstream and the relying party in
+      short order. We deliberately ignore ``no-store`` on JWKS.
+
+    Always returns False today. The function exists as the call site so
+    the policy is documented and overridable in one place if a future
+    ``max-age=0`` honoring path is added.
+
+    Refs:
+        - Issue #396 (security: jwks-cache C-4 — ``no-cache`` providers
+          fetch JWKS on every request).
+        - Common deployments that send ``no-cache, no-store`` on JWKS
+          include Ory Network's free tier and some Descope-style
+          configurations.
+    """
+    return False
 
 
 def parse_max_age(cache_control: str | None) -> float | None:
@@ -394,9 +438,12 @@ def apply_jwks_cache_outcome(
       Checked *before* the uncacheable branch so a malformed ``200 {"keys":
       []}`` paired with ``Cache-Control: no-cache`` does not delete a working
       entry on a transient empty-body blip.
-    - ``Cache-Control: no-store`` or ``no-cache``: invalidate the existing
-      entry. Any stale entry would otherwise survive its TTL alongside a
-      provider that explicitly forbade caching, defeating key rotation.
+    - ``Cache-Control: no-store`` or ``no-cache`` (via
+      :func:`is_uncacheable_for_jwks`): JWKS is public material, so
+      caching with the resolved TTL is operationally safe and
+      necessary at scale. Today this branch is never taken because
+      ``is_uncacheable_for_jwks`` always returns False; it is retained
+      as the documented policy hook for future strict-mode opt-ins.
     - Successful, cacheable, non-empty: store with the resolved TTL.
 
     The optional ``cooldown`` dict is a sidecar of per-URI timestamps that
@@ -407,7 +454,7 @@ def apply_jwks_cache_outcome(
         return
     if not response.keys:
         return
-    if is_uncacheable(response.cache_control):
+    if is_uncacheable_for_jwks(response.cache_control):
         cache.pop(jwks_uri, None)
         if cooldown is not None:
             cooldown.pop(jwks_uri, None)
@@ -469,6 +516,7 @@ __all__ = [
     "get_max_cache_entries",
     "is_cache_expired",
     "is_uncacheable",
+    "is_uncacheable_for_jwks",
     "parse_max_age",
     "resolve_disco_ttl",
     "resolve_ttl",

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -7,7 +7,7 @@ Includes:
 """
 
 from contextlib import suppress
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 import json
 import secrets
 import time
@@ -123,7 +123,9 @@ def discovery_document(test_config, tmp_path_factory):
         response = get_discovery_document(disco_doc_req)
         if not response.is_successful:
             pytest.fail(f"Failed to fetch discovery document: {response.error}")
-        cache_file.write_text(json.dumps(asdict(response)))
+        # ``asdict()`` trips the BaseResponse field-access guards; use vars()
+        # to read the underlying storage. See models.BaseResponse docstring.
+        cache_file.write_text(json.dumps(vars(response)))
         return response
 
 
@@ -250,7 +252,11 @@ def jwks_response(test_config, tmp_path_factory):
         response = get_jwks(jwks_req)
         if not response.is_successful:
             pytest.fail(f"Failed to fetch JWKS: {response.error}")
-        cache_file.write_text(json.dumps(asdict(response)))
+        # vars() bypasses BaseResponse field-access guards; manually expand
+        # the nested JsonWebKey list since vars() doesn't recurse.
+        data = vars(response).copy()
+        data["keys"] = [vars(k) for k in response.keys or []]
+        cache_file.write_text(json.dumps(data))
         return response
 
 

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -39,8 +39,15 @@ from py_identity_model import (
     request_client_credentials_token,
     validate_authorize_callback_state,
 )
+from py_identity_model.aio import token_validation as aio_tv
 from py_identity_model.core.discovery_policy import DiscoveryPolicy
-from py_identity_model.core.jwks_cache import is_uncacheable
+from py_identity_model.core.jwks_cache import (
+    DiscoCacheEntry,
+    JwksCacheEntry,
+    is_uncacheable,
+    resolve_disco_ttl,
+    resolve_ttl,
+)
 from py_identity_model.core.models import DiscoveryDocumentResponse
 from py_identity_model.core.parsers import (
     extract_kid_from_jwt,
@@ -48,6 +55,7 @@ from py_identity_model.core.parsers import (
 )
 from py_identity_model.core.pkce import generate_pkce_pair
 from py_identity_model.exceptions import TokenValidationException
+from py_identity_model.sync import token_validation as sync_tv
 from py_identity_model.sync.http_client import close_http_client
 
 from .test_utils import get_config
@@ -275,6 +283,48 @@ def provider_caches_responses(discovery_document, jwks_response):
     """
     del jwks_response  # see docstring
     return not is_uncacheable(discovery_document.cache_control)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _prime_library_caches(discovery_document, jwks_response, test_config):
+    """Pre-populate the library's internal JWKS + discovery caches.
+
+    The conftest already fetches discovery/JWKS once per xdist worker
+    (cross-worker-coordinated via FileLock). But ``validate_token()``
+    consults its own per-process module-level caches
+    (``sync/aio.token_validation._jwks_cache`` and ``_disco_cache``),
+    which start cold in every worker. Without priming, the *first*
+    ``validate_token`` call in each worker triggers a fresh upstream
+    fetch — and against rate-limited providers (Ory free tier) those
+    bursts produce 429s mid-test.
+
+    Inject the fixture-resolved responses directly into both sync and
+    aio caches. After this fixture runs, no test in the session needs
+    to hit the upstream for discovery or JWKS.
+
+    Keyed identically to the library: JWKS by URI; discovery by
+    ``(address, require_https)`` tuple.
+    """
+    now = time.monotonic()
+    require_https = test_config.get("TEST_REQUIRE_HTTPS", True)
+
+    jwks_uri = test_config["TEST_JWKS_ADDRESS"]
+    jwks_entry = JwksCacheEntry(
+        response=jwks_response,
+        cached_at=now,
+        ttl=resolve_ttl(jwks_response.cache_control),
+    )
+    sync_tv._jwks_cache[jwks_uri] = jwks_entry
+    aio_tv._jwks_cache[jwks_uri] = jwks_entry
+
+    disco_key = (test_config["TEST_DISCO_ADDRESS"], require_https)
+    disco_entry = DiscoCacheEntry(
+        response=discovery_document,
+        cached_at=now,
+        ttl=resolve_disco_ttl(discovery_document.cache_control),
+    )
+    sync_tv._disco_cache[disco_key] = disco_entry
+    aio_tv._disco_cache[disco_key] = disco_entry
 
 
 @pytest.fixture(scope="session")

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -7,7 +7,7 @@ Includes:
 """
 
 from contextlib import suppress
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 import json
 import secrets
 import time
@@ -29,7 +29,9 @@ from py_identity_model import (
     ClientCredentialsTokenRequest,
     ClientCredentialsTokenResponse,
     DiscoveryDocumentRequest,
+    JsonWebKey,
     JwksRequest,
+    JwksResponse,
     get_discovery_document,
     get_jwks,
     parse_authorize_callback_response,
@@ -96,55 +98,77 @@ def test_config(env_file, tmp_path_factory):
 
 
 @pytest.fixture(scope="session")
-def discovery_document(test_config):
-    """Cached discovery document (session-scoped).
+def discovery_document(test_config, tmp_path_factory):
+    """Cached discovery document, shared across xdist workers.
 
-    The library's ``get_discovery_document`` already retries 3x on
-    429/5xx via ``@retry_with_backoff``.  No outer retry needed.
+    See ``client_credentials_token`` for the cross-worker FileLock +
+    JSON cache rationale: without it, ``pytest -n auto`` fans out N
+    simultaneous discovery requests at session start and trips upstream
+    rate limits.
     """
-    require_https = test_config.get("TEST_REQUIRE_HTTPS", True)
-    policy = DiscoveryPolicy(require_https=require_https)
-    disco_doc_req = DiscoveryDocumentRequest(
-        address=test_config["TEST_DISCO_ADDRESS"],
-        policy=policy,
-    )
-    response = get_discovery_document(disco_doc_req)
-    if not response.is_successful:
-        pytest.fail(f"Failed to fetch discovery document: {response.error}")
-    return response
+    root_tmp_dir = tmp_path_factory.getbasetemp().parent
+    cache_file = root_tmp_dir / "discovery_document.json"
+    lock_file = root_tmp_dir / "discovery_document.lock"
+
+    with FileLock(str(lock_file)):
+        if cache_file.exists():
+            return DiscoveryDocumentResponse(**json.loads(cache_file.read_text()))
+
+        require_https = test_config.get("TEST_REQUIRE_HTTPS", True)
+        policy = DiscoveryPolicy(require_https=require_https)
+        disco_doc_req = DiscoveryDocumentRequest(
+            address=test_config["TEST_DISCO_ADDRESS"],
+            policy=policy,
+        )
+        response = get_discovery_document(disco_doc_req)
+        if not response.is_successful:
+            pytest.fail(f"Failed to fetch discovery document: {response.error}")
+        cache_file.write_text(json.dumps(asdict(response)))
+        return response
 
 
 @pytest.fixture(scope="session")
-def raw_discovery(test_config):
+def raw_discovery(test_config, tmp_path_factory):
     """Raw discovery JSON for capability detection.
 
     Provides access to all RFC 8414 fields, including those not yet
-    in the typed DiscoveryDocumentResponse model. Uses retry logic
-    for rate-limited providers (consistent with discovery_document).
+    in the typed DiscoveryDocumentResponse model. Shared across xdist
+    workers via FileLock + JSON cache; see ``client_credentials_token``
+    for the rationale.
     """
-    address = test_config["TEST_DISCO_ADDRESS"]
+    root_tmp_dir = tmp_path_factory.getbasetemp().parent
+    cache_file = root_tmp_dir / "raw_discovery.json"
+    lock_file = root_tmp_dir / "raw_discovery.lock"
 
-    @retry_with_backoff()
-    def fetch_raw():
-        resp = httpx.get(address, timeout=10.0)
-        if resp.status_code == HTTP_TOO_MANY_REQUESTS:
-            raise httpx.HTTPStatusError(
-                RATE_LIMIT_ERROR_MESSAGE,
-                request=resp.request,
-                response=resp,
-            )
-        return resp
+    with FileLock(str(lock_file)):
+        if cache_file.exists():
+            return json.loads(cache_file.read_text())
 
-    try:
-        resp = fetch_raw()
-    except httpx.TransportError as exc:
-        pytest.fail(f"raw_discovery: cannot reach {address}: {exc}")
-    if resp.status_code != HTTP_OK:
-        pytest.fail(f"raw_discovery: HTTP {resp.status_code} from {address}")
-    try:
-        return resp.json()
-    except ValueError as exc:
-        pytest.fail(f"raw_discovery: invalid JSON from {address}: {exc}")
+        address = test_config["TEST_DISCO_ADDRESS"]
+
+        @retry_with_backoff()
+        def fetch_raw():
+            resp = httpx.get(address, timeout=10.0)
+            if resp.status_code == HTTP_TOO_MANY_REQUESTS:
+                raise httpx.HTTPStatusError(
+                    RATE_LIMIT_ERROR_MESSAGE,
+                    request=resp.request,
+                    response=resp,
+                )
+            return resp
+
+        try:
+            resp = fetch_raw()
+        except httpx.TransportError as exc:
+            pytest.fail(f"raw_discovery: cannot reach {address}: {exc}")
+        if resp.status_code != HTTP_OK:
+            pytest.fail(f"raw_discovery: HTTP {resp.status_code} from {address}")
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            pytest.fail(f"raw_discovery: invalid JSON from {address}: {exc}")
+        cache_file.write_text(json.dumps(data))
+        return data
 
 
 def _detect_grant_capabilities(raw_discovery: dict, grants: set) -> set[str]:
@@ -206,16 +230,28 @@ def provider_capabilities(raw_discovery):
 
 
 @pytest.fixture(scope="session")
-def jwks_response(test_config):
-    """Cached JWKS response (session-scoped).
+def jwks_response(test_config, tmp_path_factory):
+    """Cached JWKS response, shared across xdist workers.
 
-    The library's ``get_jwks`` already retries 3x on 429/5xx.
+    See ``client_credentials_token`` for the cross-worker FileLock +
+    JSON cache rationale.
     """
-    jwks_req = JwksRequest(address=test_config["TEST_JWKS_ADDRESS"])
-    response = get_jwks(jwks_req)
-    if not response.is_successful:
-        pytest.fail(f"Failed to fetch JWKS: {response.error}")
-    return response
+    root_tmp_dir = tmp_path_factory.getbasetemp().parent
+    cache_file = root_tmp_dir / "jwks_response.json"
+    lock_file = root_tmp_dir / "jwks_response.lock"
+
+    with FileLock(str(lock_file)):
+        if cache_file.exists():
+            cached = json.loads(cache_file.read_text())
+            keys = [JsonWebKey(**k) for k in cached.pop("keys") or []]
+            return JwksResponse(keys=keys, **cached)
+
+        jwks_req = JwksRequest(address=test_config["TEST_JWKS_ADDRESS"])
+        response = get_jwks(jwks_req)
+        if not response.is_successful:
+            pytest.fail(f"Failed to fetch JWKS: {response.error}")
+        cache_file.write_text(json.dumps(asdict(response)))
+        return response
 
 
 @pytest.fixture(scope="session")

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -264,16 +264,17 @@ def jwks_response(test_config, tmp_path_factory):
 def provider_caches_responses(discovery_document, jwks_response):
     """Whether the provider's Cache-Control allows the library to cache.
 
-    Per RFC 7234 §5.2.2.4-5, ``no-store`` and ``no-cache`` directives
-    instruct the client to skip caching. Some providers (e.g., Descope on
-    JWKS) set these directives, which means the library will (correctly)
-    re-fetch on every validation. Benchmarks that rely on caching should
-    skip when this fixture is False.
+    Discovery still honors strict ``no-store``/``no-cache`` semantics
+    (sensitive metadata). JWKS, per
+    :func:`py_identity_model.core.jwks_cache.is_uncacheable_for_jwks`
+    and issue #396, is always cached regardless of provider directives
+    — JWKS contains public keys, and strict honoring self-DoSes the
+    upstream at scale. ``jwks_response`` is therefore unused here but
+    retained as a fixture dep so its session-scoped cache stays
+    populated for downstream tests.
     """
-    return not (
-        is_uncacheable(discovery_document.cache_control)
-        or is_uncacheable(jwks_response.cache_control)
-    )
+    del jwks_response  # see docstring
+    return not is_uncacheable(discovery_document.cache_control)
 
 
 @pytest.fixture(scope="session")

--- a/src/tests/unit/test_cache_http_headers.py
+++ b/src/tests/unit/test_cache_http_headers.py
@@ -1,12 +1,18 @@
 """
 Tests for HTTP cache header semantics in JWKS and discovery caches.
 
-Covers three correctness fixes:
-1. Failed JWKS/discovery responses must not be cached (a transient 5xx or
-   network error would otherwise poison the cache for up to 24h).
-2. ``Cache-Control: no-store`` must not be cached at all (RFC 7234 §5.2.2.5).
-3. ``Cache-Control: no-cache`` must always re-fetch (RFC 7234 §5.2.2.4) —
-   simplest correct behavior is to skip caching.
+Discovery responses retain strict RFC 7234 semantics: ``no-store`` and
+``no-cache`` skip the cache. JWKS responses, per issue #396 and
+:func:`is_uncacheable_for_jwks`, ignore those directives because JWKS
+is public key material; strict honoring self-DoSes the upstream issuer
+at production traffic levels.
+
+Covered behaviors:
+1. Failed JWKS/discovery responses are not cached.
+2. JWKS no-store / no-cache responses ARE cached (new policy).
+3. Discovery no-store / no-cache responses are NOT cached (strict).
+4. JWKS refresh with uncacheable response writes the new entry,
+   never leaves the cache empty.
 """
 
 import time
@@ -169,10 +175,10 @@ class TestAsyncFailedResponseNotCached:
 # ============================================================================
 
 
-class TestSyncNoStoreNotCached:
+class TestSyncNoStoreCachedForJwks:
     @respx.mock
-    def test_jwks_no_store_skips_cache(self):
-        """no-store responses are returned but not cached, even with max-age."""
+    def test_jwks_no_store_still_cached(self):
+        """no-store on JWKS is ignored; response is cached. See #396."""
         key_dict = generate_rsa_keypair()[0]
         respx.get(JWKS_URL).mock(
             return_value=httpx.Response(
@@ -185,7 +191,7 @@ class TestSyncNoStoreNotCached:
         response = _get_cached_jwks(JWKS_URL)
         assert response.is_successful is True
         assert response.keys is not None
-        assert JWKS_URL not in sync_tv._jwks_cache
+        assert JWKS_URL in sync_tv._jwks_cache
 
     @respx.mock
     def test_disco_no_store_skips_cache(self):
@@ -202,10 +208,11 @@ class TestSyncNoStoreNotCached:
         assert (DISCO_URL, True) not in sync_tv._disco_cache
 
 
-class TestAsyncNoStoreNotCached:
+class TestAsyncNoStoreCachedForJwks:
     @pytest.mark.asyncio
     @respx.mock
-    async def test_jwks_no_store_skips_cache_async(self):
+    async def test_jwks_no_store_still_cached_async(self):
+        """no-store on JWKS is ignored; response is cached. See #396."""
         key_dict = generate_rsa_keypair()[0]
         respx.get(JWKS_URL).mock(
             return_value=httpx.Response(
@@ -217,7 +224,7 @@ class TestAsyncNoStoreNotCached:
 
         response = await async_get_cached_jwks(JWKS_URL)
         assert response.is_successful is True
-        assert JWKS_URL not in aio_tv._jwks_cache
+        assert JWKS_URL in aio_tv._jwks_cache
 
     @pytest.mark.asyncio
     @respx.mock
@@ -240,10 +247,10 @@ class TestAsyncNoStoreNotCached:
 # ============================================================================
 
 
-class TestSyncNoCacheRefetched:
+class TestSyncNoCacheCachedForJwks:
     @respx.mock
-    def test_jwks_no_cache_refetches_each_call(self):
-        """no-cache responses always re-fetch (we don't store them)."""
+    def test_jwks_no_cache_serves_from_cache(self):
+        """no-cache on JWKS is ignored; subsequent calls hit cache. See #396."""
         key_dict = generate_rsa_keypair()[0]
         jwks_route = respx.get(JWKS_URL).mock(
             return_value=httpx.Response(
@@ -257,8 +264,8 @@ class TestSyncNoCacheRefetched:
             response = _get_cached_jwks(JWKS_URL)
             assert response.is_successful is True
 
-        assert JWKS_URL not in sync_tv._jwks_cache
-        assert jwks_route.call_count == 3  # noqa: PLR2004
+        assert JWKS_URL in sync_tv._jwks_cache
+        assert jwks_route.call_count == 1
 
     @respx.mock
     def test_disco_no_cache_refetches_each_call(self):
@@ -278,10 +285,11 @@ class TestSyncNoCacheRefetched:
         assert disco_route.call_count == 3  # noqa: PLR2004
 
 
-class TestAsyncNoCacheRefetched:
+class TestAsyncNoCacheCachedForJwks:
     @pytest.mark.asyncio
     @respx.mock
-    async def test_jwks_no_cache_refetches_each_call_async(self):
+    async def test_jwks_no_cache_serves_from_cache_async(self):
+        """no-cache on JWKS is ignored; subsequent calls hit cache. See #396."""
         key_dict = generate_rsa_keypair()[0]
         jwks_route = respx.get(JWKS_URL).mock(
             return_value=httpx.Response(
@@ -295,8 +303,8 @@ class TestAsyncNoCacheRefetched:
             response = await async_get_cached_jwks(JWKS_URL)
             assert response.is_successful is True
 
-        assert JWKS_URL not in aio_tv._jwks_cache
-        assert jwks_route.call_count == 3  # noqa: PLR2004
+        assert JWKS_URL in aio_tv._jwks_cache
+        assert jwks_route.call_count == 1
 
     @pytest.mark.asyncio
     @respx.mock
@@ -317,14 +325,11 @@ class TestAsyncNoCacheRefetched:
 
 
 # ============================================================================
-# Refresh-time invalidation: when a refresh response is uncacheable, the
-# existing (potentially stale) cache entry must be POPPED, not left in place.
-#
-# Otherwise a key-rotation event against a provider that sends
-# ``no-store``/``no-cache`` (Descope, others) leaves the stale entry live
-# for the remainder of its 24h TTL. Every subsequent validation hits the
-# stale entry, triggers another _refresh_jwks, and pounds the upstream JWKS
-# endpoint — the exact DoS the cache exists to prevent.
+# Refresh under uncacheable response: with the JWKS-specific cache policy
+# (#396), the cache is REPLACED with the new keys rather than popped. This
+# eliminates the kid-miss → refresh → re-fetch loop the old pop-on-uncacheable
+# behavior introduced, without leaving stale keys live (the response keys
+# are fresh by definition).
 # ============================================================================
 
 
@@ -345,10 +350,10 @@ REFRESH_UNCACHEABLE_TEST_CASES = [
 ]
 
 
-class TestSyncRefreshInvalidatesStaleOnUncacheable:
+class TestSyncRefreshReplacesStaleOnUncacheable:
     @pytest.mark.parametrize("uncacheable_header", REFRESH_UNCACHEABLE_TEST_CASES)
     @respx.mock
-    def test_refresh_pops_stale_entry_when_response_uncacheable(
+    def test_refresh_writes_new_entry_when_response_uncacheable(
         self, uncacheable_header: str
     ):
         old_key = _key_with_kid("old-kid")
@@ -380,8 +385,11 @@ class TestSyncRefreshInvalidatesStaleOnUncacheable:
         assert refreshed.is_successful is True
         # Fresh response is returned to the caller …
         assert _kids(refreshed) == {"new-kid"}
-        # … but the stale entry MUST be popped, not left behind.
-        assert JWKS_URL not in sync_tv._jwks_cache
+        # … and the cache is updated with the new key (not popped).
+        # See #396: pop-on-uncacheable caused the kid-miss-refresh-loop
+        # this branch was meant to prevent.
+        assert JWKS_URL in sync_tv._jwks_cache
+        assert _kids(sync_tv._jwks_cache[JWKS_URL].response) == {"new-kid"}
         # Real refresh (not an empty-fallback) — see #403 contract.
         assert from_retained_cache is False
 
@@ -440,11 +448,11 @@ class TestSyncRefreshInvalidatesStaleOnUncacheable:
         assert cache_key not in sync_tv._disco_cache
 
 
-class TestAsyncRefreshInvalidatesStaleOnUncacheable:
+class TestAsyncRefreshReplacesStaleOnUncacheable:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("uncacheable_header", REFRESH_UNCACHEABLE_TEST_CASES)
     @respx.mock
-    async def test_refresh_pops_stale_entry_when_response_uncacheable_async(
+    async def test_refresh_writes_new_entry_when_response_uncacheable_async(
         self, uncacheable_header: str
     ):
         old_key = _key_with_kid("old-kid")
@@ -475,7 +483,9 @@ class TestAsyncRefreshInvalidatesStaleOnUncacheable:
         refreshed, from_retained_cache = await aio_tv._refresh_jwks(JWKS_URL)
         assert refreshed.is_successful is True
         assert _kids(refreshed) == {"new-kid"}
-        assert JWKS_URL not in aio_tv._jwks_cache
+        # Cache updated with new key, not popped (see #396).
+        assert JWKS_URL in aio_tv._jwks_cache
+        assert _kids(aio_tv._jwks_cache[JWKS_URL].response) == {"new-kid"}
         # Real refresh (not an empty-fallback) — see #403 contract.
         assert from_retained_cache is False
 

--- a/src/tests/unit/test_jwks_cache.py
+++ b/src/tests/unit/test_jwks_cache.py
@@ -11,6 +11,7 @@ from py_identity_model.core.jwks_cache import (
     JwksCacheEntry,
     is_cache_expired,
     is_uncacheable,
+    is_uncacheable_for_jwks,
     parse_max_age,
     resolve_ttl,
 )
@@ -125,6 +126,40 @@ class TestIsUncacheable:
 
     def test_empty_string(self):
         assert is_uncacheable("") is False
+
+
+class TestIsUncacheableForJwks:
+    """JWKS-specific policy: ignore no-cache/no-store on public keys.
+
+    See ``is_uncacheable_for_jwks`` docstring and issue #396 for
+    rationale. JWKS responses are public material and the strict
+    interpretation causes self-DoS at meaningful traffic levels.
+    """
+
+    def test_no_store_is_still_cacheable(self):
+        assert is_uncacheable_for_jwks("no-store") is False
+
+    def test_no_cache_is_still_cacheable(self):
+        assert is_uncacheable_for_jwks("no-cache") is False
+
+    def test_ory_combined_directives_still_cacheable(self):
+        """Real-world: Ory sends 'private, no-cache, no-store, must-revalidate'."""
+        assert (
+            is_uncacheable_for_jwks("private, no-cache, no-store, must-revalidate")
+            is False
+        )
+
+    def test_descope_combined_directives_still_cacheable(self):
+        assert is_uncacheable_for_jwks("no-store, no-cache") is False
+
+    def test_max_age_still_cacheable(self):
+        assert is_uncacheable_for_jwks("max-age=3600") is False
+
+    def test_none_header_still_cacheable(self):
+        assert is_uncacheable_for_jwks(None) is False
+
+    def test_empty_string_still_cacheable(self):
+        assert is_uncacheable_for_jwks("") is False
 
 
 class TestMultiProviderCacheIsolation:

--- a/src/tests/unit/test_kid_miss_cooldown.py
+++ b/src/tests/unit/test_kid_miss_cooldown.py
@@ -528,9 +528,11 @@ class TestCooldownEvictedWithCache:
         # Surviving entries preserved on both sides.
         assert set(cache.keys()) == {urls[1], urls[2], overflow_url}
 
-    def test_uncacheable_response_clears_cooldown_alongside_cache(self):
-        """``Cache-Control: no-cache`` pops the cache entry; the matching
-        cooldown stamp must also clear so a future fetch isn't suppressed."""
+    def test_uncacheable_response_replaces_entry_and_preserves_cooldown(self):
+        """``Cache-Control: no-cache`` on JWKS is ignored (see #396); the
+        rotated keys replace the cached entry and the cooldown stamp is
+        preserved (kid-miss suppression continues to apply to the URI).
+        """
         url = "https://op.example/jwks"
         cache: dict[str, JwksCacheEntry] = {}
         cooldown: dict[str, float] = {}
@@ -557,7 +559,8 @@ class TestCooldownEvictedWithCache:
         assert url in cache
         assert url in cooldown
 
-        # Now an uncacheable response with non-empty keys: pop both.
+        # Now an uncacheable response with non-empty keys: replace cache
+        # entry with rotated key, retain cooldown.
         new_kd, _ = generate_rsa_keypair()
         new_kd["kid"] = "rotated"
         new_jwk = JsonWebKey(
@@ -575,8 +578,9 @@ class TestCooldownEvictedWithCache:
             time.monotonic(),
             cooldown=cooldown,
         )
-        assert url not in cache
-        assert url not in cooldown
+        assert url in cache
+        assert {k.kid for k in (cache[url].response.keys or [])} == {"rotated"}
+        assert url in cooldown
 
 
 # Async cooldown state covered for symmetry — most of the integration


### PR DESCRIPTION
Multi-issue PR that closes out remaining blockers for OIDF certification submission. Started as a one-file workflow tweak; expanded to address a production library bug (#396) and the surrounding CI rate-limit pathology that surfaced from it.

## Issues addressed

- **Closes #396** — security: jwks-cache C-4 (``no-cache`` providers fetch JWKS on every request). Production-grade fix, not a CI band-aid.
- **Part of #242** — OpenID Connect RP Certification tracking (Phase 5 — submission readiness).
- **Unblocks #331** — fee waiver application (waiver email requires committed cert-grade hosted-suite results, which the new hosted workflow + Form Post profile now produces).

## Commits, in landing order

| Commit | Change |
|---|---|
| ``aa4ae7d`` | ``ci(conformance-hosted): add Form Post Basic RP profile`` — hosted workflow + Makefile parity with local CI |
| ``3649efb`` | ``ci(conformance): swap to official OIDF Docker image`` — drop third-party ``authelia/`` image for ``registry.gitlab.com/openid/conformance-suite`` |
| ``f7d2de3`` | ``test(integration): cache discovery/JWKS/raw-discovery across xdist workers`` — extend the proven ``client_credentials_token`` FileLock + JSON-cache pattern to other fixtures |
| ``9214199`` | ``fix(tests): use vars() not asdict() for guarded BaseResponse caching`` — ``BaseResponse.__getattribute__`` guards trip ``asdict()``; docstring instructs using ``vars()`` |
| ``b20a6ed`` | ``fix(jwks-cache): ignore Cache-Control no-cache/no-store on JWKS (#396)`` — split policy via ``is_uncacheable_for_jwks()`` |
| ``644efd2`` | ``test(integration): prime library JWKS + discovery caches at session start`` — inject fixture responses into ``sync/aio.token_validation._jwks_cache`` and ``_disco_cache`` so ``validate_token()`` never re-fetches |
| ``573af43`` | ``ci: dedupe Ory integration runs across workflow callers`` — both ``build.yml`` and ``publish-prerelease.yml`` invoked the reusable ``ci.yml``, running ``integration-tests-ory`` twice per push; plus concurrency-cancel on rapid pushes |

## Why this grew beyond the original scope

The first two commits were the planned cert-submission work. CI then surfaced cascading 429s against Ory on every PR push. Drilling in revealed four distinct amplifiers:

1. **Per-process library cache cold-starts** — every xdist worker independently cold-fetched discovery + JWKS at session start. **Fix:** cross-worker FileLock + JSON cache (``f7d2de3``) and per-process cache priming from the already-fetched fixture (``644efd2``).
2. **Library strictly honoring ``no-cache``/``no-store`` on JWKS** — at 100 RPS in production this self-DoSes the upstream. This is the actual production bug tracked by **#396**. **Fix:** JWKS-specific cache policy (``b20a6ed``).
3. **``asdict()`` on ``BaseResponse`` trips the guarded-field ``__getattribute__``** — silent failure mode in the cross-worker cache code I introduced. **Fix:** ``vars()`` per the model docstring (``9214199``).
4. **Two workflows invoking ``ci.yml`` simultaneously on every PR push** — visible as one Ory job passing and another failing on the exact same commit. **Fix:** gate ``integration-tests-ory`` on opt-in input + concurrency cancel-in-progress (``573af43``).

## Verification

- **Locally**: ``make test-integration-node-oidc`` with ``-n auto`` (20 workers): **111 passed, 4 skipped, 0 failed in ~42s** (4 skips are legitimate capability/config gates against the node-oidc fixture: JAR not supported, ``TEST_EXPIRED_TOKEN`` not in ``.env.node-oidc``).
- **Local conformance** against the new OIDF official image (``make conformance-up`` + ``run_tests.py --plan basic-rp``): **13 passed, 1 skipped, 0 failed** — identical to the pre-swap Authelia baseline.
- **CI**: green end-to-end on the final push.

## CLAUDE.md addition

New mandatory workflow rule #4: changes to ``src/tests/integration/conftest.py`` or any test fixture must be validated against an integration suite locally before pushing. ``pytest --collect-only`` and ``make lint`` are explicitly insufficient — they don't exercise fixture network code paths or xdist cross-worker behavior. The lesson came from this PR (the ``asdict()`` bug landed because I shipped a conftest change after only ``--collect-only``).

## Next steps after merge

1. Trigger ``Conformance (Hosted)`` via ``gh workflow run conformance-hosted.yml --ref main`` (or run ``make conformance-test HOSTED=1 CONFORMANCE_SERVER=https://www.certification.openid.net/`` locally with ``CONFORMANCE_TOKEN`` exported).
2. Commit the three resulting ``conformance/results/hosted/{basic-rp,config-rp,form-post-basic-rp}-latest.json`` files.
3. Send the #331 waiver email referencing the committed artifacts.
4. Submit on certification.openid.net once the waiver code lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)