### PR TITLE
feat(conformance): submission artifacts for hosted runs (plan export + RP client-side logs)

### DIFF
--- a/.github/workflows/conformance-hosted.yml
+++ b/.github/workflows/conformance-hosted.yml
@@ -61,7 +61,7 @@ jobs:
           python conformance/run_tests.py \
             --plan basic-rp \
             --output conformance/results/hosted/basic-rp-latest.json \
-            --cert-package conformance/results/hosted/basic-rp-cert-package.zip \
+            --export-zip conformance/results/hosted/basic-rp-export.zip \
             --publish "${{ inputs.publish }}" \
             --verbose
 
@@ -73,7 +73,7 @@ jobs:
           python conformance/run_tests.py \
             --plan config-rp \
             --output conformance/results/hosted/config-rp-latest.json \
-            --cert-package conformance/results/hosted/config-rp-cert-package.zip \
+            --export-zip conformance/results/hosted/config-rp-export.zip \
             --publish "${{ inputs.publish }}" \
             --verbose
 
@@ -85,7 +85,7 @@ jobs:
           python conformance/run_tests.py \
             --plan form-post-basic-rp \
             --output conformance/results/hosted/form-post-basic-rp-latest.json \
-            --cert-package conformance/results/hosted/form-post-basic-rp-cert-package.zip \
+            --export-zip conformance/results/hosted/form-post-basic-rp-export.zip \
             --publish "${{ inputs.publish }}" \
             --verbose
 
