### PR TITLE
perf(tests): zero retry backoff in tests, parallelize pre-commit pytest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         require_serial: true
       - id: pytest-coverage
         name: pytest coverage check (80% minimum)
-        entry: uv run pytest src/tests -m unit -q --cov=src/py_identity_model --cov-report=term-missing:skip-covered --cov-fail-under=80
+        entry: uv run pytest src/tests -m unit -q -n auto --cov=src/py_identity_model --cov-report=term-missing:skip-covered --cov-fail-under=80 --ignore=src/tests/benchmarks -p no:benchmark
         language: system
         types: [python]
         pass_filenames: false

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,4 +1,14 @@
+import os
+
 import pytest
+
+
+# Disable retry backoff for the whole test session. The production retry
+# decorator sleeps base_delay * 2**attempt seconds between attempts; with
+# defaults (3 attempts, 1.0s base) every test that exercises an httpx
+# RequestError path serially waits ~7s (1+2+4) before raising. Tests that
+# specifically cover retry timing override these via monkeypatch.setenv.
+os.environ.setdefault("HTTP_RETRY_BASE_DELAY", "0")
 
 from py_identity_model.aio.http_client import (
     _reset_async_http_client,


### PR DESCRIPTION
## Summary

The unit suite spent its wall-clock in two avoidable places:

1. Every test that mocks an `httpx.ConnectError` (or similar `RequestError`) ran through the production `retry_with_backoff` decorator with default `HTTP_RETRY_BASE_DELAY=1.0` and 3 attempts, sleeping 1+2+4=**7s** before the final raise. ~24 such tests bottlenecked the parallel run; the unit suite ran in 20.5s instead of ~6s.
2. The pre-commit `pytest-coverage` hook invoked pytest without `-n auto` and without skipping the benchmark plugin, so the whole serial run took ~3m21s (24 × 7s alone). Pre-commit total: **3m22s**.

## Fixes

- `src/tests/conftest.py` sets `HTTP_RETRY_BASE_DELAY=0` at import time via `os.environ.setdefault`. The retry decorator's `calculate_delay(0, attempt)` returns 0, so retries still happen but take ~0s. Tests that explicitly override via `monkeypatch.setenv` (`test_http_client_retry.py`, `test_http_security_hardening.py`) still win because monkeypatch takes priority and reverts cleanly.
- `.pre-commit-config.yaml` `pytest-coverage` hook now matches `make test-unit`: adds `-n auto`, `--ignore=src/tests/benchmarks`, and `-p no:benchmark`.

## Results

|                         | Before  | After    |
| ----------------------- | ------- | -------- |
| Unit tests (`-n auto`)  | 20.5s   | **6.6s** |
| Slowest single test     | 14.03s  | 2.55s    |
| Full pre-commit (`make lint`) | 3m22s | **12s**  |

All 1152 unit tests still pass. Coverage gate (80%) still enforced.

## Test plan

- [x] `make test-unit` — 1152 passed in 6.6s
- [x] `make lint` (full pre-commit) — passes in 12s
- [x] Retry-specific tests (`test_http_client_retry.py`, `test_http_security_hardening.py`) still pass — they override the env var via monkeypatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)