@@ -96,5 +96,5 @@ jobs:
           name: conformance-hosted-results
           path: |
             conformance/results/hosted/*-latest.json
-            conformance/results/hosted/*-cert-package.zip
+            conformance/results/hosted/*-export.zip
           retention-days: 30

--- a/.github/workflows/conformance-hosted.yml
+++ b/.github/workflows/conformance-hosted.yml
@@ -5,6 +5,15 @@ permissions:
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish results on the public certification.openid.net list"
+        type: choice
+        default: none
+        options:
+          - none
+          - summary
+          - everything
 
 jobs:
   conformance-hosted:
@@ -52,6 +61,8 @@ jobs:
           python conformance/run_tests.py \
             --plan basic-rp \
             --output conformance/results/hosted/basic-rp-latest.json \
+            --cert-package conformance/results/hosted/basic-rp-cert-package.zip \
+            --publish "${{ inputs.publish }}" \
             --verbose
 
       - name: Run Config RP conformance tests
@@ -62,6 +73,8 @@ jobs:
           python conformance/run_tests.py \
             --plan config-rp \
             --output conformance/results/hosted/config-rp-latest.json \
+            --cert-package conformance/results/hosted/config-rp-cert-package.zip \
+            --publish "${{ inputs.publish }}" \
             --verbose
 
       - name: Run Form Post Basic RP conformance tests
@@ -72,6 +85,8 @@ jobs:
           python conformance/run_tests.py \
             --plan form-post-basic-rp \
             --output conformance/results/hosted/form-post-basic-rp-latest.json \
+            --cert-package conformance/results/hosted/form-post-basic-rp-cert-package.zip \
+            --publish "${{ inputs.publish }}" \
             --verbose
 
       - name: Upload conformance results
@@ -81,4 +96,5 @@ jobs:
           name: conformance-hosted-results
           path: |
             conformance/results/hosted/*-latest.json
+            conformance/results/hosted/*-cert-package.zip
           retention-days: 30

--- a/.github/workflows/conformance-hosted.yml
+++ b/.github/workflows/conformance-hosted.yml
@@ -62,6 +62,7 @@ jobs:
             --plan basic-rp \
             --output conformance/results/hosted/basic-rp-latest.json \
             --export-zip conformance/results/hosted/basic-rp-export.zip \
+            --rp-logs-zip conformance/results/hosted/basic-rp-rp-logs.zip \
             --publish "${{ inputs.publish }}" \
             --verbose
 
@@ -74,6 +75,7 @@ jobs:
             --plan config-rp \
             --output conformance/results/hosted/config-rp-latest.json \
             --export-zip conformance/results/hosted/config-rp-export.zip \
+            --rp-logs-zip conformance/results/hosted/config-rp-rp-logs.zip \
             --publish "${{ inputs.publish }}" \
             --verbose
 
@@ -86,6 +88,7 @@ jobs:
             --plan form-post-basic-rp \
             --output conformance/results/hosted/form-post-basic-rp-latest.json \
             --export-zip conformance/results/hosted/form-post-basic-rp-export.zip \
+            --rp-logs-zip conformance/results/hosted/form-post-basic-rp-rp-logs.zip \
             --publish "${{ inputs.publish }}" \
             --verbose
 
@@ -97,4 +100,5 @@ jobs:
           path: |
             conformance/results/hosted/*-latest.json
             conformance/results/hosted/*-export.zip
+            conformance/results/hosted/*-rp-logs.zip
           retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -148,9 +148,10 @@ dmypy.json
 .claude/review-*.patch
 .claude/pre-review-sha.txt
 
-# Conformance plan export zips (binary evidence artifacts; preserved via CI
-# upload-artifact, not committed)
+# Conformance plan export zips + per-test RP logs (binary evidence artifacts;
+# preserved via CI upload-artifact, not committed)
 conformance/results/hosted/*.zip
+conformance/results/hosted/rp-logs/
 
 # Ralph orchestrator runtime state
 .ralph/

--- a/.gitignore
+++ b/.gitignore
@@ -148,6 +148,10 @@ dmypy.json
 .claude/review-*.patch
 .claude/pre-review-sha.txt
 
+# Conformance certification packages (binary OIDF submission artifacts;
+# preserved via CI upload-artifact, not committed)
+conformance/results/hosted/*.zip
+
 # Ralph orchestrator runtime state
 .ralph/
 PROMPT.md

--- a/.gitignore
+++ b/.gitignore
@@ -148,8 +148,8 @@ dmypy.json
 .claude/review-*.patch
 .claude/pre-review-sha.txt
 
-# Conformance certification packages (binary OIDF submission artifacts;
-# preserved via CI upload-artifact, not committed)
+# Conformance plan export zips (binary evidence artifacts; preserved via CI
+# upload-artifact, not committed)
 conformance/results/hosted/*.zip
 
 # Ralph orchestrator runtime state

--- a/Makefile
+++ b/Makefile
@@ -147,9 +147,9 @@ conformance-down: ## Tear down conformance suite
 .PHONY: conformance-test
 conformance-test: $(if $(HOSTED),,conformance-up) ## Run conformance tests (HOSTED=1 for hosted suite)
 ifdef HOSTED
-	uv run python conformance/run_tests.py --plan basic-rp --suite-url "$(CONFORMANCE_SERVER)" --output conformance/results/hosted/basic-rp-latest.json --cert-package conformance/results/hosted/basic-rp-cert-package.zip --publish "$(or $(PUBLISH),none)" --verbose
-	uv run python conformance/run_tests.py --plan config-rp --suite-url "$(CONFORMANCE_SERVER)" --output conformance/results/hosted/config-rp-latest.json --cert-package conformance/results/hosted/config-rp-cert-package.zip --publish "$(or $(PUBLISH),none)" --verbose
-	uv run python conformance/run_tests.py --plan form-post-basic-rp --suite-url "$(CONFORMANCE_SERVER)" --output conformance/results/hosted/form-post-basic-rp-latest.json --cert-package conformance/results/hosted/form-post-basic-rp-cert-package.zip --publish "$(or $(PUBLISH),none)" --verbose
+	uv run python conformance/run_tests.py --plan basic-rp --suite-url "$(CONFORMANCE_SERVER)" --output conformance/results/hosted/basic-rp-latest.json --export-zip conformance/results/hosted/basic-rp-export.zip --publish "$(or $(PUBLISH),none)" --verbose
+	uv run python conformance/run_tests.py --plan config-rp --suite-url "$(CONFORMANCE_SERVER)" --output conformance/results/hosted/config-rp-latest.json --export-zip conformance/results/hosted/config-rp-export.zip --publish "$(or $(PUBLISH),none)" --verbose
+	uv run python conformance/run_tests.py --plan form-post-basic-rp --suite-url "$(CONFORMANCE_SERVER)" --output conformance/results/hosted/form-post-basic-rp-latest.json --export-zip conformance/results/hosted/form-post-basic-rp-export.zip --publish "$(or $(PUBLISH),none)" --verbose
 	@echo "Hosted conformance tests complete. Results in conformance/results/hosted/"
 else
 	uv run python conformance/run_tests.py --plan basic-rp --output conformance/results/basic-rp-latest.json --verbose

--- a/Makefile
+++ b/Makefile
@@ -147,9 +147,9 @@ conformance-down: ## Tear down conformance suite
 .PHONY: conformance-test
 conformance-test: $(if $(HOSTED),,conformance-up) ## Run conformance tests (HOSTED=1 for hosted suite)
 ifdef HOSTED
-	uv run python conformance/run_tests.py --plan basic-rp --suite-url "$(CONFORMANCE_SERVER)" --output conformance/results/hosted/basic-rp-latest.json --export-zip conformance/results/hosted/basic-rp-export.zip --publish "$(or $(PUBLISH),none)" --verbose
-	uv run python conformance/run_tests.py --plan config-rp --suite-url "$(CONFORMANCE_SERVER)" --output conformance/results/hosted/config-rp-latest.json --export-zip conformance/results/hosted/config-rp-export.zip --publish "$(or $(PUBLISH),none)" --verbose
-	uv run python conformance/run_tests.py --plan form-post-basic-rp --suite-url "$(CONFORMANCE_SERVER)" --output conformance/results/hosted/form-post-basic-rp-latest.json --export-zip conformance/results/hosted/form-post-basic-rp-export.zip --publish "$(or $(PUBLISH),none)" --verbose
+	uv run python conformance/run_tests.py --plan basic-rp --suite-url "$(CONFORMANCE_SERVER)" --output conformance/results/hosted/basic-rp-latest.json --export-zip conformance/results/hosted/basic-rp-export.zip --rp-logs-zip conformance/results/hosted/basic-rp-rp-logs.zip --publish "$(or $(PUBLISH),none)" --verbose
+	uv run python conformance/run_tests.py --plan config-rp --suite-url "$(CONFORMANCE_SERVER)" --output conformance/results/hosted/config-rp-latest.json --export-zip conformance/results/hosted/config-rp-export.zip --rp-logs-zip conformance/results/hosted/config-rp-rp-logs.zip --publish "$(or $(PUBLISH),none)" --verbose
+	uv run python conformance/run_tests.py --plan form-post-basic-rp --suite-url "$(CONFORMANCE_SERVER)" --output conformance/results/hosted/form-post-basic-rp-latest.json --export-zip conformance/results/hosted/form-post-basic-rp-export.zip --rp-logs-zip conformance/results/hosted/form-post-basic-rp-rp-logs.zip --publish "$(or $(PUBLISH),none)" --verbose
 	@echo "Hosted conformance tests complete. Results in conformance/results/hosted/"
 else
 	uv run python conformance/run_tests.py --plan basic-rp --output conformance/results/basic-rp-latest.json --verbose

--- a/Makefile
+++ b/Makefile
@@ -147,9 +147,9 @@ conformance-down: ## Tear down conformance suite
 .PHONY: conformance-test
 conformance-test: $(if $(HOSTED),,conformance-up) ## Run conformance tests (HOSTED=1 for hosted suite)
 ifdef HOSTED
-	uv run python conformance/run_tests.py --plan basic-rp --suite-url "$(CONFORMANCE_SERVER)" --output conformance/results/hosted/basic-rp-latest.json --verbose
-	uv run python conformance/run_tests.py --plan config-rp --suite-url "$(CONFORMANCE_SERVER)" --output conformance/results/hosted/config-rp-latest.json --verbose
-	uv run python conformance/run_tests.py --plan form-post-basic-rp --suite-url "$(CONFORMANCE_SERVER)" --output conformance/results/hosted/form-post-basic-rp-latest.json --verbose
+	uv run python conformance/run_tests.py --plan basic-rp --suite-url "$(CONFORMANCE_SERVER)" --output conformance/results/hosted/basic-rp-latest.json --cert-package conformance/results/hosted/basic-rp-cert-package.zip --publish "$(or $(PUBLISH),none)" --verbose
+	uv run python conformance/run_tests.py --plan config-rp --suite-url "$(CONFORMANCE_SERVER)" --output conformance/results/hosted/config-rp-latest.json --cert-package conformance/results/hosted/config-rp-cert-package.zip --publish "$(or $(PUBLISH),none)" --verbose
+	uv run python conformance/run_tests.py --plan form-post-basic-rp --suite-url "$(CONFORMANCE_SERVER)" --output conformance/results/hosted/form-post-basic-rp-latest.json --cert-package conformance/results/hosted/form-post-basic-rp-cert-package.zip --publish "$(or $(PUBLISH),none)" --verbose
 	@echo "Hosted conformance tests complete. Results in conformance/results/hosted/"
 else
 	uv run python conformance/run_tests.py --plan basic-rp --output conformance/results/basic-rp-latest.json --verbose
@@ -160,7 +160,7 @@ endif
 
 .PHONY: conformance-test-harness
 conformance-test-harness: ## Run conformance harness unit tests (parser + callback)
-	uv run --with fastapi --with httpx --with python-multipart pytest conformance/tests/ -v
+	uv run --with fastapi --with httpx --with python-multipart --with respx pytest conformance/tests/ -v
 
 .PHONY: conformance-token
 conformance-token: ## Manage OIDF API token (ACTION=create|show|env)

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -203,21 +203,21 @@ runner agree regardless of working directory); override it for *both* processes
 if you change it. The logs are captured regardless of pass/fail — the logs for a
 failed test are exactly what you'd want to inspect.
 
-### Certification package (manual — the actual OIDF submission)
+### Submission (manual — the actual OIDF certification)
 
-The **certification package** is a different thing and is **not automated here**.
-Per the suite's own `scripts/conformance.py`, it is created via
-`POST /api/plan/{plan_id}/certificationpackage` as `multipart/form-data` with:
+Submission is **not automated here**. The current OIDF flow is portal-based:
+fill the web form at <https://submissions.openid.net/>, upload the test result
+zips (`*-export.zip`) + client data (`*-rp-logs.zip`) per profile, and OIDF
+generates the Certification of Conformance and emails a **DocuSign** signature
+request — there is no PDF template to fill manually.
 
-- `certificationOfConformancePdf` — the **signed Certification of Conformance**
-  PDF (you fill and sign this), and
-- `clientSideData` — **required for RP tests**: the RP (harness) client-side
-  logs as a zip.
+(The suite's `scripts/conformance.py` also exposes a programmatic
+`POST /api/plan/{plan_id}/certificationpackage` taking a *pre-signed* PDF +
+`clientSideData`, which **publishes and permanently freezes** the plan. The
+portal is the standard route.)
 
-Calling it **publishes the plan and marks it permanently immutable**. Because it
-needs the signed PDF + RP logs and is irreversible, it is the owner-driven
-submission step tracked in **#331**, not something CI or this runner fires
-automatically.
+This is the owner-driven step tracked in **#331**. See the full write-up in
+[`docs/certification.md`](../docs/certification.md).
 
 `--publish {none,summary,everything}` (default `none`) is independent: it only
 controls whether a *run* is listed on the public published-tests list. The

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -155,26 +155,46 @@ uv run conformance/scripts/rotate_conformance_token.py --dry-run
 
 See the script's module docstring for full design notes and flag reference.
 
-## Producing a certification package
+## Plan exports vs. the certification package
 
-A passing run prints a pass/fail summary, but OIDF certification submission
-requires the **certification package** — a zip of every test log downloaded from
-`GET /api/plan/{plan_id}/certificationpackage` on the hosted suite. Pass
-`--cert-package PATH` to fetch it after the run:
+Two distinct artifacts — don't confuse them:
+
+### Plan export (automated, safe)
+
+A passing run prints a pass/fail summary; `--export-zip PATH` additionally
+downloads the suite's **signed plan export** (`GET /api/plan/export/{plan_id}` —
+JSON + RSA signature, the format the suite recommends for CI). It's a read-only
+evidence/regression artifact: no publish, no freeze.
 
 ```bash
-# Hosted run that also downloads the submission package
+# Hosted run that also downloads the signed plan export per profile
 make conformance-test HOSTED=1 CONFORMANCE_SERVER=https://www.certification.openid.net/
-# -> conformance/results/hosted/<plan>-cert-package.zip
+# -> conformance/results/hosted/<plan>-export.zip
 ```
 
-The package is only downloaded for a **hosted** suite when **every test passes**;
-`--cert-package` is ignored (with a warning) for the local Docker suite, which
-does not produce a valid OIDF package. The zips are git-ignored binary artifacts
-— in CI they are retained via the `conformance-hosted` workflow's uploaded
-artifacts (`gh run download -n conformance-hosted-results`).
+`--export-kind` selects `export` (default, JSON+signature) or `exporthtml`
+(human-readable). Exports are only downloaded for a **hosted** suite when
+**every test passes**; `--export-zip` is ignored (with a warning) for the local
+Docker suite. The zips are git-ignored binaries — in CI they're retained via the
+`conformance-hosted` workflow's uploaded artifacts
+(`gh run download -n conformance-hosted-results`).
 
-`--publish {none,summary,everything}` (default `none`) controls whether the run
-is listed publicly on certification.openid.net; the package is generated either
-way. Publishing is typically done at actual submission time (see #331). The
+### Certification package (manual — the actual OIDF submission)
+
+The **certification package** is a different thing and is **not automated here**.
+Per the suite's own `scripts/conformance.py`, it is created via
+`POST /api/plan/{plan_id}/certificationpackage` as `multipart/form-data` with:
+
+- `certificationOfConformancePdf` — the **signed Certification of Conformance**
+  PDF (you fill and sign this), and
+- `clientSideData` — **required for RP tests**: the RP (harness) client-side
+  logs as a zip.
+
+Calling it **publishes the plan and marks it permanently immutable**. Because it
+needs the signed PDF + RP logs and is irreversible, it is the owner-driven
+submission step tracked in **#331**, not something CI or this runner fires
+automatically.
+
+`--publish {none,summary,everything}` (default `none`) is independent: it only
+controls whether a *run* is listed on the public published-tests list. The
 hosted CI workflow exposes the same choice as a `workflow_dispatch` input.

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -154,3 +154,27 @@ uv run conformance/scripts/rotate_conformance_token.py --dry-run
 - HCP Vault Secrets app configured (default name: `py-identity-model`)
 
 See the script's module docstring for full design notes and flag reference.
+
+## Producing a certification package
+
+A passing run prints a pass/fail summary, but OIDF certification submission
+requires the **certification package** — a zip of every test log downloaded from
+`GET /api/plan/{plan_id}/certificationpackage` on the hosted suite. Pass
+`--cert-package PATH` to fetch it after the run:
+
+```bash
+# Hosted run that also downloads the submission package
+make conformance-test HOSTED=1 CONFORMANCE_SERVER=https://www.certification.openid.net/
+# -> conformance/results/hosted/<plan>-cert-package.zip
+```
+
+The package is only downloaded for a **hosted** suite when **every test passes**;
+`--cert-package` is ignored (with a warning) for the local Docker suite, which
+does not produce a valid OIDF package. The zips are git-ignored binary artifacts
+— in CI they are retained via the `conformance-hosted` workflow's uploaded
+artifacts (`gh run download -n conformance-hosted-results`).
+
+`--publish {none,summary,everything}` (default `none`) controls whether the run
+is listed publicly on certification.openid.net; the package is generated either
+way. Publishing is typically done at actual submission time (see #331). The
+hosted CI workflow exposes the same choice as a `workflow_dispatch` input.

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -179,6 +179,30 @@ Docker suite. The zips are git-ignored binaries — in CI they're retained via t
 `conformance-hosted` workflow's uploaded artifacts
 (`gh run download -n conformance-hosted-results`).
 
+### RP client-side logs (`clientSideData`)
+
+OIDF RP certification additionally requires **one log file per test, named by the
+test id**, showing the RP's behaviour — in particular that negative tests are
+*rejected* ([connect_rp_submission](https://openid.net/certification/connect_rp_submission/)).
+The conformance suite only logs the OP side, so the RP harness produces these:
+
+- The harness (`app.py`) routes its own + `py_identity_model` log records to
+  `<RP_LOG_DIR>/<profile>/<test_name>.log` for whichever test the runner has
+  active, logging explicit `ACCEPTED` / `REJECTED: <reason>` decision lines.
+- `run_tests.py --rp-logs-zip PATH` resets that per-profile directory before the
+  run and zips it after — one zip per profile, the `clientSideData` you submit.
+
+```bash
+make conformance-test HOSTED=1 CONFORMANCE_SERVER=https://www.certification.openid.net/
+# -> conformance/results/hosted/<plan>-rp-logs.zip  (one <test_name>.log per test)
+```
+
+`RP_LOG_DIR` defaults to `conformance/results/hosted/rp-logs` (an absolute path
+derived from the source location, so the harness and the separately-launched
+runner agree regardless of working directory); override it for *both* processes
+if you change it. The logs are captured regardless of pass/fail — the logs for a
+failed test are exactly what you'd want to inspect.
+
 ### Certification package (manual — the actual OIDF submission)
 
 The **certification package** is a different thing and is **not automated here**.

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -181,9 +181,9 @@ Docker suite. The zips are git-ignored binaries — in CI they're retained via t
 
 ### RP client-side logs (`clientSideData`)
 
-OIDF RP certification additionally requires **one log file per test, named by the
-test id**, showing the RP's behaviour — in particular that negative tests are
-*rejected* ([connect_rp_submission](https://openid.net/certification/connect_rp_submission/)).
+OIDF RP certification additionally requires **one log file per test** (named by the
+suite test module name), showing the RP's behaviour — in particular that negative
+tests are *rejected* ([connect_rp_submission](https://openid.net/certification/connect_rp_submission/)).
 The conformance suite only logs the OP side, so the RP harness produces these:
 
 - The harness (`app.py`) routes its own + `py_identity_model` log records to

--- a/conformance/app.py
+++ b/conformance/app.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass, field
 import html
 import logging
 import os
+from pathlib import Path
+import re
 import secrets
 from urllib.parse import urlencode
 
@@ -51,6 +53,79 @@ logger = logging.getLogger("conformance-rp")
 app = FastAPI(title="py-identity-model Conformance RP")
 
 # ---------------------------------------------------------------------------
+# Per-test RP log capture (clientSideData for OIDF RP certification)
+# ---------------------------------------------------------------------------
+#
+# OIDF RP certification requires one log file per test, named by the test id,
+# demonstrating the RP's behaviour — in particular that negative tests are
+# rejected (https://openid.net/certification/connect_rp_submission/). The
+# conformance suite only logs the OP side, so the RP must produce these itself.
+#
+# The runner drives tests strictly sequentially and tells the harness which
+# test is active via /authorize, /discover and /callback, so a process-global
+# pointer plus a logging handler that routes records to the active test's file
+# is sufficient. RP_LOG_DIR defaults to an absolute path derived from this
+# file's location so the harness and the (separately-launched) runner agree on
+# it regardless of working directory.
+
+_active_test: tuple[str, str] | None = None
+
+
+def _rp_log_base() -> Path:
+    """Base directory for per-test RP logs (env-overridable)."""
+    return Path(
+        os.environ.get("RP_LOG_DIR")
+        or (Path(__file__).parent / "results" / "hosted" / "rp-logs")
+    )
+
+
+def _rp_log_path(profile: str, test_name: str) -> Path:
+    """Path to the log file for ``test_name`` within ``profile`` (dir created).
+
+    Names are sanitised so a test id can never escape the profile directory.
+    """
+    safe_profile = re.sub(r"[^A-Za-z0-9._-]", "_", profile) or "default"
+    safe_test = re.sub(r"[^A-Za-z0-9._-]", "_", test_name)
+    profile_dir = _rp_log_base() / safe_profile
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    return profile_dir / f"{safe_test}.log"
+
+
+def _set_active_test(profile: str | None, test_name: str | None) -> None:
+    """Point per-test logging at ``test_name`` (or clear it when no test)."""
+    global _active_test
+    _active_test = (profile or "", test_name) if test_name else None
+
+
+class _PerTestLogRouter(logging.Handler):
+    """Appends harness + library log records to the active test's log file."""
+
+    def emit(self, record: logging.LogRecord) -> None:
+        test = _active_test
+        if not test or not test[1]:
+            return
+        try:
+            with _rp_log_path(test[0], test[1]).open("a", encoding="utf-8") as fh:
+                fh.write(self.format(record) + "\n")
+        except OSError:
+            # Never let log capture break the flow under test.
+            pass
+
+
+def _install_rp_log_router() -> None:
+    router = _PerTestLogRouter()
+    router.setFormatter(
+        logging.Formatter("%(asctime)s %(levelname)-8s %(name)s: %(message)s")
+    )
+    for name in ("conformance-rp", "py_identity_model"):
+        logging.getLogger(name).addHandler(router)
+    # Capture the library's own validation detail in the per-test logs.
+    logging.getLogger("py_identity_model").setLevel(logging.DEBUG)
+
+
+_install_rp_log_router()
+
+# ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
 
@@ -76,6 +151,9 @@ class AuthSession:
     client_secret: str = ""
     redirect_uri: str = ""
     skip_userinfo: bool = False
+    # Per-test RP-log routing (recovered in /callback via the session)
+    test_name: str = ""
+    profile: str = ""
     # Results populated after callback
     result: dict = field(default_factory=dict)
 
@@ -117,6 +195,7 @@ def clear_cache() -> dict:
     Without clearing caches, validate_token uses stale keys and hangs on
     retry backoff (3 retries x 30s timeout = ~2 min timeout per test).
     """
+    _set_active_test(None, None)
     clear_discovery_cache()
     clear_jwks_cache()
     logger.info("Cleared discovery and JWKS caches")
@@ -127,12 +206,15 @@ def clear_cache() -> dict:
 def discover(
     issuer: str = Query(..., description="Issuer URL for this test"),
     test_id: str = Query("", description="Test module ID for result tracking"),
+    test_name: str = Query("", description="Test module name for RP log capture"),
+    profile: str = Query("", description="Profile/plan name for RP log capture"),
 ) -> JSONResponse:
     """Fetch discovery document (and JWKS) without starting an auth flow.
 
     Used for Config RP discovery-only tests where the suite just needs to
     observe the RP fetching the openid-configuration endpoint.
     """
+    _set_active_test(profile, test_name)
     http_client = _get_http_client()
     try:
         disco_endpoint = parse_discovery_url(issuer)
@@ -189,6 +271,8 @@ def authorize(
     client_id: str = Query(..., description="Client ID registered with the suite"),
     client_secret: str = Query("", description="Client secret"),
     test_id: str = Query("", description="Test module ID for result tracking"),
+    test_name: str = Query("", description="Test module name for RP log capture"),
+    profile: str = Query("", description="Profile/plan name for RP log capture"),
     use_pkce: str = Query("false", description="Whether to use PKCE"),
     skip_userinfo: str = Query(
         "false", description="Skip UserInfo fetch after token validation"
@@ -201,6 +285,7 @@ def authorize(
 
     The conformance test runner calls this to start an authorization flow.
     """
+    _set_active_test(profile, test_name)
     http_client = _get_http_client()
 
     # Fetch discovery document for this issuer
@@ -322,11 +407,16 @@ def authorize(
         client_secret=client_secret,
         redirect_uri=redirect_uri,
         skip_userinfo=skip_userinfo.lower() == "true",
+        test_name=test_name,
+        profile=profile,
     )
     sessions[state] = session
     if test_id:
         session.result["test_id"] = test_id
 
+    logger.info(
+        "ACCEPTED discovery: issuer '%s' matches expected; redirecting to OP", issuer
+    )
     logger.info("Redirecting to OP: %s", auth_url)
     return RedirectResponse(url=auth_url, status_code=302)
 
@@ -417,12 +507,15 @@ def _handle_callback(request_url: str) -> HTMLResponse | JSONResponse:
         )
 
     session = sessions.pop(state_value)
+    # Route this flow's logs to the test that started it (recovered via state).
+    _set_active_test(session.profile, session.test_name)
 
     # Validate state
     state_result = validate_authorize_callback_state(cb_response, session.state)
     if not state_result.is_valid:
         session.result["status"] = "error"
         session.result["error"] = f"state_validation: {state_result.result.value}"
+        logger.error("REJECTED: state validation failed: %s", state_result.result.value)
         _store_test_result(session)
         return HTMLResponse(
             content=(
@@ -437,6 +530,11 @@ def _handle_callback(request_url: str) -> HTMLResponse | JSONResponse:
         session.result["status"] = "error"
         session.result["error"] = cb_response.error
         session.result["error_description"] = cb_response.error_description
+        logger.error(
+            "REJECTED: OP returned error response: %s (%s)",
+            cb_response.error,
+            cb_response.error_description,
+        )
         _store_test_result(session)
         return HTMLResponse(
             content=(
@@ -485,6 +583,7 @@ def _handle_callback(request_url: str) -> HTMLResponse | JSONResponse:
     if not token_response.is_successful:
         session.result["status"] = "error"
         session.result["error"] = f"token_exchange: {token_response.error}"
+        logger.error("REJECTED: token exchange failed: %s", token_response.error)
         _store_test_result(session)
         return HTMLResponse(
             content=(
@@ -541,6 +640,7 @@ def _handle_callback(request_url: str) -> HTMLResponse | JSONResponse:
         except TokenValidationException as exc:
             session.result["status"] = "error"
             session.result["error"] = f"id_token_validation: {exc.message}"
+            logger.error("REJECTED: id_token validation failed: %s", exc.message)
             _store_test_result(session)
             return HTMLResponse(
                 content=(
@@ -550,12 +650,22 @@ def _handle_callback(request_url: str) -> HTMLResponse | JSONResponse:
                 status_code=400,
             )
 
+        logger.info(
+            "ACCEPTED: id_token validated by py-identity-model "
+            "(signature, issuer, audience, expiry)"
+        )
+
         # Validate nonce
         token_nonce = claims.get("nonce")
         if token_nonce != session.nonce:
             session.result["status"] = "error"
             session.result["error"] = (
                 f"nonce_mismatch: expected={session.nonce}, got={token_nonce}"
+            )
+            logger.error(
+                "REJECTED: nonce mismatch (expected=%s, got=%s)",
+                session.nonce,
+                token_nonce,
             )
             _store_test_result(session)
             return HTMLResponse(
@@ -586,7 +696,11 @@ def _handle_callback(request_url: str) -> HTMLResponse | JSONResponse:
                 # The RP MUST reject the UserInfo response if sub differs
                 # from the ID token sub.
                 error_msg = userinfo_response.error
-                logger.error("UserInfo validation failed: %s", error_msg)
+                logger.error(
+                    "REJECTED: UserInfo validation failed (sub mismatch per "
+                    "OIDC Core §5.3.4): %s",
+                    error_msg,
+                )
                 session.result["status"] = "error"
                 session.result["error"] = f"userinfo_validation: {error_msg}"
                 _store_test_result(session)
@@ -609,7 +723,9 @@ def _handle_callback(request_url: str) -> HTMLResponse | JSONResponse:
     _store_test_result(session)
 
     logger.info(
-        "Callback successful for issuer=%s, sub=%s", session.issuer, claims.get("sub")
+        "ACCEPTED: authentication successful for issuer=%s, sub=%s",
+        session.issuer,
+        claims.get("sub"),
     )
 
     # Build response body with ID token and UserInfo claims so the conformance

--- a/conformance/app.py
+++ b/conformance/app.py
@@ -82,13 +82,22 @@ def _rp_log_base() -> Path:
 def _rp_log_path(profile: str, test_name: str) -> Path:
     """Path to the log file for ``test_name`` within ``profile`` (dir created).
 
-    Names are sanitised so a test id can never escape the profile directory.
+    ``profile`` and ``test_name`` arrive as request parameters, so the path is
+    hardened two ways: every character outside ``[A-Za-z0-9._-]`` is replaced
+    (removing any path separators), and the resolved path is verified to stay
+    inside the log base — a value that somehow escaped raises rather than
+    writing outside the base directory.
     """
+    base = _rp_log_base().resolve()
     safe_profile = re.sub(r"[^A-Za-z0-9._-]", "_", profile) or "default"
-    safe_test = re.sub(r"[^A-Za-z0-9._-]", "_", test_name)
-    profile_dir = _rp_log_base() / safe_profile
-    profile_dir.mkdir(parents=True, exist_ok=True)
-    return profile_dir / f"{safe_test}.log"
+    safe_test = re.sub(r"[^A-Za-z0-9._-]", "_", test_name) or "unknown"
+    candidate = (base / safe_profile / f"{safe_test}.log").resolve()
+    if base not in candidate.parents:
+        raise ValueError(
+            f"refusing unsafe RP log path (profile={profile!r}, test={test_name!r})"
+        )
+    candidate.parent.mkdir(parents=True, exist_ok=True)
+    return candidate
 
 
 def _set_active_test(profile: str | None, test_name: str | None) -> None:
@@ -107,7 +116,7 @@ class _PerTestLogRouter(logging.Handler):
         try:
             with _rp_log_path(test[0], test[1]).open("a", encoding="utf-8") as fh:
                 fh.write(self.format(record) + "\n")
-        except OSError:
+        except (OSError, ValueError):
             # Never let log capture break the flow under test.
             pass
 

--- a/conformance/app.py
+++ b/conformance/app.py
@@ -6,6 +6,7 @@ using py-identity-model's public API to exercise all RP conformance tests.
 
 from __future__ import annotations
 
+import contextvars
 from dataclasses import dataclass, field
 import html
 import logging
@@ -13,6 +14,7 @@ import os
 from pathlib import Path
 import re
 import secrets
+import sys
 from urllib.parse import urlencode
 
 from fastapi import FastAPI, Query, Request
@@ -56,19 +58,24 @@ app = FastAPI(title="py-identity-model Conformance RP")
 # Per-test RP log capture (clientSideData for OIDF RP certification)
 # ---------------------------------------------------------------------------
 #
-# OIDF RP certification requires one log file per test, named by the test id,
-# demonstrating the RP's behaviour — in particular that negative tests are
-# rejected (https://openid.net/certification/connect_rp_submission/). The
-# conformance suite only logs the OP side, so the RP must produce these itself.
+# OIDF RP certification requires one log file per test (named by the suite test
+# module name), demonstrating the RP's behaviour — in particular that negative
+# tests are rejected (https://openid.net/certification/connect_rp_submission/).
+# The conformance suite only logs the OP side, so the RP must produce these.
 #
-# The runner drives tests strictly sequentially and tells the harness which
-# test is active via /authorize, /discover and /callback, so a process-global
-# pointer plus a logging handler that routes records to the active test's file
-# is sufficient. RP_LOG_DIR defaults to an absolute path derived from this
-# file's location so the harness and the (separately-launched) runner agree on
-# it regardless of working directory.
+# The runner tells the harness which test is active via /authorize, /discover
+# and /callback, and a logging handler routes records to the active test's file.
+# The active-test pointer is a ContextVar rather than a plain global: every
+# request (and the threadpool call FastAPI runs sync endpoints in) gets its own
+# context copy, so concurrent or overlapping requests can never route a record
+# to the wrong test's file, and a request's pointer cannot leak into the next
+# one. RP_LOG_DIR defaults to an absolute path derived from this file's location
+# so the harness and the (separately-launched) runner agree on it regardless of
+# working directory.
 
-_active_test: tuple[str, str] | None = None
+_active_test: contextvars.ContextVar[tuple[str, str] | None] = contextvars.ContextVar(
+    "rp_active_test", default=None
+)
 
 
 def _rp_log_base() -> Path:
@@ -79,20 +86,34 @@ def _rp_log_base() -> Path:
     )
 
 
+def _sanitize_path_component(value: str, fallback: str) -> str:
+    """Reduce ``value`` to a single safe path segment.
+
+    Every character outside ``[A-Za-z0-9._-]`` is replaced (removing path
+    separators), and a result that is empty or consists only of dots (``""``,
+    ``"."``, ``".."``, ...) — which the character class alone would let through
+    and which would walk out of the log base — collapses to ``fallback``.
+    """
+    safe = re.sub(r"[^A-Za-z0-9._-]", "_", value)
+    if not safe or set(safe) == {"."}:
+        return fallback
+    return safe
+
+
 def _rp_log_path(profile: str, test_name: str) -> Path:
     """Path to the log file for ``test_name`` within ``profile`` (dir created).
 
     ``profile`` and ``test_name`` arrive as request parameters, so the path is
-    hardened two ways: every character outside ``[A-Za-z0-9._-]`` is replaced
-    (removing any path separators), and the resolved path is verified to stay
-    inside the log base — a value that somehow escaped raises rather than
-    writing outside the base directory.
+    hardened two ways: each is reduced to a single sanitised path segment via
+    :func:`_sanitize_path_component` (no separators, no dot-only escapes), and
+    the resolved path is verified to stay inside the log base — a value that
+    somehow escaped raises rather than writing outside the base directory.
     """
     base = _rp_log_base().resolve()
-    safe_profile = re.sub(r"[^A-Za-z0-9._-]", "_", profile) or "default"
-    safe_test = re.sub(r"[^A-Za-z0-9._-]", "_", test_name) or "unknown"
+    safe_profile = _sanitize_path_component(profile, "default")
+    safe_test = _sanitize_path_component(test_name, "unknown")
     candidate = (base / safe_profile / f"{safe_test}.log").resolve()
-    if base not in candidate.parents:
+    if not candidate.is_relative_to(base):
         raise ValueError(
             f"refusing unsafe RP log path (profile={profile!r}, test={test_name!r})"
         )
@@ -102,23 +123,37 @@ def _rp_log_path(profile: str, test_name: str) -> Path:
 
 def _set_active_test(profile: str | None, test_name: str | None) -> None:
     """Point per-test logging at ``test_name`` (or clear it when no test)."""
-    global _active_test
-    _active_test = (profile or "", test_name) if test_name else None
+    _active_test.set((profile or "", test_name) if test_name else None)
+
+
+def _get_active_test() -> tuple[str, str] | None:
+    """Current ``(profile, test_name)`` for log routing, or ``None``."""
+    return _active_test.get()
 
 
 class _PerTestLogRouter(logging.Handler):
     """Appends harness + library log records to the active test's log file."""
 
+    _warned_on_failure = False
+
     def emit(self, record: logging.LogRecord) -> None:
-        test = _active_test
+        test = _get_active_test()
         if not test or not test[1]:
             return
         try:
             with _rp_log_path(test[0], test[1]).open("a", encoding="utf-8") as fh:
                 fh.write(self.format(record) + "\n")
-        except (OSError, ValueError):
-            # Never let log capture break the flow under test.
-            pass
+        except (OSError, ValueError) as exc:
+            # Never let log capture break the flow under test, but a silently
+            # empty clientSideData bundle is a worthless submission artifact, so
+            # surface the first failure on stderr (bypassing logging to avoid
+            # recursing back into this handler).
+            if not _PerTestLogRouter._warned_on_failure:
+                _PerTestLogRouter._warned_on_failure = True
+                sys.stderr.write(
+                    f"WARNING: RP per-test log capture failing for "
+                    f"profile={test[0]!r} test={test[1]!r}: {exc}\n"
+                )
 
 
 def _install_rp_log_router() -> None:
@@ -229,7 +264,7 @@ def discover(
         disco_endpoint = parse_discovery_url(issuer)
     except ConfigurationException as exc:
         error_msg = f"invalid_issuer: {exc}"
-        logger.error("Discovery URL parse error: %s", exc)
+        logger.error("REJECTED: invalid issuer URL: %s", exc)
         if test_id:
             error_session = AuthSession(issuer=issuer, state="", nonce="")
             error_session.result = {
@@ -249,6 +284,7 @@ def discover(
     )
 
     if not disco.is_successful:
+        logger.error("REJECTED: discovery fetch failed: %s", disco.error)
         if test_id:
             error_session = AuthSession(issuer=issuer, state="", nonce="")
             error_session.result = {
@@ -271,6 +307,10 @@ def discover(
         }
         test_results[test_id] = session
 
+    logger.info(
+        "ACCEPTED: discovery document fetched and validated for issuer '%s'",
+        disco.issuer,
+    )
     return JSONResponse(content={"status": "ok", "issuer": disco.issuer})
 
 
@@ -302,7 +342,7 @@ def authorize(
         disco_endpoint = parse_discovery_url(issuer)
     except ConfigurationException as exc:
         error_msg = f"invalid_issuer: {exc}"
-        logger.error("Discovery URL parse error: %s", exc)
+        logger.error("REJECTED: invalid issuer URL: %s", exc)
         if test_id:
             error_session = AuthSession(issuer=issuer, state="", nonce="")
             error_session.result = {
@@ -323,6 +363,7 @@ def authorize(
 
     if not disco.is_successful:
         # Discovery failure includes format/validation errors — store as test result
+        logger.error("REJECTED: discovery fetch failed: %s", disco.error)
         if test_id:
             error_session = AuthSession(issuer=issuer, state="", nonce="")
             error_session.result = {
@@ -339,7 +380,7 @@ def authorize(
     # OIDC Discovery 1.0 §4.3: issuer in document MUST match the URL used to retrieve it
     if not disco.issuer:
         error_msg = "Discovery document missing required 'issuer' field"
-        logger.error(error_msg)
+        logger.error("REJECTED: %s", error_msg)
         if test_id:
             error_session = AuthSession(issuer=issuer, state="", nonce="")
             error_session.result = {
@@ -357,7 +398,7 @@ def authorize(
             f"Issuer mismatch: discovery document issuer '{disco.issuer}' "
             f"does not match expected '{issuer}'"
         )
-        logger.error(error_msg)
+        logger.error("REJECTED: %s", error_msg)
         if test_id:
             error_session = AuthSession(issuer=issuer, state="", nonce="")
             error_session.result = {
@@ -424,7 +465,7 @@ def authorize(
         session.result["test_id"] = test_id
 
     logger.info(
-        "ACCEPTED discovery: issuer '%s' matches expected; redirecting to OP", issuer
+        "ACCEPTED: discovery issuer '%s' matches expected; redirecting to OP", issuer
     )
     logger.info("Redirecting to OP: %s", auth_url)
     return RedirectResponse(url=auth_url, status_code=302)
@@ -441,7 +482,7 @@ def _fetch_and_validate_discovery(
         disco_endpoint = parse_discovery_url(issuer)
     except ConfigurationException as exc:
         error_msg = f"invalid_issuer: {exc}"
-        logger.error("Discovery URL parse error in callback: %s", exc)
+        logger.error("REJECTED: invalid issuer URL in callback: %s", exc)
         session.result["status"] = "error"
         session.result["error"] = error_msg
         _store_test_result(session)
@@ -456,6 +497,7 @@ def _fetch_and_validate_discovery(
     )
 
     if not disco.is_successful:
+        logger.error("REJECTED: discovery fetch failed in callback: %s", disco.error)
         session.result["status"] = "error"
         session.result["error"] = f"discovery_failed: {disco.error}"
         _store_test_result(session)
@@ -467,7 +509,7 @@ def _fetch_and_validate_discovery(
     # OIDC Discovery 1.0 §4.3: issuer in document MUST match the URL used to retrieve it
     if not disco.issuer:
         error_msg = "Discovery document missing required 'issuer' field"
-        logger.error(error_msg)
+        logger.error("REJECTED: %s", error_msg)
         session.result["status"] = "error"
         session.result["error"] = f"missing_issuer: {error_msg}"
         _store_test_result(session)
@@ -480,7 +522,7 @@ def _fetch_and_validate_discovery(
             f"Issuer mismatch: discovery document issuer '{disco.issuer}' "
             f"does not match expected '{issuer}'"
         )
-        logger.error(error_msg)
+        logger.error("REJECTED: %s", error_msg)
         session.result["status"] = "error"
         session.result["error"] = f"issuer_mismatch: {error_msg}"
         _store_test_result(session)

--- a/conformance/results/hosted/basic-rp-latest.json
+++ b/conformance/results/hosted/basic-rp-latest.json
@@ -1,0 +1,114 @@
+{
+  "plan": "basic-rp",
+  "plan_id": "BzbbUs8KpKRez",
+  "suite_url": "https://www.certification.openid.net/",
+  "results": [
+    {
+      "test": "oidcc-client-test",
+      "status": "PASSED",
+      "test_id": "RyLhZeiGnoq7tot",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=RyLhZeiGnoq7tot",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-invalid-iss",
+      "status": "PASSED",
+      "test_id": "YWacaFvLeiMTx3O",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=YWacaFvLeiMTx3O",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-missing-sub",
+      "status": "PASSED",
+      "test_id": "ECB12rpy4uAdfwc",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=ECB12rpy4uAdfwc",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-invalid-aud",
+      "status": "PASSED",
+      "test_id": "B45hDzdJCxWg3NP",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=B45hDzdJCxWg3NP",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-missing-iat",
+      "status": "PASSED",
+      "test_id": "gCW9Ma4KOBaAWeH",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=gCW9Ma4KOBaAWeH",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-kid-absent-single-jwks",
+      "status": "PASSED",
+      "test_id": "OO2KUXPghetjA3W",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=OO2KUXPghetjA3W",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-kid-absent-multiple-jwks",
+      "status": "PASSED",
+      "test_id": "Jm5bGqCZqCHG9v6",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=Jm5bGqCZqCHG9v6",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-idtoken-sig-rs256",
+      "status": "PASSED",
+      "test_id": "n66lMhylU2Y2Cx7",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=n66lMhylU2Y2Cx7",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-idtoken-sig-none",
+      "status": "SKIPPED",
+      "test_id": "I2AODPCZA74senD",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=I2AODPCZA74senD",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-invalid-sig-rs256",
+      "status": "PASSED",
+      "test_id": "QjWUtr2j1r4xQHY",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=QjWUtr2j1r4xQHY",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-userinfo-invalid-sub",
+      "status": "PASSED",
+      "test_id": "uxrfdnzBpS8dGy8",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=uxrfdnzBpS8dGy8",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-nonce-invalid",
+      "status": "PASSED",
+      "test_id": "6wtZlfbF1hJ846x",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=6wtZlfbF1hJ846x",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-scope-userinfo-claims",
+      "status": "PASSED",
+      "test_id": "4uB5gbMzTgTtRKD",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=4uB5gbMzTgTtRKD",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-client-secret-basic",
+      "status": "PASSED",
+      "test_id": "kZXEWmkEo8Avk5x",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=kZXEWmkEo8Avk5x",
+      "detail": ""
+    }
+  ],
+  "summary": {
+    "total": 14,
+    "passed": 13,
+    "warning": 0,
+    "failed": 0,
+    "review": 0,
+    "skipped": 1
+  },
+  "all_passed": true
+}

--- a/conformance/results/hosted/basic-rp-latest.json
+++ b/conformance/results/hosted/basic-rp-latest.json
@@ -1,104 +1,104 @@
 {
   "plan": "basic-rp",
-  "plan_id": "jBXwIRd9C8nzj",
+  "plan_id": "IMdvuXvIWxTdR",
   "suite_url": "https://www.certification.openid.net/",
   "results": [
     {
       "test": "oidcc-client-test",
       "status": "PASSED",
-      "test_id": "p98Qh66dgVctRhL",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=p98Qh66dgVctRhL",
+      "test_id": "SX2Sf0s6Nd9P7zY",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=SX2Sf0s6Nd9P7zY",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-invalid-iss",
       "status": "PASSED",
-      "test_id": "RLH60wjqUWR40jf",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=RLH60wjqUWR40jf",
+      "test_id": "FmaUQTEwISHL1nc",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=FmaUQTEwISHL1nc",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-missing-sub",
       "status": "PASSED",
-      "test_id": "FadQlL8CV3WQ53t",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=FadQlL8CV3WQ53t",
+      "test_id": "XpxQSZ6NmVDnnII",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=XpxQSZ6NmVDnnII",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-invalid-aud",
       "status": "PASSED",
-      "test_id": "9Rl5xhcnLjvqkKa",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=9Rl5xhcnLjvqkKa",
+      "test_id": "MKp9HCa71Pt7jJH",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=MKp9HCa71Pt7jJH",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-missing-iat",
       "status": "PASSED",
-      "test_id": "L34kjo8vWtAAg8B",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=L34kjo8vWtAAg8B",
+      "test_id": "00ElBx2h76lQICK",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=00ElBx2h76lQICK",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-kid-absent-single-jwks",
       "status": "PASSED",
-      "test_id": "D7a54cbDv9m91Wu",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=D7a54cbDv9m91Wu",
+      "test_id": "Eun9qEXqAIPrPbH",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=Eun9qEXqAIPrPbH",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-kid-absent-multiple-jwks",
       "status": "PASSED",
-      "test_id": "NQhymRCfWJ4dxI4",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=NQhymRCfWJ4dxI4",
+      "test_id": "G4WvSGZXpn5dhLW",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=G4WvSGZXpn5dhLW",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-idtoken-sig-rs256",
       "status": "PASSED",
-      "test_id": "hEGyqR3aOmsx0VR",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=hEGyqR3aOmsx0VR",
+      "test_id": "AEh6mqH7AiBnWAq",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=AEh6mqH7AiBnWAq",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-idtoken-sig-none",
       "status": "SKIPPED",
-      "test_id": "69EQkOXuvETe3eI",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=69EQkOXuvETe3eI",
+      "test_id": "U3D3z1PiJXy3jEr",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=U3D3z1PiJXy3jEr",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-invalid-sig-rs256",
       "status": "PASSED",
-      "test_id": "J9H5335ANFTez5k",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=J9H5335ANFTez5k",
+      "test_id": "3fy9hQDGAgGXBZa",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=3fy9hQDGAgGXBZa",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-userinfo-invalid-sub",
       "status": "PASSED",
-      "test_id": "EMkdA2u5olxNL23",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=EMkdA2u5olxNL23",
+      "test_id": "6TxFNUUnwju5BBR",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=6TxFNUUnwju5BBR",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-nonce-invalid",
       "status": "PASSED",
-      "test_id": "CyYrDKdDO4rOFZ2",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=CyYrDKdDO4rOFZ2",
+      "test_id": "7Vr9QYsLs2wBV33",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=7Vr9QYsLs2wBV33",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-scope-userinfo-claims",
       "status": "PASSED",
-      "test_id": "D5Z3SjG0gPsqXmL",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=D5Z3SjG0gPsqXmL",
+      "test_id": "Ki7eUhXmuotPr1J",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=Ki7eUhXmuotPr1J",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-client-secret-basic",
       "status": "PASSED",
-      "test_id": "r3Wl4Y2HnTxLL4H",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=r3Wl4Y2HnTxLL4H",
+      "test_id": "BaNOsQJOqyOhJiG",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=BaNOsQJOqyOhJiG",
       "detail": ""
     }
   ],

--- a/conformance/results/hosted/basic-rp-latest.json
+++ b/conformance/results/hosted/basic-rp-latest.json
@@ -1,104 +1,104 @@
 {
   "plan": "basic-rp",
-  "plan_id": "BzbbUs8KpKRez",
+  "plan_id": "jBXwIRd9C8nzj",
   "suite_url": "https://www.certification.openid.net/",
   "results": [
     {
       "test": "oidcc-client-test",
       "status": "PASSED",
-      "test_id": "RyLhZeiGnoq7tot",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=RyLhZeiGnoq7tot",
+      "test_id": "p98Qh66dgVctRhL",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=p98Qh66dgVctRhL",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-invalid-iss",
       "status": "PASSED",
-      "test_id": "YWacaFvLeiMTx3O",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=YWacaFvLeiMTx3O",
+      "test_id": "RLH60wjqUWR40jf",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=RLH60wjqUWR40jf",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-missing-sub",
       "status": "PASSED",
-      "test_id": "ECB12rpy4uAdfwc",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=ECB12rpy4uAdfwc",
+      "test_id": "FadQlL8CV3WQ53t",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=FadQlL8CV3WQ53t",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-invalid-aud",
       "status": "PASSED",
-      "test_id": "B45hDzdJCxWg3NP",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=B45hDzdJCxWg3NP",
+      "test_id": "9Rl5xhcnLjvqkKa",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=9Rl5xhcnLjvqkKa",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-missing-iat",
       "status": "PASSED",
-      "test_id": "gCW9Ma4KOBaAWeH",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=gCW9Ma4KOBaAWeH",
+      "test_id": "L34kjo8vWtAAg8B",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=L34kjo8vWtAAg8B",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-kid-absent-single-jwks",
       "status": "PASSED",
-      "test_id": "OO2KUXPghetjA3W",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=OO2KUXPghetjA3W",
+      "test_id": "D7a54cbDv9m91Wu",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=D7a54cbDv9m91Wu",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-kid-absent-multiple-jwks",
       "status": "PASSED",
-      "test_id": "Jm5bGqCZqCHG9v6",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=Jm5bGqCZqCHG9v6",
+      "test_id": "NQhymRCfWJ4dxI4",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=NQhymRCfWJ4dxI4",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-idtoken-sig-rs256",
       "status": "PASSED",
-      "test_id": "n66lMhylU2Y2Cx7",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=n66lMhylU2Y2Cx7",
+      "test_id": "hEGyqR3aOmsx0VR",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=hEGyqR3aOmsx0VR",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-idtoken-sig-none",
       "status": "SKIPPED",
-      "test_id": "I2AODPCZA74senD",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=I2AODPCZA74senD",
+      "test_id": "69EQkOXuvETe3eI",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=69EQkOXuvETe3eI",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-invalid-sig-rs256",
       "status": "PASSED",
-      "test_id": "QjWUtr2j1r4xQHY",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=QjWUtr2j1r4xQHY",
+      "test_id": "J9H5335ANFTez5k",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=J9H5335ANFTez5k",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-userinfo-invalid-sub",
       "status": "PASSED",
-      "test_id": "uxrfdnzBpS8dGy8",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=uxrfdnzBpS8dGy8",
+      "test_id": "EMkdA2u5olxNL23",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=EMkdA2u5olxNL23",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-nonce-invalid",
       "status": "PASSED",
-      "test_id": "6wtZlfbF1hJ846x",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=6wtZlfbF1hJ846x",
+      "test_id": "CyYrDKdDO4rOFZ2",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=CyYrDKdDO4rOFZ2",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-scope-userinfo-claims",
       "status": "PASSED",
-      "test_id": "4uB5gbMzTgTtRKD",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=4uB5gbMzTgTtRKD",
+      "test_id": "D5Z3SjG0gPsqXmL",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=D5Z3SjG0gPsqXmL",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-client-secret-basic",
       "status": "PASSED",
-      "test_id": "kZXEWmkEo8Avk5x",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=kZXEWmkEo8Avk5x",
+      "test_id": "r3Wl4Y2HnTxLL4H",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=r3Wl4Y2HnTxLL4H",
       "detail": ""
     }
   ],

--- a/conformance/results/hosted/config-rp-latest.json
+++ b/conformance/results/hosted/config-rp-latest.json
@@ -1,0 +1,58 @@
+{
+  "plan": "config-rp",
+  "plan_id": "BuVb1cr1NCfrh",
+  "suite_url": "https://www.certification.openid.net/",
+  "results": [
+    {
+      "test": "oidcc-client-test-discovery-openid-config",
+      "status": "PASSED",
+      "test_id": "K7VUnOHR8OM5FQb",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=K7VUnOHR8OM5FQb",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-discovery-jwks-uri-keys",
+      "status": "PASSED",
+      "test_id": "bqutxl2nEsryGSD",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=bqutxl2nEsryGSD",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-discovery-issuer-mismatch",
+      "status": "PASSED",
+      "test_id": "VX62iE3rTJpyPYn",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=VX62iE3rTJpyPYn",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-idtoken-sig-none",
+      "status": "SKIPPED",
+      "test_id": "S8eGdDBJ1kag3fK",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=S8eGdDBJ1kag3fK",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-signing-key-rotation-just-before-signing",
+      "status": "PASSED",
+      "test_id": "MSgvdwunmgrpk5H",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=MSgvdwunmgrpk5H",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-signing-key-rotation",
+      "status": "PASSED",
+      "test_id": "o8bWMpy6lto8Plc",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=o8bWMpy6lto8Plc",
+      "detail": ""
+    }
+  ],
+  "summary": {
+    "total": 6,
+    "passed": 5,
+    "warning": 0,
+    "failed": 0,
+    "review": 0,
+    "skipped": 1
+  },
+  "all_passed": true
+}

--- a/conformance/results/hosted/config-rp-latest.json
+++ b/conformance/results/hosted/config-rp-latest.json
@@ -1,48 +1,48 @@
 {
   "plan": "config-rp",
-  "plan_id": "BuVb1cr1NCfrh",
+  "plan_id": "6GYBauwh5fa3v",
   "suite_url": "https://www.certification.openid.net/",
   "results": [
     {
       "test": "oidcc-client-test-discovery-openid-config",
       "status": "PASSED",
-      "test_id": "K7VUnOHR8OM5FQb",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=K7VUnOHR8OM5FQb",
+      "test_id": "1kHFfJC0bYSGAhQ",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=1kHFfJC0bYSGAhQ",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-discovery-jwks-uri-keys",
       "status": "PASSED",
-      "test_id": "bqutxl2nEsryGSD",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=bqutxl2nEsryGSD",
+      "test_id": "LCXQOuFC0HkPkZL",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=LCXQOuFC0HkPkZL",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-discovery-issuer-mismatch",
       "status": "PASSED",
-      "test_id": "VX62iE3rTJpyPYn",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=VX62iE3rTJpyPYn",
+      "test_id": "CJcgHqO9f0RVjI7",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=CJcgHqO9f0RVjI7",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-idtoken-sig-none",
       "status": "SKIPPED",
-      "test_id": "S8eGdDBJ1kag3fK",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=S8eGdDBJ1kag3fK",
+      "test_id": "JXDrRzyMvzmsL1Z",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=JXDrRzyMvzmsL1Z",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-signing-key-rotation-just-before-signing",
       "status": "PASSED",
-      "test_id": "MSgvdwunmgrpk5H",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=MSgvdwunmgrpk5H",
+      "test_id": "JzNuFp75Iz2rP1j",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=JzNuFp75Iz2rP1j",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-signing-key-rotation",
       "status": "PASSED",
-      "test_id": "o8bWMpy6lto8Plc",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=o8bWMpy6lto8Plc",
+      "test_id": "ycaVxoOQFxIy1jh",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=ycaVxoOQFxIy1jh",
       "detail": ""
     }
   ],

--- a/conformance/results/hosted/form-post-basic-rp-latest.json
+++ b/conformance/results/hosted/form-post-basic-rp-latest.json
@@ -1,0 +1,114 @@
+{
+  "plan": "form-post-basic-rp",
+  "plan_id": "tWqPbMYvG25YM",
+  "suite_url": "https://www.certification.openid.net/",
+  "results": [
+    {
+      "test": "oidcc-client-test",
+      "status": "PASSED",
+      "test_id": "vcnBmVUFb2VBP27",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=vcnBmVUFb2VBP27",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-invalid-iss",
+      "status": "PASSED",
+      "test_id": "fE6V47UtR0mlPks",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=fE6V47UtR0mlPks",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-missing-sub",
+      "status": "PASSED",
+      "test_id": "yfvuTQlkwum5ekc",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=yfvuTQlkwum5ekc",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-invalid-aud",
+      "status": "PASSED",
+      "test_id": "k48ELbTOi1ar2pC",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=k48ELbTOi1ar2pC",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-missing-iat",
+      "status": "PASSED",
+      "test_id": "7Sd3LY1gOwkkbdq",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=7Sd3LY1gOwkkbdq",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-kid-absent-single-jwks",
+      "status": "PASSED",
+      "test_id": "hs1g3Imh5sg66QV",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=hs1g3Imh5sg66QV",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-kid-absent-multiple-jwks",
+      "status": "PASSED",
+      "test_id": "7oRfv1HUG9Psjr9",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=7oRfv1HUG9Psjr9",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-idtoken-sig-rs256",
+      "status": "PASSED",
+      "test_id": "kTciNsSQkHvDZoH",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=kTciNsSQkHvDZoH",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-idtoken-sig-none",
+      "status": "SKIPPED",
+      "test_id": "ppaOLGMXp8WwhKT",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=ppaOLGMXp8WwhKT",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-invalid-sig-rs256",
+      "status": "PASSED",
+      "test_id": "DOz65qd7Gw0VImB",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=DOz65qd7Gw0VImB",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-userinfo-invalid-sub",
+      "status": "PASSED",
+      "test_id": "piASAq2Tgc2DS9d",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=piASAq2Tgc2DS9d",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-nonce-invalid",
+      "status": "PASSED",
+      "test_id": "ApGPUUNy6vFSR2e",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=ApGPUUNy6vFSR2e",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-scope-userinfo-claims",
+      "status": "PASSED",
+      "test_id": "zPzKGPnakjKu0ud",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=zPzKGPnakjKu0ud",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-client-secret-basic",
+      "status": "PASSED",
+      "test_id": "diirxBPSPRV2U8T",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=diirxBPSPRV2U8T",
+      "detail": ""
+    }
+  ],
+  "summary": {
+    "total": 14,
+    "passed": 13,
+    "warning": 0,
+    "failed": 0,
+    "review": 0,
+    "skipped": 1
+  },
+  "all_passed": true
+}

--- a/conformance/results/hosted/form-post-basic-rp-latest.json
+++ b/conformance/results/hosted/form-post-basic-rp-latest.json
@@ -1,104 +1,104 @@
 {
   "plan": "form-post-basic-rp",
-  "plan_id": "tWqPbMYvG25YM",
+  "plan_id": "NybceFU0jJXui",
   "suite_url": "https://www.certification.openid.net/",
   "results": [
     {
       "test": "oidcc-client-test",
       "status": "PASSED",
-      "test_id": "vcnBmVUFb2VBP27",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=vcnBmVUFb2VBP27",
+      "test_id": "v4dFcuCxw626bsz",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=v4dFcuCxw626bsz",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-invalid-iss",
       "status": "PASSED",
-      "test_id": "fE6V47UtR0mlPks",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=fE6V47UtR0mlPks",
+      "test_id": "t1EBsRtl9iJ7Fvk",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=t1EBsRtl9iJ7Fvk",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-missing-sub",
       "status": "PASSED",
-      "test_id": "yfvuTQlkwum5ekc",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=yfvuTQlkwum5ekc",
+      "test_id": "RD2g3kbZRzhObWm",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=RD2g3kbZRzhObWm",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-invalid-aud",
       "status": "PASSED",
-      "test_id": "k48ELbTOi1ar2pC",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=k48ELbTOi1ar2pC",
+      "test_id": "Dvh7Wh2PY85CFIH",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=Dvh7Wh2PY85CFIH",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-missing-iat",
       "status": "PASSED",
-      "test_id": "7Sd3LY1gOwkkbdq",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=7Sd3LY1gOwkkbdq",
+      "test_id": "tfErCJqUqEsMmWf",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=tfErCJqUqEsMmWf",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-kid-absent-single-jwks",
       "status": "PASSED",
-      "test_id": "hs1g3Imh5sg66QV",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=hs1g3Imh5sg66QV",
+      "test_id": "PUoIbXkVwlDrYK2",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=PUoIbXkVwlDrYK2",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-kid-absent-multiple-jwks",
       "status": "PASSED",
-      "test_id": "7oRfv1HUG9Psjr9",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=7oRfv1HUG9Psjr9",
+      "test_id": "zr4CPp9AHUbnbFc",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=zr4CPp9AHUbnbFc",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-idtoken-sig-rs256",
       "status": "PASSED",
-      "test_id": "kTciNsSQkHvDZoH",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=kTciNsSQkHvDZoH",
+      "test_id": "CRop7YpadA5tjhy",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=CRop7YpadA5tjhy",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-idtoken-sig-none",
       "status": "SKIPPED",
-      "test_id": "ppaOLGMXp8WwhKT",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=ppaOLGMXp8WwhKT",
+      "test_id": "ywL84fO9qIvovqD",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=ywL84fO9qIvovqD",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-invalid-sig-rs256",
       "status": "PASSED",
-      "test_id": "DOz65qd7Gw0VImB",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=DOz65qd7Gw0VImB",
+      "test_id": "4tKL258YhfCBUBA",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=4tKL258YhfCBUBA",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-userinfo-invalid-sub",
       "status": "PASSED",
-      "test_id": "piASAq2Tgc2DS9d",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=piASAq2Tgc2DS9d",
+      "test_id": "jCP89bJqyxN56ed",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=jCP89bJqyxN56ed",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-nonce-invalid",
       "status": "PASSED",
-      "test_id": "ApGPUUNy6vFSR2e",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=ApGPUUNy6vFSR2e",
+      "test_id": "f25m27ys7I5sW7w",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=f25m27ys7I5sW7w",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-scope-userinfo-claims",
       "status": "PASSED",
-      "test_id": "zPzKGPnakjKu0ud",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=zPzKGPnakjKu0ud",
+      "test_id": "X9fhXv5X87bEIuq",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=X9fhXv5X87bEIuq",
       "detail": ""
     },
     {
       "test": "oidcc-client-test-client-secret-basic",
       "status": "PASSED",
-      "test_id": "diirxBPSPRV2U8T",
-      "log_url": "https://www.certification.openid.net/log-detail.html?log=diirxBPSPRV2U8T",
+      "test_id": "7lBFuXrt1qPsZfl",
+      "log_url": "https://www.certification.openid.net/log-detail.html?log=7lBFuXrt1qPsZfl",
       "detail": ""
     }
   ],

--- a/conformance/run_tests.py
+++ b/conformance/run_tests.py
@@ -15,9 +15,11 @@ import logging
 import os
 from pathlib import Path
 import re
+import shutil
 import sys
 import time
 from urllib.parse import urljoin, urlparse
+import zipfile
 
 import httpx
 
@@ -257,6 +259,8 @@ def drive_rp_discover(
     rp_base_url: str,
     issuer: str,
     test_id: str,
+    test_name: str = "",
+    profile: str = "",
 ) -> None:
     """Hit the RP's /discover endpoint to fetch discovery without starting an auth flow.
 
@@ -266,6 +270,8 @@ def drive_rp_discover(
     params = {
         "issuer": issuer,
         "test_id": test_id,
+        "test_name": test_name,
+        "profile": profile,
     }
 
     with httpx.Client(verify=False, timeout=30.0) as client:
@@ -321,6 +327,8 @@ def drive_rp_authorize(
     test_id: str,
     use_pkce: bool = False,
     skip_userinfo: bool = False,
+    test_name: str = "",
+    profile: str = "",
 ) -> None:
     """Hit the RP's /authorize endpoint to start an auth flow.
 
@@ -337,6 +345,8 @@ def drive_rp_authorize(
         "client_id": client_id,
         "client_secret": client_secret,
         "test_id": test_id,
+        "test_name": test_name,
+        "profile": profile,
         "use_pkce": str(use_pkce).lower(),
         "skip_userinfo": str(skip_userinfo).lower(),
     }
@@ -419,6 +429,7 @@ def run_test_module(
     rp_base_url: str,
     client_id: str,
     client_secret: str,
+    profile: str = "",
 ) -> TestResult:
     """Execute a single conformance test module."""
     logger.info("=" * 60)
@@ -478,6 +489,8 @@ def run_test_module(
             rp_base_url=rp_base_url,
             issuer=issuer,
             test_id=module_id,
+            test_name=test_name,
+            profile=profile,
         )
     elif test_type == "auth_double":
         # Double-flow tests (key rotation): drive two sequential auth flows
@@ -488,6 +501,8 @@ def run_test_module(
             client_id=client_id,
             client_secret=client_secret,
             test_id=module_id,
+            test_name=test_name,
+            profile=profile,
         )
         # Wait briefly for the suite to rotate keys
         time.sleep(1)
@@ -498,6 +513,8 @@ def run_test_module(
             client_id=client_id,
             client_secret=client_secret,
             test_id=module_id,
+            test_name=test_name,
+            profile=profile,
         )
     else:
         # Standard auth flow (with optional userinfo skip)
@@ -508,6 +525,8 @@ def run_test_module(
             client_secret=client_secret,
             test_id=module_id,
             skip_userinfo=(test_type == "auth_no_userinfo"),
+            test_name=test_name,
+            profile=profile,
         )
 
     # Poll until the test finishes
@@ -565,6 +584,7 @@ def run_plan(
     rp_base_url: str = RP_BASE_URL,
     token: str | None = None,
     publish: str = "",
+    profile: str = "",
 ) -> tuple[str, list[TestResult]]:
     """Run all tests in a conformance test plan.
 
@@ -626,6 +646,7 @@ def run_plan(
             rp_base_url=rp_base_url,
             client_id=client_id,
             client_secret=client_secret,
+            profile=profile,
         )
         results.append(result)
 
@@ -700,6 +721,46 @@ def _should_download_export(
 
 
 # ---------------------------------------------------------------------------
+# RP client-side logs (clientSideData)
+# ---------------------------------------------------------------------------
+
+
+def _rp_log_dir() -> Path:
+    """Base directory for per-test RP logs the harness writes.
+
+    Defaults to an absolute path derived from this file's location so it matches
+    the harness default (``app.py`` computes the same path from its own
+    ``__file__``) regardless of working directory. Env-overridable via
+    ``RP_LOG_DIR`` — set the same value for both processes if you override it.
+    """
+    return Path(
+        os.environ.get("RP_LOG_DIR")
+        or (Path(__file__).parent / "results" / "hosted" / "rp-logs")
+    )
+
+
+def _reset_dir(path: Path) -> None:
+    """Remove ``path`` and recreate it empty (so stale logs never leak in)."""
+    if path.exists():
+        shutil.rmtree(path)
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def _zip_directory(src_dir: Path, output: Path) -> int:
+    """Zip the files directly under ``src_dir`` (flat) into ``output``.
+
+    Returns the number of files written. Used to assemble the per-profile RP
+    log bundle submitted to OIDF as ``clientSideData``.
+    """
+    files = sorted(p for p in src_dir.glob("*") if p.is_file())
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(output, "w", zipfile.ZIP_DEFLATED) as zf:
+        for p in files:
+            zf.write(p, arcname=p.name)
+    return len(files)
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -755,6 +816,16 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--rp-logs-zip",
+        default=None,
+        help=(
+            "Path to write the per-test RP client-side logs (.zip) the harness "
+            "captured for this plan — one log file per test, the 'clientSideData' "
+            "uploaded with an OIDF certification submission (see #331). The "
+            "per-profile log dir is reset before the run and zipped after."
+        ),
+    )
+    parser.add_argument(
         "--publish",
         choices=["none", "summary", "everything"],
         default="none",
@@ -795,12 +866,19 @@ def main() -> None:
 
     publish_value = "" if args.publish == "none" else args.publish
 
+    # Reset this profile's RP-log directory so the zip only contains this run's
+    # per-test logs (the harness appends, so stale files would otherwise leak in).
+    rp_log_profile_dir = _rp_log_dir() / args.plan
+    if args.rp_logs_zip:
+        _reset_dir(rp_log_profile_dir)
+
     plan_id, results = run_plan(
         config_path=str(config_path),
         suite_base_url=args.suite_url,
         rp_base_url=args.rp_url,
         token=env_token or None,
         publish=publish_value,
+        profile=args.plan,
     )
 
     all_ok = print_summary(results)
@@ -863,6 +941,24 @@ def main() -> None:
             export_path,
             len(content),
         )
+
+    # Assemble the per-test RP client-side logs zip (clientSideData). Captured
+    # regardless of pass/fail — the logs for failed tests are exactly what you'd
+    # inspect — so this is gated only on the flag, not on all_ok.
+    if args.rp_logs_zip:
+        count = _zip_directory(rp_log_profile_dir, Path(args.rp_logs_zip))
+        if count == 0:
+            logger.warning(
+                "No RP logs captured in %s — is the harness running this build "
+                "(it must receive test_name/profile and share RP_LOG_DIR)?",
+                rp_log_profile_dir,
+            )
+        else:
+            logger.info(
+                "RP client-side logs (%d files) written to %s",
+                count,
+                args.rp_logs_zip,
+            )
 
     sys.exit(0 if all_ok else 1)
 

--- a/conformance/run_tests.py
+++ b/conformance/run_tests.py
@@ -14,6 +14,7 @@ import json
 import logging
 import os
 from pathlib import Path
+import re
 import sys
 import time
 from urllib.parse import urljoin, urlparse
@@ -99,8 +100,8 @@ class ConformanceSuiteClient:
 
         ``publish`` controls whether the suite makes the plan's results publicly
         visible on the published-tests list: "" (default) keeps it private,
-        "summary" / "everything" publish it. The downloadable certification
-        package is produced regardless of this setting.
+        "summary" / "everything" publish it. The downloadable plan export is
+        available regardless of this setting.
 
         Returns the plan response including plan ID and list of test modules.
         """
@@ -180,21 +181,35 @@ class ConformanceSuiteClient:
             time.sleep(POLL_INTERVAL)
         return {"status": "TIMEOUT", "id": module_id}
 
-    def get_certification_package(self, plan_id: str) -> bytes:
-        """Download the OIDF certification package zip for a completed plan.
+    def download_plan_export(
+        self, plan_id: str, kind: str = "export"
+    ) -> tuple[str, bytes]:
+        """Download a plan-results export zip for a completed plan.
 
-        ``GET /api/plan/{plan_id}/certificationpackage`` returns a zip archive
-        bundling every test log in the plan — this is the artifact submitted to
-        the OpenID Foundation for certification. Uses a longer read timeout than
-        the default client because the suite generates the archive on demand and
-        bundling all logs can take a while.
+        ``kind`` is "export" (JSON + RSA signature — cheap, tamper-evident, the
+        suite's recommended CI artifact) or "exporthtml" (human-readable HTML).
+        The endpoint shape mirrors the suite's own ``scripts/conformance.py``
+        client: ``GET /api/plan/{kind}/{plan_id}``. Returns
+        ``(filename, zip_bytes)`` where ``filename`` comes from the
+        Content-Disposition header. Uses a longer read timeout than the default
+        client because the suite generates the archive on demand.
+
+        NOTE: this is NOT the OIDF certification package. The certification
+        package (``POST /api/plan/{plan_id}/certificationpackage``) additionally
+        requires a signed Certification of Conformance PDF and the RP
+        client-side logs zip, and it publishes and permanently freezes the plan.
+        That is the manual submission step (see #331) and is deliberately not
+        automated here.
         """
         response = self.client.get(
-            f"{self.base_url}/api/plan/{plan_id}/certificationpackage",
+            f"{self.base_url}/api/plan/{kind}/{plan_id}",
             timeout=120.0,
         )
         response.raise_for_status()
-        return response.content
+        disposition = response.headers.get("content-disposition", "")
+        match = re.findall(r'filename="(.+)"', disposition)
+        filename = match[0] if match else f"{plan_id}-{kind}.zip"
+        return filename, response.content
 
 
 # ---------------------------------------------------------------------------
@@ -656,28 +671,28 @@ def print_summary(results: list[TestResult]) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# Certification package gating
+# Plan export gating
 # ---------------------------------------------------------------------------
 
 
-def _should_download_package(
-    cert_package: str | None, suite_url: str, all_ok: bool
+def _should_download_export(
+    export_zip: str | None, suite_url: str, all_ok: bool
 ) -> tuple[bool, str | None]:
-    """Decide whether to download a certification package.
+    """Decide whether to download a plan-results export zip.
 
     Returns ``(do_download, skip_reason)``. ``skip_reason`` is ``None`` when
-    ``do_download`` is True. The package is only worth generating when a real
+    ``do_download`` is True. An export is only worth keeping when a real
     (hosted) suite ran every test to a passing/warning state — the local
-    conformance instance does not produce a valid OIDF package, and a run with
-    failures is not submission-worthy.
+    conformance instance is a throwaway regression shield, and a run with
+    failures is not evidence-worthy.
     """
-    if not cert_package:
+    if not export_zip:
         return False, None
     if _is_local_suite(suite_url):
         return (
             False,
-            "local suite does not produce a valid OIDF certification package; "
-            "run against a hosted suite (CONFORMANCE_SERVER) to generate one",
+            "local suite export is not useful evidence; run against a hosted "
+            "suite (CONFORMANCE_SERVER) to capture a signed plan export",
         )
     if not all_ok:
         return False, "not all tests passed"
@@ -720,11 +735,23 @@ def main() -> None:
         help="Path to write JSON results file",
     )
     parser.add_argument(
-        "--cert-package",
+        "--export-zip",
         default=None,
         help=(
-            "Path to write the OIDF certification package (.zip). Only honoured "
+            "Path to write the signed plan-results export (.zip) after a passing "
+            "hosted run. This is the suite's CI evidence artifact, NOT the OIDF "
+            "certification package (which is a manual, publish-and-freeze step "
+            "requiring a signed PDF — see conformance/README.md). Only honoured "
             "for a hosted suite when every test passes; ignored for local runs."
+        ),
+    )
+    parser.add_argument(
+        "--export-kind",
+        choices=["export", "exporthtml"],
+        default="export",
+        help=(
+            "Plan export format: 'export' (JSON + RSA signature, default) or "
+            "'exporthtml' (human-readable HTML)."
         ),
     )
     parser.add_argument(
@@ -812,25 +839,29 @@ def main() -> None:
         output_path.write_text(json.dumps(results_json, indent=2) + "\n")
         logger.info("Results written to %s", output_path)
 
-    # Download the certification package for submission-worthy hosted runs.
-    do_download, skip_reason = _should_download_package(
-        args.cert_package, args.suite_url, all_ok
+    # Download the signed plan export as evidence for submission-worthy hosted
+    # runs. This is NOT the OIDF certification package — see download_plan_export.
+    do_download, skip_reason = _should_download_export(
+        args.export_zip, args.suite_url, all_ok
     )
-    if args.cert_package and not do_download:
-        logger.warning("Certification package skipped: %s", skip_reason)
+    if args.export_zip and not do_download:
+        logger.warning("Plan export skipped: %s", skip_reason)
     elif do_download:
-        logger.info("Downloading certification package for plan %s...", plan_id)
+        logger.info("Downloading %s for plan %s...", args.export_kind, plan_id)
         download_client = ConformanceSuiteClient(
             args.suite_url, token=env_token or None
         )
-        package = download_client.get_certification_package(plan_id)
-        pkg_path = Path(args.cert_package)
-        pkg_path.parent.mkdir(parents=True, exist_ok=True)
-        pkg_path.write_bytes(package)
+        filename, content = download_client.download_plan_export(
+            plan_id, kind=args.export_kind
+        )
+        export_path = Path(args.export_zip)
+        export_path.parent.mkdir(parents=True, exist_ok=True)
+        export_path.write_bytes(content)
         logger.info(
-            "Certification package written to %s (%d bytes)",
-            pkg_path,
-            len(package),
+            "Plan export (%s) written to %s (%d bytes)",
+            filename,
+            export_path,
+            len(content),
         )
 
     sys.exit(0 if all_ok else 1)

--- a/conformance/run_tests.py
+++ b/conformance/run_tests.py
@@ -9,12 +9,12 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass
+from email.message import Message
 from html.parser import HTMLParser
 import json
 import logging
 import os
 from pathlib import Path
-import re
 import shutil
 import sys
 import time
@@ -53,6 +53,21 @@ def _is_local_suite(url: str) -> bool:
     """Check if the suite URL points to a local conformance instance."""
     hostname = urlparse(url).hostname or ""
     return hostname in LOCAL_HOSTNAMES
+
+
+def _parse_content_disposition_filename(disposition: str) -> str | None:
+    """Extract the filename from a ``Content-Disposition`` header.
+
+    Uses the stdlib ``email`` parser so quoted, token, and RFC 5987/2231
+    extended (``filename*=``) forms are all handled correctly, rather than a
+    greedy regex that over-captures multi-parameter headers and ignores
+    ``filename*``. Returns ``None`` when no filename is present.
+    """
+    if not disposition:
+        return None
+    msg = Message()
+    msg["content-disposition"] = disposition
+    return msg.get_filename()
 
 
 # ---------------------------------------------------------------------------
@@ -208,10 +223,22 @@ class ConformanceSuiteClient:
             timeout=120.0,
         )
         response.raise_for_status()
-        disposition = response.headers.get("content-disposition", "")
-        match = re.findall(r'filename="(.+)"', disposition)
-        filename = match[0] if match else f"{plan_id}-{kind}.zip"
-        return filename, response.content
+        content = response.content
+        # The export is a zip; a 200 carrying an HTML proxy-error page or an
+        # empty body would otherwise be written out as worthless "evidence".
+        if not content.startswith(b"PK"):
+            raise ValueError(
+                f"plan export for {plan_id!r} is not a zip "
+                f"(got {len(content)} bytes, content-type "
+                f"{response.headers.get('content-type', 'unknown')!r})"
+            )
+        filename = (
+            _parse_content_disposition_filename(
+                response.headers.get("content-disposition", "")
+            )
+            or f"{plan_id}-{kind}.zip"
+        )
+        return filename, content
 
 
 # ---------------------------------------------------------------------------
@@ -653,15 +680,27 @@ def run_plan(
     return plan_id, results
 
 
+# Statuses that count as a clean, submission-worthy outcome. Everything else —
+# FAILED/INTERRUPTED/TIMEOUT, REVIEW (needs a human), and any unknown status —
+# must keep an export from being treated as passing evidence. SKIPPED is fine
+# (e.g. the expected idtoken-sig-none skip); WARNING is an accepted pass.
+PASSING_STATUSES = frozenset({"PASSED", "WARNING", "SKIPPED"})
+
+
 def print_summary(results: list[TestResult]) -> bool:
-    """Print a summary table and return True if all passed/warned."""
+    """Print a summary table and return True only if the run is evidence-worthy.
+
+    Returns True when there is at least one result and every result is in
+    :data:`PASSING_STATUSES`. An empty run (no test ran) and any REVIEW/unknown
+    status both return False — "nothing ran" and "needs review" are not "all
+    passed", and neither should gate a certification export open.
+    """
     print("\n" + "=" * 70)
     print("CONFORMANCE TEST RESULTS")
     print("=" * 70)
     print(f"{'Test':<50} {'Result':<10}")
     print("-" * 70)
 
-    all_ok = True
     for r in results:
         symbol = {
             "PASSED": "PASS",
@@ -673,8 +712,8 @@ def print_summary(results: list[TestResult]) -> bool:
         print(f"{r.test_name:<50} [{symbol}]")
         if r.detail:
             print(f"  {r.detail}")
-        if r.status in ("FAILED", "INTERRUPTED", "TIMEOUT"):
-            all_ok = False
+
+    all_ok = bool(results) and all(r.status in PASSING_STATUSES for r in results)
 
     print("-" * 70)
     passed = sum(1 for r in results if r.status == "PASSED")
@@ -686,6 +725,8 @@ def print_summary(results: list[TestResult]) -> bool:
         f"Total: {len(results)} | Passed: {passed} | Warnings: {warned} | "
         f"Failed: {failed} | Review: {review} | Skipped: {skipped}"
     )
+    if not results:
+        print("No tests ran — not treating this as a passing run.")
     print("=" * 70)
 
     return all_ok
@@ -868,7 +909,18 @@ def main() -> None:
 
     # Reset this profile's RP-log directory so the zip only contains this run's
     # per-test logs (the harness appends, so stale files would otherwise leak in).
-    rp_log_profile_dir = _rp_log_dir() / args.plan
+    # Confine the rmtree target to the log base before deleting — args.plan is
+    # already constrained by argparse choices, but _reset_dir removes a tree, so
+    # a mistuned RP_LOG_DIR must never let it escape the intended directory.
+    rp_log_base = _rp_log_dir().resolve()
+    rp_log_profile_dir = (rp_log_base / args.plan).resolve()
+    if not rp_log_profile_dir.is_relative_to(rp_log_base):
+        logger.error(
+            "Refusing to use RP log dir outside base: %s not under %s",
+            rp_log_profile_dir,
+            rp_log_base,
+        )
+        sys.exit(1)
     if args.rp_logs_zip:
         _reset_dir(rp_log_profile_dir)
 
@@ -922,6 +974,7 @@ def main() -> None:
     do_download, skip_reason = _should_download_export(
         args.export_zip, args.suite_url, all_ok
     )
+    artifact_failed = False
     if args.export_zip and not do_download:
         logger.warning("Plan export skipped: %s", skip_reason)
     elif do_download:
@@ -929,18 +982,26 @@ def main() -> None:
         download_client = ConformanceSuiteClient(
             args.suite_url, token=env_token or None
         )
-        filename, content = download_client.download_plan_export(
-            plan_id, kind=args.export_kind
-        )
-        export_path = Path(args.export_zip)
-        export_path.parent.mkdir(parents=True, exist_ok=True)
-        export_path.write_bytes(content)
-        logger.info(
-            "Plan export (%s) written to %s (%d bytes)",
-            filename,
-            export_path,
-            len(content),
-        )
+        try:
+            filename, content = download_client.download_plan_export(
+                plan_id, kind=args.export_kind
+            )
+            export_path = Path(args.export_zip)
+            export_path.parent.mkdir(parents=True, exist_ok=True)
+            export_path.write_bytes(content)
+            logger.info(
+                "Plan export (%s) written to %s (%d bytes)",
+                filename,
+                export_path,
+                len(content),
+            )
+        except (httpx.HTTPError, ValueError, OSError) as exc:
+            # The run passed but we could not capture its evidence — fail loudly
+            # rather than exit 0 with a missing/corrupt export.
+            logger.error("Plan export failed for plan %s: %s", plan_id, exc)
+            artifact_failed = True
+        finally:
+            download_client.client.close()
 
     # Assemble the per-test RP client-side logs zip (clientSideData). Captured
     # regardless of pass/fail — the logs for failed tests are exactly what you'd
@@ -948,11 +1009,15 @@ def main() -> None:
     if args.rp_logs_zip:
         count = _zip_directory(rp_log_profile_dir, Path(args.rp_logs_zip))
         if count == 0:
-            logger.warning(
+            # An empty clientSideData bundle is worthless as a submission
+            # artifact, so an explicit --rp-logs-zip that captured nothing is a
+            # hard failure, not a warning that exits 0.
+            logger.error(
                 "No RP logs captured in %s — is the harness running this build "
                 "(it must receive test_name/profile and share RP_LOG_DIR)?",
                 rp_log_profile_dir,
             )
+            artifact_failed = True
         else:
             logger.info(
                 "RP client-side logs (%d files) written to %s",
@@ -960,7 +1025,7 @@ def main() -> None:
                 args.rp_logs_zip,
             )
 
-    sys.exit(0 if all_ok else 1)
+    sys.exit(0 if (all_ok and not artifact_failed) else 1)
 
 
 if __name__ == "__main__":

--- a/conformance/run_tests.py
+++ b/conformance/run_tests.py
@@ -88,9 +88,19 @@ class ConformanceSuiteClient:
         )
 
     def create_plan(
-        self, plan_name: str, variant: dict, alias: str, rp_base_url: str = RP_BASE_URL
+        self,
+        plan_name: str,
+        variant: dict,
+        alias: str,
+        rp_base_url: str = RP_BASE_URL,
+        publish: str = "",
     ) -> dict:
         """Create a test plan.
+
+        ``publish`` controls whether the suite makes the plan's results publicly
+        visible on the published-tests list: "" (default) keeps it private,
+        "summary" / "everything" publish it. The downloadable certification
+        package is produced regardless of this setting.
 
         Returns the plan response including plan ID and list of test modules.
         """
@@ -98,7 +108,7 @@ class ConformanceSuiteClient:
         plan_config = {
             "alias": alias,
             "description": f"py-identity-model conformance: {alias}",
-            "publish": "",
+            "publish": publish,
             "server": {
                 "discoveryUrl": "",
             },
@@ -169,6 +179,22 @@ class ConformanceSuiteClient:
             logger.debug("Test %s status: %s", module_id, status)
             time.sleep(POLL_INTERVAL)
         return {"status": "TIMEOUT", "id": module_id}
+
+    def get_certification_package(self, plan_id: str) -> bytes:
+        """Download the OIDF certification package zip for a completed plan.
+
+        ``GET /api/plan/{plan_id}/certificationpackage`` returns a zip archive
+        bundling every test log in the plan — this is the artifact submitted to
+        the OpenID Foundation for certification. Uses a longer read timeout than
+        the default client because the suite generates the archive on demand and
+        bundling all logs can take a while.
+        """
+        response = self.client.get(
+            f"{self.base_url}/api/plan/{plan_id}/certificationpackage",
+            timeout=120.0,
+        )
+        response.raise_for_status()
+        return response.content
 
 
 # ---------------------------------------------------------------------------
@@ -523,6 +549,7 @@ def run_plan(
     suite_base_url: str = SUITE_BASE_URL,
     rp_base_url: str = RP_BASE_URL,
     token: str | None = None,
+    publish: str = "",
 ) -> tuple[str, list[TestResult]]:
     """Run all tests in a conformance test plan.
 
@@ -544,7 +571,7 @@ def run_plan(
     # Create the test plan
     logger.info("Creating test plan...")
     plan_response = suite.create_plan(
-        plan_name, variant, alias, rp_base_url=rp_base_url
+        plan_name, variant, alias, rp_base_url=rp_base_url, publish=publish
     )
     plan_id = plan_response.get("id", "")
     modules = plan_response.get("modules", [])
@@ -629,6 +656,35 @@ def print_summary(results: list[TestResult]) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Certification package gating
+# ---------------------------------------------------------------------------
+
+
+def _should_download_package(
+    cert_package: str | None, suite_url: str, all_ok: bool
+) -> tuple[bool, str | None]:
+    """Decide whether to download a certification package.
+
+    Returns ``(do_download, skip_reason)``. ``skip_reason`` is ``None`` when
+    ``do_download`` is True. The package is only worth generating when a real
+    (hosted) suite ran every test to a passing/warning state — the local
+    conformance instance does not produce a valid OIDF package, and a run with
+    failures is not submission-worthy.
+    """
+    if not cert_package:
+        return False, None
+    if _is_local_suite(suite_url):
+        return (
+            False,
+            "local suite does not produce a valid OIDF certification package; "
+            "run against a hosted suite (CONFORMANCE_SERVER) to generate one",
+        )
+    if not all_ok:
+        return False, "not all tests passed"
+    return True, None
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -664,6 +720,24 @@ def main() -> None:
         help="Path to write JSON results file",
     )
     parser.add_argument(
+        "--cert-package",
+        default=None,
+        help=(
+            "Path to write the OIDF certification package (.zip). Only honoured "
+            "for a hosted suite when every test passes; ignored for local runs."
+        ),
+    )
+    parser.add_argument(
+        "--publish",
+        choices=["none", "summary", "everything"],
+        default="none",
+        help=(
+            "Publish results on the suite's public published-tests list "
+            "(default: none — keep private). The certification package is "
+            "produced regardless."
+        ),
+    )
+    parser.add_argument(
         "--verbose",
         "-v",
         action="store_true",
@@ -692,11 +766,14 @@ def main() -> None:
         logger.error("Config not found: %s", config_path)
         sys.exit(1)
 
+    publish_value = "" if args.publish == "none" else args.publish
+
     plan_id, results = run_plan(
         config_path=str(config_path),
         suite_base_url=args.suite_url,
         rp_base_url=args.rp_url,
         token=env_token or None,
+        publish=publish_value,
     )
 
     all_ok = print_summary(results)
@@ -734,6 +811,27 @@ def main() -> None:
         }
         output_path.write_text(json.dumps(results_json, indent=2) + "\n")
         logger.info("Results written to %s", output_path)
+
+    # Download the certification package for submission-worthy hosted runs.
+    do_download, skip_reason = _should_download_package(
+        args.cert_package, args.suite_url, all_ok
+    )
+    if args.cert_package and not do_download:
+        logger.warning("Certification package skipped: %s", skip_reason)
+    elif do_download:
+        logger.info("Downloading certification package for plan %s...", plan_id)
+        download_client = ConformanceSuiteClient(
+            args.suite_url, token=env_token or None
+        )
+        package = download_client.get_certification_package(plan_id)
+        pkg_path = Path(args.cert_package)
+        pkg_path.parent.mkdir(parents=True, exist_ok=True)
+        pkg_path.write_bytes(package)
+        logger.info(
+            "Certification package written to %s (%d bytes)",
+            pkg_path,
+            len(package),
+        )
 
     sys.exit(0 if all_ok else 1)
 

--- a/conformance/tests/test_cert_package.py
+++ b/conformance/tests/test_cert_package.py
@@ -1,0 +1,136 @@
+"""Tests for certification-package download in conformance/run_tests.py.
+
+These cover the pieces that make a hosted run *submission-capable*:
+
+- ``ConformanceSuiteClient.get_certification_package`` — the REST call that
+  downloads the signed zip submitted to the OpenID Foundation.
+- ``ConformanceSuiteClient.create_plan`` honouring the ``publish`` setting.
+- ``_should_download_package`` — the gate deciding when a package is worth
+  generating (hosted suite + all tests passed only).
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+from run_tests import ConformanceSuiteClient, _should_download_package
+
+
+HOSTED_URL = "https://www.certification.openid.net"
+LOCAL_URL = "https://localhost.emobix.co.uk:8443"
+
+
+# ---------------------------------------------------------------------------
+# get_certification_package
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_get_certification_package_returns_zip_bytes() -> None:
+    plan_id = "abc123"
+    zip_bytes = b"PK\x03\x04 fake-zip-payload"
+    route = respx.get(f"{HOSTED_URL}/api/plan/{plan_id}/certificationpackage").mock(
+        return_value=httpx.Response(200, content=zip_bytes)
+    )
+
+    client = ConformanceSuiteClient(HOSTED_URL, token="tok-123")
+    result = client.get_certification_package(plan_id)
+
+    assert result == zip_bytes
+    assert route.called
+
+
+@respx.mock
+def test_get_certification_package_sends_bearer_token() -> None:
+    plan_id = "plan-xyz"
+    route = respx.get(f"{HOSTED_URL}/api/plan/{plan_id}/certificationpackage").mock(
+        return_value=httpx.Response(200, content=b"zip")
+    )
+
+    client = ConformanceSuiteClient(HOSTED_URL, token="secret-token")
+    client.get_certification_package(plan_id)
+
+    assert route.calls.last.request.headers["Authorization"] == "Bearer secret-token"
+
+
+@respx.mock
+def test_get_certification_package_raises_on_error_status() -> None:
+    plan_id = "missing"
+    respx.get(f"{HOSTED_URL}/api/plan/{plan_id}/certificationpackage").mock(
+        return_value=httpx.Response(404)
+    )
+
+    client = ConformanceSuiteClient(HOSTED_URL, token="tok")
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        client.get_certification_package(plan_id)
+
+    assert exc_info.value.response.status_code == httpx.codes.NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
+# create_plan publish wiring
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_create_plan_sends_publish_value() -> None:
+    route = respx.post(f"{HOSTED_URL}/api/plan").mock(
+        return_value=httpx.Response(200, json={"id": "p1", "modules": []})
+    )
+
+    client = ConformanceSuiteClient(HOSTED_URL, token="tok")
+    client.create_plan(
+        "oidcc-client-basic-certification-test-plan",
+        {"client_registration": "static_client"},
+        "py-identity-model-basic-rp",
+        publish="summary",
+    )
+
+    body = json.loads(route.calls.last.request.content)
+    assert body["publish"] == "summary"
+
+
+@respx.mock
+def test_create_plan_defaults_publish_to_empty() -> None:
+    route = respx.post(f"{HOSTED_URL}/api/plan").mock(
+        return_value=httpx.Response(200, json={"id": "p1", "modules": []})
+    )
+
+    client = ConformanceSuiteClient(HOSTED_URL, token="tok")
+    client.create_plan("plan", {}, "alias")
+
+    body = json.loads(route.calls.last.request.content)
+    assert body["publish"] == ""
+
+
+# ---------------------------------------------------------------------------
+# _should_download_package gate
+# ---------------------------------------------------------------------------
+
+
+def test_no_cert_package_path_means_no_download() -> None:
+    do_download, reason = _should_download_package(None, HOSTED_URL, all_ok=True)
+    assert do_download is False
+    assert reason is None
+
+
+def test_local_suite_skips_download() -> None:
+    do_download, reason = _should_download_package("out.zip", LOCAL_URL, all_ok=True)
+    assert do_download is False
+    assert reason is not None
+    assert "local suite" in reason
+
+
+def test_failed_run_skips_download() -> None:
+    do_download, reason = _should_download_package("out.zip", HOSTED_URL, all_ok=False)
+    assert do_download is False
+    assert reason == "not all tests passed"
+
+
+def test_hosted_passing_run_downloads() -> None:
+    do_download, reason = _should_download_package("out.zip", HOSTED_URL, all_ok=True)
+    assert do_download is True
+    assert reason is None

--- a/conformance/tests/test_plan_export.py
+++ b/conformance/tests/test_plan_export.py
@@ -20,11 +20,20 @@ import json
 import httpx
 import pytest
 import respx
-from run_tests import ConformanceSuiteClient, _should_download_export
+from run_tests import (
+    ConformanceSuiteClient,
+    _parse_content_disposition_filename,
+    _should_download_export,
+    print_summary,
+)
+from run_tests import TestResult as _TestResult  # aliased: avoid pytest collection
 
 
 HOSTED_URL = "https://www.certification.openid.net"
 LOCAL_URL = "https://localhost.emobix.co.uk:8443"
+
+# Minimal valid zip magic — download_plan_export rejects non-zip payloads.
+ZIP_MAGIC = b"PK\x03\x04"
 
 
 # ---------------------------------------------------------------------------
@@ -35,7 +44,7 @@ LOCAL_URL = "https://localhost.emobix.co.uk:8443"
 @respx.mock
 def test_download_plan_export_returns_filename_and_bytes() -> None:
     plan_id = "abc123"
-    zip_bytes = b"PK\x03\x04 fake-export-payload"
+    zip_bytes = ZIP_MAGIC + b" fake-export-payload"
     route = respx.get(f"{HOSTED_URL}/api/plan/export/{plan_id}").mock(
         return_value=httpx.Response(
             200,
@@ -56,7 +65,7 @@ def test_download_plan_export_returns_filename_and_bytes() -> None:
 def test_download_plan_export_uses_kind_in_path() -> None:
     plan_id = "p1"
     route = respx.get(f"{HOSTED_URL}/api/plan/exporthtml/{plan_id}").mock(
-        return_value=httpx.Response(200, content=b"zip")
+        return_value=httpx.Response(200, content=ZIP_MAGIC + b"zip")
     )
 
     client = ConformanceSuiteClient(HOSTED_URL, token="tok")
@@ -69,7 +78,7 @@ def test_download_plan_export_uses_kind_in_path() -> None:
 def test_download_plan_export_falls_back_when_no_disposition() -> None:
     plan_id = "noheader"
     respx.get(f"{HOSTED_URL}/api/plan/export/{plan_id}").mock(
-        return_value=httpx.Response(200, content=b"zip")
+        return_value=httpx.Response(200, content=ZIP_MAGIC + b"zip")
     )
 
     client = ConformanceSuiteClient(HOSTED_URL, token="tok")
@@ -79,10 +88,56 @@ def test_download_plan_export_falls_back_when_no_disposition() -> None:
 
 
 @respx.mock
+def test_download_plan_export_no_over_capture_on_multiparam() -> None:
+    # The old greedy regex (filename="(.+)") would swallow trailing parameters;
+    # the quoted value must be parsed exactly.
+    plan_id = "pmulti"
+    respx.get(f"{HOSTED_URL}/api/plan/export/{plan_id}").mock(
+        return_value=httpx.Response(
+            200,
+            content=ZIP_MAGIC + b"zip",
+            headers={
+                "content-disposition": 'attachment; filename="real.zip"; foo="bar"'
+            },
+        )
+    )
+
+    client = ConformanceSuiteClient(HOSTED_URL, token="tok")
+    filename, _ = client.download_plan_export(plan_id)
+
+    assert filename == "real.zip"
+
+
+@respx.mock
+def test_download_plan_export_rejects_non_zip_payload() -> None:
+    # A 200 carrying an HTML proxy-error page must not be written as evidence.
+    plan_id = "htmlerror"
+    respx.get(f"{HOSTED_URL}/api/plan/export/{plan_id}").mock(
+        return_value=httpx.Response(200, content=b"<html>502 Bad Gateway</html>")
+    )
+
+    client = ConformanceSuiteClient(HOSTED_URL, token="tok")
+    with pytest.raises(ValueError, match="not a zip"):
+        client.download_plan_export(plan_id)
+
+
+@respx.mock
+def test_download_plan_export_rejects_empty_payload() -> None:
+    plan_id = "empty"
+    respx.get(f"{HOSTED_URL}/api/plan/export/{plan_id}").mock(
+        return_value=httpx.Response(200, content=b"")
+    )
+
+    client = ConformanceSuiteClient(HOSTED_URL, token="tok")
+    with pytest.raises(ValueError, match="not a zip"):
+        client.download_plan_export(plan_id)
+
+
+@respx.mock
 def test_download_plan_export_sends_bearer_token() -> None:
     plan_id = "plan-xyz"
     route = respx.get(f"{HOSTED_URL}/api/plan/export/{plan_id}").mock(
-        return_value=httpx.Response(200, content=b"zip")
+        return_value=httpx.Response(200, content=ZIP_MAGIC + b"zip")
     )
 
     client = ConformanceSuiteClient(HOSTED_URL, token="secret-token")
@@ -103,6 +158,34 @@ def test_download_plan_export_raises_on_error_status() -> None:
         client.download_plan_export(plan_id)
 
     assert exc_info.value.response.status_code == httpx.codes.NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
+# Content-Disposition filename parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_content_disposition_quoted() -> None:
+    assert (
+        _parse_content_disposition_filename('attachment; filename="a b.zip"')
+        == "a b.zip"
+    )
+
+
+def test_parse_content_disposition_extended_form() -> None:
+    # RFC 5987 percent-encoded extended filename is decoded with its charset.
+    disposition = "attachment; filename*=UTF-8''r%C3%A9el.zip"
+    assert _parse_content_disposition_filename(disposition) == "réel.zip"
+
+
+def test_parse_content_disposition_no_over_capture() -> None:
+    disposition = 'attachment; filename="real.zip"; foo="bar"'
+    assert _parse_content_disposition_filename(disposition) == "real.zip"
+
+
+def test_parse_content_disposition_absent_returns_none() -> None:
+    assert _parse_content_disposition_filename("attachment") is None
+    assert _parse_content_disposition_filename("") is None
 
 
 # ---------------------------------------------------------------------------
@@ -169,3 +252,38 @@ def test_hosted_passing_run_downloads() -> None:
     do_download, reason = _should_download_export("out.zip", HOSTED_URL, all_ok=True)
     assert do_download is True
     assert reason is None
+
+
+# ---------------------------------------------------------------------------
+# print_summary evidence gate (drives all_ok → export gating + exit code)
+# ---------------------------------------------------------------------------
+
+
+def _result(status: str) -> _TestResult:
+    return _TestResult(test_name=f"t-{status}", test_id="id", status=status)
+
+
+def test_summary_empty_run_is_not_passing() -> None:
+    # "nothing ran" must not count as all-passed evidence.
+    assert print_summary([]) is False
+
+
+def test_summary_all_passing_statuses_pass() -> None:
+    results = [_result("PASSED"), _result("WARNING"), _result("SKIPPED")]
+    assert print_summary(results) is True
+
+
+def test_summary_review_status_blocks_pass() -> None:
+    # REVIEW needs a human — it must not gate an export open.
+    results = [_result("PASSED"), _result("REVIEW")]
+    assert print_summary(results) is False
+
+
+def test_summary_failed_status_blocks_pass() -> None:
+    results = [_result("PASSED"), _result("FAILED")]
+    assert print_summary(results) is False
+
+
+def test_summary_unknown_status_blocks_pass() -> None:
+    results = [_result("PASSED"), _result("WEIRD")]
+    assert print_summary(results) is False

--- a/conformance/tests/test_plan_export.py
+++ b/conformance/tests/test_plan_export.py
@@ -1,12 +1,16 @@
-"""Tests for certification-package download in conformance/run_tests.py.
+"""Tests for plan-export download in conformance/run_tests.py.
 
-These cover the pieces that make a hosted run *submission-capable*:
+These cover the pieces that let a hosted run capture evidence artifacts:
 
-- ``ConformanceSuiteClient.get_certification_package`` — the REST call that
-  downloads the signed zip submitted to the OpenID Foundation.
+- ``ConformanceSuiteClient.download_plan_export`` — the read-only REST call that
+  downloads the signed plan export zip (``GET /api/plan/{kind}/{plan_id}``).
 - ``ConformanceSuiteClient.create_plan`` honouring the ``publish`` setting.
-- ``_should_download_package`` — the gate deciding when a package is worth
-  generating (hosted suite + all tests passed only).
+- ``_should_download_export`` — the gate deciding when an export is worth
+  keeping (hosted suite + all tests passed only).
+
+The export is deliberately distinct from the OIDF *certification package* (a
+manual, publish-and-freeze ``POST .../certificationpackage`` step requiring a
+signed PDF), which is not exercised here.
 """
 
 from __future__ import annotations
@@ -16,7 +20,7 @@ import json
 import httpx
 import pytest
 import respx
-from run_tests import ConformanceSuiteClient, _should_download_package
+from run_tests import ConformanceSuiteClient, _should_download_export
 
 
 HOSTED_URL = "https://www.certification.openid.net"
@@ -24,48 +28,79 @@ LOCAL_URL = "https://localhost.emobix.co.uk:8443"
 
 
 # ---------------------------------------------------------------------------
-# get_certification_package
+# download_plan_export
 # ---------------------------------------------------------------------------
 
 
 @respx.mock
-def test_get_certification_package_returns_zip_bytes() -> None:
+def test_download_plan_export_returns_filename_and_bytes() -> None:
     plan_id = "abc123"
-    zip_bytes = b"PK\x03\x04 fake-zip-payload"
-    route = respx.get(f"{HOSTED_URL}/api/plan/{plan_id}/certificationpackage").mock(
-        return_value=httpx.Response(200, content=zip_bytes)
+    zip_bytes = b"PK\x03\x04 fake-export-payload"
+    route = respx.get(f"{HOSTED_URL}/api/plan/export/{plan_id}").mock(
+        return_value=httpx.Response(
+            200,
+            content=zip_bytes,
+            headers={"content-disposition": 'attachment; filename="plan-abc123.zip"'},
+        )
     )
 
     client = ConformanceSuiteClient(HOSTED_URL, token="tok-123")
-    result = client.get_certification_package(plan_id)
+    filename, content = client.download_plan_export(plan_id)
 
-    assert result == zip_bytes
+    assert content == zip_bytes
+    assert filename == "plan-abc123.zip"
     assert route.called
 
 
 @respx.mock
-def test_get_certification_package_sends_bearer_token() -> None:
+def test_download_plan_export_uses_kind_in_path() -> None:
+    plan_id = "p1"
+    route = respx.get(f"{HOSTED_URL}/api/plan/exporthtml/{plan_id}").mock(
+        return_value=httpx.Response(200, content=b"zip")
+    )
+
+    client = ConformanceSuiteClient(HOSTED_URL, token="tok")
+    client.download_plan_export(plan_id, kind="exporthtml")
+
+    assert route.called
+
+
+@respx.mock
+def test_download_plan_export_falls_back_when_no_disposition() -> None:
+    plan_id = "noheader"
+    respx.get(f"{HOSTED_URL}/api/plan/export/{plan_id}").mock(
+        return_value=httpx.Response(200, content=b"zip")
+    )
+
+    client = ConformanceSuiteClient(HOSTED_URL, token="tok")
+    filename, _ = client.download_plan_export(plan_id)
+
+    assert filename == "noheader-export.zip"
+
+
+@respx.mock
+def test_download_plan_export_sends_bearer_token() -> None:
     plan_id = "plan-xyz"
-    route = respx.get(f"{HOSTED_URL}/api/plan/{plan_id}/certificationpackage").mock(
+    route = respx.get(f"{HOSTED_URL}/api/plan/export/{plan_id}").mock(
         return_value=httpx.Response(200, content=b"zip")
     )
 
     client = ConformanceSuiteClient(HOSTED_URL, token="secret-token")
-    client.get_certification_package(plan_id)
+    client.download_plan_export(plan_id)
 
     assert route.calls.last.request.headers["Authorization"] == "Bearer secret-token"
 
 
 @respx.mock
-def test_get_certification_package_raises_on_error_status() -> None:
+def test_download_plan_export_raises_on_error_status() -> None:
     plan_id = "missing"
-    respx.get(f"{HOSTED_URL}/api/plan/{plan_id}/certificationpackage").mock(
+    respx.get(f"{HOSTED_URL}/api/plan/export/{plan_id}").mock(
         return_value=httpx.Response(404)
     )
 
     client = ConformanceSuiteClient(HOSTED_URL, token="tok")
     with pytest.raises(httpx.HTTPStatusError) as exc_info:
-        client.get_certification_package(plan_id)
+        client.download_plan_export(plan_id)
 
     assert exc_info.value.response.status_code == httpx.codes.NOT_FOUND
 
@@ -107,30 +142,30 @@ def test_create_plan_defaults_publish_to_empty() -> None:
 
 
 # ---------------------------------------------------------------------------
-# _should_download_package gate
+# _should_download_export gate
 # ---------------------------------------------------------------------------
 
 
-def test_no_cert_package_path_means_no_download() -> None:
-    do_download, reason = _should_download_package(None, HOSTED_URL, all_ok=True)
+def test_no_export_path_means_no_download() -> None:
+    do_download, reason = _should_download_export(None, HOSTED_URL, all_ok=True)
     assert do_download is False
     assert reason is None
 
 
 def test_local_suite_skips_download() -> None:
-    do_download, reason = _should_download_package("out.zip", LOCAL_URL, all_ok=True)
+    do_download, reason = _should_download_export("out.zip", LOCAL_URL, all_ok=True)
     assert do_download is False
     assert reason is not None
     assert "local suite" in reason
 
 
 def test_failed_run_skips_download() -> None:
-    do_download, reason = _should_download_package("out.zip", HOSTED_URL, all_ok=False)
+    do_download, reason = _should_download_export("out.zip", HOSTED_URL, all_ok=False)
     assert do_download is False
     assert reason == "not all tests passed"
 
 
 def test_hosted_passing_run_downloads() -> None:
-    do_download, reason = _should_download_package("out.zip", HOSTED_URL, all_ok=True)
+    do_download, reason = _should_download_export("out.zip", HOSTED_URL, all_ok=True)
     assert do_download is True
     assert reason is None

--- a/conformance/tests/test_rp_logs.py
+++ b/conformance/tests/test_rp_logs.py
@@ -15,7 +15,20 @@ import logging
 import zipfile
 
 import app as harness_app
+import pytest
 from run_tests import _reset_dir, _rp_log_dir, _zip_directory
+
+
+@pytest.fixture(autouse=True)
+def _reset_active_test():
+    """Keep the process-wide active-test pointer from leaking across tests.
+
+    Tests poke ``_set_active_test`` directly; an early failure before a manual
+    reset would otherwise route a later test's records to a stale file.
+    """
+    harness_app._set_active_test(None, None)
+    yield
+    harness_app._set_active_test(None, None)
 
 
 # ---------------------------------------------------------------------------
@@ -56,12 +69,38 @@ def test_rp_log_path_sanitises_and_creates_dir(tmp_path, monkeypatch) -> None:
     assert path.parent.is_dir()
 
 
+def test_rp_log_path_collapses_dot_only_components(tmp_path, monkeypatch) -> None:
+    # A profile of ".." survives the character class (all dots) but must not be
+    # allowed to walk out of the base — it collapses to the fallback segment.
+    monkeypatch.setenv("RP_LOG_DIR", str(tmp_path))
+    base = tmp_path.resolve()
+    path = harness_app._rp_log_path("..", "..")
+
+    assert path == base / "default" / "unknown.log"
+    assert base in path.parents
+
+
+def test_rp_log_path_router_drops_dot_only_without_writing_outside(
+    tmp_path, monkeypatch
+) -> None:
+    # End-to-end: routing a record for a dot-only profile/test writes inside the
+    # base (collapsed), never a sibling of it.
+    monkeypatch.setenv("RP_LOG_DIR", str(tmp_path / "base"))
+    harness_app._set_active_test("..", "..")
+    logging.getLogger("conformance-rp").error("REJECTED: dotty")
+
+    assert not list((tmp_path).glob("*.log"))  # nothing beside the base
+    written = list((tmp_path / "base").rglob("*.log"))
+    assert [p.name for p in written] == ["unknown.log"]
+
+
 def test_set_active_test_clears_on_empty_name() -> None:
     harness_app._set_active_test("basic-rp", "")
-    assert harness_app._active_test is None
+    assert harness_app._get_active_test() is None
     harness_app._set_active_test("basic-rp", "some-test")
-    assert harness_app._active_test == ("basic-rp", "some-test")
+    assert harness_app._get_active_test() == ("basic-rp", "some-test")
     harness_app._set_active_test(None, None)
+    assert harness_app._get_active_test() is None
 
 
 # ---------------------------------------------------------------------------

--- a/conformance/tests/test_rp_logs.py
+++ b/conformance/tests/test_rp_logs.py
@@ -46,11 +46,13 @@ def test_router_silent_when_no_active_test(tmp_path, monkeypatch) -> None:
 
 def test_rp_log_path_sanitises_and_creates_dir(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("RP_LOG_DIR", str(tmp_path))
+    base = tmp_path.resolve()
     path = harness_app._rp_log_path("basic/rp", "oidcc/../evil")
 
     # Path separators in either component are neutralised — no escaping the base.
-    assert path.parent == tmp_path / "basic_rp"
     assert path.name == "oidcc_.._evil.log"
+    assert path.parent == base / "basic_rp"
+    assert base in path.parents
     assert path.parent.is_dir()
 
 

--- a/conformance/tests/test_rp_logs.py
+++ b/conformance/tests/test_rp_logs.py
@@ -1,0 +1,122 @@
+"""Tests for per-test RP client-side log capture.
+
+Covers both halves of the `clientSideData` feature:
+
+- Harness side (`app.py`): the per-test log router writes each active test's
+  records to `<RP_LOG_DIR>/<profile>/<test_name>.log`, sanitises names, and
+  stays silent when no test is active.
+- Runner side (`run_tests.py`): the directory reset + flat-zip helpers that
+  assemble the per-profile RP-logs bundle, and the shared `RP_LOG_DIR` default.
+"""
+
+from __future__ import annotations
+
+import logging
+import zipfile
+
+import app as harness_app
+from run_tests import _reset_dir, _rp_log_dir, _zip_directory
+
+
+# ---------------------------------------------------------------------------
+# Harness: per-test log router (app.py)
+# ---------------------------------------------------------------------------
+
+
+def test_router_writes_active_test_log(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("RP_LOG_DIR", str(tmp_path))
+    harness_app._set_active_test("basic-rp", "oidcc-client-test-invalid-iss")
+    try:
+        logging.getLogger("conformance-rp").error("REJECTED: bad iss")
+    finally:
+        harness_app._set_active_test(None, None)
+
+    log_file = tmp_path / "basic-rp" / "oidcc-client-test-invalid-iss.log"
+    assert log_file.exists()
+    assert "REJECTED: bad iss" in log_file.read_text()
+
+
+def test_router_silent_when_no_active_test(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("RP_LOG_DIR", str(tmp_path))
+    harness_app._set_active_test(None, None)
+    logging.getLogger("conformance-rp").error("must not be written anywhere")
+
+    assert not list(tmp_path.rglob("*.log"))
+
+
+def test_rp_log_path_sanitises_and_creates_dir(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("RP_LOG_DIR", str(tmp_path))
+    path = harness_app._rp_log_path("basic/rp", "oidcc/../evil")
+
+    # Path separators in either component are neutralised — no escaping the base.
+    assert path.parent == tmp_path / "basic_rp"
+    assert path.name == "oidcc_.._evil.log"
+    assert path.parent.is_dir()
+
+
+def test_set_active_test_clears_on_empty_name() -> None:
+    harness_app._set_active_test("basic-rp", "")
+    assert harness_app._active_test is None
+    harness_app._set_active_test("basic-rp", "some-test")
+    assert harness_app._active_test == ("basic-rp", "some-test")
+    harness_app._set_active_test(None, None)
+
+
+# ---------------------------------------------------------------------------
+# Runner: bundle assembly (run_tests.py)
+# ---------------------------------------------------------------------------
+
+
+def test_zip_directory_zips_files_flat(tmp_path) -> None:
+    src = tmp_path / "config-rp"
+    src.mkdir()
+    (src / "test-a.log").write_text("a")
+    (src / "test-b.log").write_text("b")
+    nested = src / "sub"
+    nested.mkdir()
+    (nested / "ignored.log").write_text("c")  # directories are not recursed
+
+    out = tmp_path / "bundle.zip"
+    count = _zip_directory(src, out)
+
+    expected_files = ["test-a.log", "test-b.log"]
+    assert count == len(expected_files)
+    with zipfile.ZipFile(out) as zf:
+        assert sorted(zf.namelist()) == expected_files
+
+
+def test_zip_directory_empty_dir_writes_empty_zip(tmp_path) -> None:
+    src = tmp_path / "empty"
+    src.mkdir()
+    out = tmp_path / "bundle.zip"
+
+    assert _zip_directory(src, out) == 0
+    with zipfile.ZipFile(out) as zf:
+        assert zf.namelist() == []
+
+
+def test_reset_dir_clears_existing_contents(tmp_path) -> None:
+    d = tmp_path / "profile"
+    d.mkdir()
+    (d / "stale.log").write_text("old")
+
+    _reset_dir(d)
+
+    assert d.is_dir()
+    assert list(d.iterdir()) == []
+
+
+def test_reset_dir_creates_when_absent(tmp_path) -> None:
+    d = tmp_path / "missing" / "profile"
+    _reset_dir(d)
+    assert d.is_dir()
+
+
+def test_rp_log_dir_honours_env(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("RP_LOG_DIR", str(tmp_path))
+    assert _rp_log_dir() == tmp_path
+
+
+def test_rp_log_dir_default_is_absolute(monkeypatch) -> None:
+    monkeypatch.delenv("RP_LOG_DIR", raising=False)
+    assert _rp_log_dir().is_absolute()

--- a/docs/certification.md
+++ b/docs/certification.md
@@ -1,0 +1,173 @@
+# OpenID Connect Certification
+
+This page documents how py-identity-model is tested for, and submitted to, the
+[OpenID Foundation conformance program](https://openid.net/certification/) as a
+certified **Relying Party (RP)** library, and how the submission artifacts are
+generated from this repository.
+
+## What is certified
+
+The **library itself** is the certified deployment — listed as
+`py-identity-model <version>`, the same model Roland Hedberg used for
+`pyoidc`/`oidcrp` and Duende used for `IdentityModel.OidcClient`. The
+`conformance/` harness is **disposable scaffolding** that drives the library
+through the OIDF conformance suite; it is not shipped, versioned, or certified.
+
+Target profiles (all passing against `certification.openid.net`):
+
+| Profile | Plan | Result |
+|---------|------|--------|
+| Basic RP | `oidcc-client-basic-certification-test-plan` | 13 pass / 1 skip |
+| Config RP | `oidcc-client-config-certification-test-plan` | 5 pass / 1 skip |
+| Form Post Basic RP | `oidcc-client-formpost-basic-certification-test-plan` | 13 pass / 1 skip |
+
+The single skip per profile is `oidcc-client-test-idtoken-sig-none` — expected,
+because py-identity-model correctly rejects unsigned ID tokens (secure default).
+
+## The harness
+
+- `conformance/app.py` — a thin FastAPI RP that exercises the library's public
+  API (discovery, auth-code + PKCE, token validation, UserInfo).
+- `conformance/run_tests.py` — drives the suite's REST API and walks the RP
+  through each test module. Works against the local Docker suite (regression)
+  or the hosted suite (submission-grade).
+- `conformance/docker-compose.yml` — the local OIDF suite for regression CI.
+
+See `conformance/README.md` for the operational details (setup, SSL, token
+rotation).
+
+## Submission artifacts
+
+An OIDF RP submission needs **two artifacts per profile**, both produced by a
+hosted run:
+
+### 1. Signed plan export (suite-side evidence)
+
+Downloaded from `GET /api/plan/{kind}/{plan_id}` — the `export` variant is a
+JSON + RSA-signature zip (the format the suite recommends for automation).
+Produced by `run_tests.py --export-zip <path>` (gated to a hosted suite when
+every test passes). This is **not** the certification package — see
+[Submitting to OIDF](#submitting-to-oidf).
+
+### 2. RP client-side logs (`clientSideData`)
+
+OIDF requires **one log file per test, named by the test id**, demonstrating
+the RP's behaviour — in particular that negative tests are *rejected*
+([submission rules](https://openid.net/certification/connect_rp_submission/)).
+The conformance suite only logs the OP side, so the RP harness produces these
+itself.
+
+#### How the logs are generated
+
+The harness and runner are separate processes, so capture is split:
+
+1. **Runner tags each test.** For every test module, `run_test_module` →
+   `drive_rp_authorize` / `drive_rp_discover` pass the suite's `test_name` and
+   the `profile` to the harness as query params. The `/clear-cache` call before
+   each test also clears the active-test pointer.
+2. **Harness routes records per active test.** `_set_active_test(profile,
+   test_name)` sets a process-global pointer at `/authorize` and `/discover`,
+   and re-establishes it in `/callback` (recovered from the session, since the
+   OP redirect carries only `state`). A `logging.Handler` attached to the
+   `conformance-rp` (harness) and `py_identity_model` (library, DEBUG) loggers
+   appends every record to `<RP_LOG_DIR>/<profile>/<test_name>.log`. Explicit
+   `ACCEPTED` / `REJECTED: <reason>` lines are logged at each decision point.
+3. **Runner bundles per profile.** `--rp-logs-zip <path>` resets the
+   per-profile directory before the run and zips it after — one file per test.
+
+The runner drives tests strictly sequentially, so a single process-global
+pointer is sufficient. `RP_LOG_DIR` defaults to an absolute path derived from
+the source location so the harness and the separately-launched runner agree on
+it regardless of working directory (override it for *both* processes if you
+change it).
+
+A negative test log shows both the library's own rejection and the harness
+decision, e.g.:
+
+```
+py_identity_model: Invalid issuer
+conformance-rp: REJECTED: id_token validation failed: Invalid issuer
+```
+
+A positive test log shows the full acceptance trail:
+
+```
+conformance-rp: ACCEPTED: id_token validated by py-identity-model (signature, issuer, audience, expiry)
+conformance-rp: ACCEPTED: authentication successful ... sub=user-subject-1234531
+```
+
+#### Compliance with OIDF requirements
+
+| OIDF requirement | How it is met |
+|------------------|---------------|
+| One log file per test (not one combined log) | One `<test_name>.log` per module |
+| Named by test id | Files named exactly by the suite test id |
+| Must demonstrate detecting the error condition | Negative tests log the library rejection plus a `REJECTED:` line |
+| One zip per profile | One `<plan>-rp-logs.zip` per profile |
+
+Notes:
+
+- OIDF reviews these **by hand** (no machine schema), so a reviewer may request
+  more detail; the logs include both the library's records and explicit
+  decisions to make the behaviour unambiguous.
+- OIDF also mentions **screenshots** for interactive/browser login steps — not
+  applicable here, as these three plans run fully automated server-to-server.
+
+## Producing the artifacts
+
+A long-lived API token for the hosted suite is required (`CONFORMANCE_TOKEN`);
+see `conformance/README.md` for token rotation.
+
+```bash
+# Local regression (Docker suite) — no submission artifacts
+make conformance-test
+
+# Hosted run — produces <plan>-export.zip + <plan>-rp-logs.zip per profile
+make conformance-test HOSTED=1 CONFORMANCE_SERVER=https://www.certification.openid.net/
+#   -> conformance/results/hosted/<plan>-export.zip
+#   -> conformance/results/hosted/<plan>-rp-logs.zip   (one <test_name>.log per test)
+```
+
+The zips are git-ignored binaries. In CI, the `conformance-hosted` workflow
+(`workflow_dispatch`) produces the same artifacts and uploads them:
+
+```bash
+gh workflow run conformance-hosted.yml --ref <branch>
+gh run download <run-id> -n conformance-hosted-results
+```
+
+`--publish {none,summary,everything}` (default `none`) controls whether a run is
+listed on the public published-tests list; the artifacts are produced
+regardless.
+
+## Submitting to OIDF
+
+The **Certification of Conformance is not a downloadable template.** The current
+flow is portal-based:
+
+1. Go to **<https://submissions.openid.net/>** and complete the web form
+   (deployment name `py-identity-model <version>`, profiles, etc.).
+2. **Upload the artifacts** — the test result zips (`*-export.zip`) and the
+   client data (`*-rp-logs.zip`), one set per profile.
+3. OIDF **generates** the Certification of Conformance from the form data and
+   emails the designated signer a **DocuSign** request (subject *"Declaration of
+   Conformance signing"*). Sign electronically — there is no PDF to handle
+   manually.
+
+py-identity-model qualifies for the OIDF **Open-Source Project Certification
+Policy fee waiver** (Apache-2.0, unpaid individual maintainer); request it from
+`certification@oidf.org`. See issue #331.
+
+!!! note "Alternative API path"
+    The suite's `scripts/conformance.py` exposes a programmatic
+    `POST /api/plan/{id}/certificationpackage` (multipart: a *pre-signed*
+    Certification of Conformance PDF + the `clientSideData` zip) which
+    **publishes and permanently freezes** the plan. The portal flow above is the
+    standard route and does not require you to produce the PDF yourself.
+
+## Status
+
+Library code and conformance harness are complete; all three target profiles
+pass against the hosted suite, and both submission artifacts are generated
+automatically. The remaining steps (portal submission, DocuSign signature, fee
+waiver) are owner-driven and tracked in #331 / #242.

--- a/docs/certification.md
+++ b/docs/certification.md
@@ -51,7 +51,7 @@ every test passes). This is **not** the certification package — see
 
 ### 2. RP client-side logs (`clientSideData`)
 
-OIDF requires **one log file per test, named by the test id**, demonstrating
+OIDF requires **one log file per test**, demonstrating
 the RP's behaviour — in particular that negative tests are *rejected*
 ([submission rules](https://openid.net/certification/connect_rp_submission/)).
 The conformance suite only logs the OP side, so the RP harness produces these
@@ -101,7 +101,7 @@ conformance-rp: ACCEPTED: authentication successful ... sub=user-subject-1234531
 | OIDF requirement | How it is met |
 |------------------|---------------|
 | One log file per test (not one combined log) | One `<test_name>.log` per module |
-| Named by test id | Files named exactly by the suite test id |
+| Identifiable per test | Files named by the suite test module name (e.g. `oidcc-client-test-...`), one per plan module |
 | Must demonstrate detecting the error condition | Negative tests log the library rejection plus a `REJECTED:` line |
 | One zip per profile | One `<plan>-rp-logs.zip` per profile |
 

--- a/docs/certification.md
+++ b/docs/certification.md
@@ -145,18 +145,29 @@ regardless.
 The **Certification of Conformance is not a downloadable template.** The current
 flow is portal-based:
 
+0. **Obtain a payment code first — this is a hard prerequisite.** The submission
+   form at <https://submissions.openid.net/> cannot be started without one. The
+   form states: *"The Payment Code was created when the payment for the
+   submission was done or the invoice requested."* The standard fee is **$700**
+   per deployment (member rate; see
+   <https://openid.net/certification/fees/>). py-identity-model **may qualify**
+   for a no-cost waiver under the OIDF **Open-Source Project Certification
+   Policy** (<https://openid.net/certification/open-source-project-certification-policy/>),
+   which the OIDF evaluates **case-by-case** — "Not all open source projects
+   will qualify." Request the waiver from `certification@oidf.org`
+   (Apache-2.0, unpaid individual maintainer); if granted, the waiver reference
+   code goes in the form's payment-code field. See issue #331. (OIDF members can
+   recover an existing code under
+   <https://openid.net/foundation/members/certifications/>.)
 1. Go to **<https://submissions.openid.net/>** and complete the web form
-   (deployment name `py-identity-model <version>`, profiles, etc.).
-2. **Upload the artifacts** — the test result zips (`*-export.zip`) and the
-   client data (`*-rp-logs.zip`), one set per profile.
-3. OIDF **generates** the Certification of Conformance from the form data and
-   emails the designated signer a **DocuSign** request (subject *"Declaration of
-   Conformance signing"*). Sign electronically — there is no PDF to handle
-   manually.
-
-py-identity-model qualifies for the OIDF **Open-Source Project Certification
-Policy fee waiver** (Apache-2.0, unpaid individual maintainer); request it from
-`certification@oidf.org`. See issue #331.
+   (deployment name `py-identity-model <version>`, profiles, payment code, etc.).
+2. **Upload the artifacts** — up to **6 zip files** total. We submit exactly 6:
+   the test result zip (`*-export.zip`) and the client data zip (`*-rp-logs.zip`)
+   for each of the three profiles.
+3. OIDF validates the submission and **sends the Declaration of Conformance for
+   signature** to the designated signer, then generates the certification.
+   Processing usually takes a few working days. (The form does not specify the
+   signature mechanism — do not assume DocuSign or any particular tool.)
 
 !!! note "Alternative API path"
     The suite's `scripts/conformance.py` exposes a programmatic
@@ -168,6 +179,11 @@ Policy fee waiver** (Apache-2.0, unpaid individual maintainer); request it from
 ## Status
 
 Library code and conformance harness are complete; all three target profiles
-pass against the hosted suite, and both submission artifacts are generated
-automatically. The remaining steps (portal submission, DocuSign signature, fee
-waiver) are owner-driven and tracked in #331 / #242.
+pass against the hosted suite, and both submission artifacts (6 zips total) are
+generated automatically. The remaining steps are owner-driven and tracked in
+#331 / #242:
+
+1. **Obtain a payment code** (fee waiver via `certification@oidf.org`) — the
+   submission form is blocked without it. This is the current gating step.
+2. Complete the portal submission and upload the 6 artifact zips.
+3. Sign the Declaration of Conformance when OIDF sends it for signature.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
   - Specifications:
       - Discovery Compliance: discovery_specification_compliance_assessment.md
       - JWKS Compliance: jwks_specification_compliance_assessment.md
+      - OIDC Certification: certification.md
   - API Reference:
       - Overview: api/index.md
       - Discovery: api/discovery.md

--- a/src/py_identity_model/core/token_exchange_logic.py
+++ b/src/py_identity_model/core/token_exchange_logic.py
@@ -122,17 +122,27 @@ def _parse_error_response(response: httpx.Response) -> str:
         )
 
     if isinstance(data, dict):
-        error = data.get("error", "unknown")
+        error = data.get("error")
         error_description = data.get("error_description", "")
-        if error_description:
+        if error:
+            if error_description:
+                return (
+                    f"Token exchange failed with status code: "
+                    f"{response.status_code}. "
+                    f"Error: {error} — {error_description}"
+                )
             return (
                 f"Token exchange failed with status code: "
-                f"{response.status_code}. "
-                f"Error: {error} — {error_description}"
+                f"{response.status_code}. Error: {error}"
             )
+        # No standard RFC 6749 §5.2 ``error`` field. Surface the raw JSON body
+        # rather than masking it as "unknown" — providers such as Descope return
+        # a non-standard error shape (e.g. errorCode/errorDescription) whose
+        # detail is essential for diagnosing the rejection.
+        body = json.dumps(data)[:1024]
         return (
             f"Token exchange failed with status code: "
-            f"{response.status_code}. Error: {error}"
+            f"{response.status_code}. Response: {body}"
         )
 
     content = response.content[:1024]

--- a/src/tests/integration/test_device_token_exchange.py
+++ b/src/tests/integration/test_device_token_exchange.py
@@ -169,13 +169,9 @@ class TestTokenExchangeLive:
             )
         )
 
-        # A provider may advertise the token-exchange grant in its discovery
-        # document (so provider_capabilities reports it) yet reject the actual
-        # exchange for this client. Treat that as an unsupported-config skip,
-        # consistent with test_exchange_with_audience below.
-        if not response.is_successful:
-            pytest.skip(f"Provider rejected token exchange: {response.error}")
-
+        assert response.is_successful is True, (
+            f"Token exchange failed: {response.error}"
+        )
         assert response.token is not None
         assert "access_token" in response.token
         assert response.issued_token_type is not None

--- a/src/tests/integration/test_device_token_exchange.py
+++ b/src/tests/integration/test_device_token_exchange.py
@@ -169,9 +169,13 @@ class TestTokenExchangeLive:
             )
         )
 
-        assert response.is_successful is True, (
-            f"Token exchange failed: {response.error}"
-        )
+        # A provider may advertise the token-exchange grant in its discovery
+        # document (so provider_capabilities reports it) yet reject the actual
+        # exchange for this client. Treat that as an unsupported-config skip,
+        # consistent with test_exchange_with_audience below.
+        if not response.is_successful:
+            pytest.skip(f"Provider rejected token exchange: {response.error}")
+
         assert response.token is not None
         assert "access_token" in response.token
         assert response.issued_token_type is not None

--- a/src/tests/integration/test_device_token_exchange.py
+++ b/src/tests/integration/test_device_token_exchange.py
@@ -19,6 +19,29 @@ from py_identity_model.sync.device_auth import (
 from py_identity_model.sync.token_exchange import exchange_token
 
 
+# Signals that a provider's token endpoint rejects the token-exchange grant as
+# *unsupported*, despite advertising it in grant_types_supported. Descope is
+# known to over-advertise its discovery metadata: it lists token-exchange (and
+# jwt-bearer) but the endpoint returns E011003 "grant_type field must be one of:
+# authorization_code, refresh_token, client_credentials".
+_UNSUPPORTED_GRANT_SIGNALS = (
+    "unsupported_grant_type",  # RFC 6749 Section 5.2
+    "grant_type field must be one of",  # Descope E011003
+)
+
+
+def _provider_lacks_token_exchange(error: str | None) -> bool:
+    """True when the failure is the provider declaring the grant unsupported.
+
+    Distinguishes "provider does not implement token-exchange" (skip) from a
+    genuine library or request defect (which must still fail the test).
+    """
+    if not error:
+        return False
+    lowered = error.lower()
+    return any(signal in lowered for signal in _UNSUPPORTED_GRANT_SIGNALS)
+
+
 # ============================================================================
 # Device Authorization (RFC 8628)
 # ============================================================================
@@ -168,6 +191,17 @@ class TestTokenExchangeLive:
                 client_secret=test_config.get("TEST_CLIENT_SECRET"),
             )
         )
+
+        # Some providers advertise the token-exchange grant in discovery but
+        # reject it at the endpoint (e.g. Descope E011003). Skip only on that
+        # explicit unsupported-grant signal — any other failure is a real defect.
+        if not response.is_successful and _provider_lacks_token_exchange(
+            response.error
+        ):
+            pytest.skip(
+                "Provider advertises token-exchange in discovery but the token "
+                f"endpoint rejects the grant: {response.error}"
+            )
 
         assert response.is_successful is True, (
             f"Token exchange failed: {response.error}"

--- a/src/tests/unit/test_token_exchange.py
+++ b/src/tests/unit/test_token_exchange.py
@@ -111,6 +111,39 @@ class TestExchangeToken:
         assert response.is_successful is False
 
     @respx.mock
+    def test_nonstandard_error_body_surfaces_raw_body(self):
+        """A 400 without a standard OAuth ``error`` field surfaces the raw body.
+
+        Providers such as Descope return a non-standard error shape
+        (errorCode/errorDescription); the detail must not be masked as
+        "unknown".
+        """
+        respx.post(TOKEN_URL).mock(
+            return_value=httpx.Response(
+                400,
+                json={
+                    "errorCode": "E062108",
+                    "errorDescription": "Token exchange not enabled",
+                    "errorMessage": "grant type not allowed for client",
+                },
+            )
+        )
+        response = exchange_token(
+            TokenExchangeRequest(
+                address=TOKEN_URL,
+                client_id="service-a",
+                subject_token="some-token",
+                subject_token_type=ACCESS_TOKEN,
+                client_secret="secret",
+            )
+        )
+        assert response.is_successful is False
+        assert response.error is not None
+        assert "unknown" not in response.error
+        assert "E062108" in response.error
+        assert "Token exchange not enabled" in response.error
+
+    @respx.mock
     def test_public_client(self):
         respx.post(TOKEN_URL).mock(
             return_value=httpx.Response(200, json=TOKEN_EXCHANGE_RESPONSE)


### PR DESCRIPTION
Makes hosted conformance runs produce the artifacts an OIDF RP certification submission needs. Two pieces, both validated live against `certification.openid.net`.

## 1. Signed plan export (the suite's evidence artifact)

- `download_plan_export(plan_id, kind) -> (filename, bytes)` → `GET /api/plan/{kind}/{plan_id}` (`export` = JSON+RSA signature, or `exporthtml`).
- `--export-zip` / `--export-kind`; gated to hosted-suite + all-passing.
- `--publish {none,summary,everything}` (default none) threads into `create_plan`.

### Course correction (mid-PR)
First attempt used `POST /api/plan/{id}/certificationpackage` — a live run returned 405. Per the suite's `scripts/conformance.py` that endpoint is the *manual* submission: multipart with a **signed Certification of Conformance PDF** + the **RP logs zip**, and it **publishes + permanently freezes** the plan (= #331). Switched to the read-only `export` endpoint.

## 2. RP client-side logs (`clientSideData`)

OIDF requires **one log file per test, named by test id**, showing the RP detected each error condition. The suite logs only the OP side, so the harness now produces them:

- `app.py`: a process-global active-test pointer + a `logging.Handler` routes `conformance-rp` + `py_identity_model` records to `<RP_LOG_DIR>/<profile>/<test_name>.log`; explicit `ACCEPTED` / `REJECTED: <reason>` lines at each branch.
- `run_tests.py`: passes `test_name`/`profile` to the harness; `--rp-logs-zip` resets the per-profile dir before the run and zips it after.
- `RP_LOG_DIR` defaults to an absolute `__file__`-derived path so harness + runner agree across CWDs.

**Live sample (basic-rp, 14 per-test logs):**
```
# negative test:
py_identity_model: Invalid issuer
conformance-rp: REJECTED: id_token validation failed: Invalid issuer
# positive test:
conformance-rp: ACCEPTED: id_token validated by py-identity-model (signature, issuer, audience, expiry)
conformance-rp: ACCEPTED: authentication successful ... sub=user-subject-1234531
```

## Plumbing
- Makefile `HOSTED` branch + `conformance-hosted.yml` emit `<plan>-export.zip` and `<plan>-rp-logs.zip`, uploaded as CI artifacts; `workflow_dispatch` exposes `publish`.
- `.gitignore` the binary zips + `rp-logs/` dir.

## Live results
All three RP profiles pass against `certification.openid.net`: Basic 13/1skip, Config 5/1skip, Form Post 13/1skip (skip = expected `idtoken-sig-none`). Committed `*-latest.json` as evidence.

## Test plan
- `make conformance-test-harness` → 58 passed (35 new across `test_plan_export.py` + `test_rp_logs.py`)
- `make lint` → green
- Full `make conformance-test HOSTED=1` → 3 export zips + 3 rp-logs zips

## Adversarial review fixes (follow-up commit)
A three-layer adversarial review (blind / edge-case / acceptance) surfaced gaps in the evidence gating; addressed in `fix(conformance): harden submission-artifact gating and log routing`:
- **Evidence gate**: empty runs and `REVIEW`/unknown statuses no longer count as "all passing"; downloaded export is validated as a real zip (rejects HTML proxy-error/empty bodies); an explicit `--rp-logs-zip` that captured nothing is now a hard failure.
- **Log routing**: active-test pointer moved to a `ContextVar` (no cross-request misrouting/leak); dot-only path components collapsed and containment via `is_relative_to`; explicit `ACCEPTED:`/`REJECTED:` lines added to `/discover` + discovery-failure branches.
- **Robustness**: `Content-Disposition` parsed via stdlib `email` (RFC 5987 + multi-param, no greedy over-capture); `rmtree` target confined to the log base.
- **Docs**: corrected the "named by test id" claim — logs are named by the suite test module name.

## Remaining for #331 (manual, owner-driven)
Fill + sign the Certification of Conformance PDF, then `POST .../certificationpackage` with that PDF + the rp-logs zip (publishes + freezes the plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
