### PR TITLE
fix(integration): exercise real discovery/JWKS fetch instead of fake-primed caches

### DIFF
--- a/src/py_identity_model/aio/http_client.py
+++ b/src/py_identity_model/aio/http_client.py
@@ -22,6 +22,7 @@ from ..core.http_utils import (
     check_no_redirect,
     get_retry_config,
     get_timeout,
+    resolve_retry_delay,
     should_retry_response,
 )
 from ..logging_config import logger
@@ -102,7 +103,7 @@ def retry_with_backoff_async(
 
                     # Check if response needs retry (429 or 5xx with retries remaining)
                     if should_retry_response(response, attempt, retries):
-                        delay = calculate_delay(delay_base, attempt)
+                        delay = resolve_retry_delay(response, delay_base, attempt)
                         _log_retry(
                             f"HTTP {response.status_code}",
                             delay,

--- a/src/py_identity_model/core/http_utils.py
+++ b/src/py_identity_model/core/http_utils.py
@@ -9,7 +9,10 @@ Environment Variables:
     HTTP_TIMEOUT: Request timeout in seconds (default: 30.0)
 """
 
+from datetime import UTC
+from email.utils import parsedate_to_datetime
 import os
+import time
 
 import httpx
 
@@ -22,6 +25,10 @@ DEFAULT_RETRY_MAX_ATTEMPTS = 3
 DEFAULT_RETRY_BASE_DELAY = 1.0
 DEFAULT_MAX_JWKS_SIZE = 512 * 1024  # 512 KB
 DEFAULT_MAX_JWKS_KEYS = 100
+
+# Upper bound on a single retry wait. A misbehaving server can send a huge
+# Retry-After; cap it so a request cannot stall for an unbounded time.
+MAX_RETRY_DELAY_SECONDS = 120.0
 
 # HTTP status codes for retry logic
 HTTP_TOO_MANY_REQUESTS = 429
@@ -88,6 +95,58 @@ def calculate_delay(base_delay: float, attempt: int) -> float:
     return base_delay * (2**attempt)
 
 
+def parse_retry_after(value: str | None, now: float | None = None) -> float | None:
+    """Parse an HTTP ``Retry-After`` header (RFC 9110 Section 10.2.3).
+
+    Accepts both the delta-seconds and HTTP-date forms.
+
+    Args:
+        value: Raw header value, or ``None`` when absent.
+        now: Reference epoch seconds for the HTTP-date form (defaults to
+            the current time); accepted for deterministic testing.
+
+    Returns:
+        Delay in seconds (never negative), or ``None`` when the header is
+        absent or cannot be parsed.
+    """
+    if value is None:
+        return None
+    value = value.strip()
+    if not value:
+        return None
+
+    if value.isdigit():
+        return float(value)
+
+    try:
+        retry_at = parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return None
+    if retry_at is None:
+        return None
+    if retry_at.tzinfo is None:
+        retry_at = retry_at.replace(tzinfo=UTC)
+
+    reference = time.time() if now is None else now
+    return max(0.0, retry_at.timestamp() - reference)
+
+
+def resolve_retry_delay(
+    response: httpx.Response, base_delay: float, attempt: int
+) -> float:
+    """Delay to wait before the next retry of an HTTP response.
+
+    Honors a server-provided ``Retry-After`` header when present, using the
+    larger of it and the exponential backoff so a rate limiter's explicit
+    pacing is respected. The result is capped at ``MAX_RETRY_DELAY_SECONDS``.
+    """
+    backoff = calculate_delay(base_delay, attempt)
+    retry_after = parse_retry_after(response.headers.get("Retry-After"))
+    if retry_after is None:
+        return backoff
+    return min(max(backoff, retry_after), MAX_RETRY_DELAY_SECONDS)
+
+
 def check_no_redirect(response: httpx.Response) -> None:
     """Raise if the response is a redirect (3xx).
 
@@ -133,11 +192,14 @@ __all__ = [
     "HTTP_REDIRECT_MAX",
     "HTTP_REDIRECT_MIN",
     "HTTP_TOO_MANY_REQUESTS",
+    "MAX_RETRY_DELAY_SECONDS",
     "calculate_delay",
     "check_no_redirect",
     "get_max_jwks_keys",
     "get_max_jwks_size",
     "get_retry_config",
     "get_timeout",
+    "parse_retry_after",
+    "resolve_retry_delay",
     "should_retry_response",
 ]

--- a/src/py_identity_model/sync/http_client.py
+++ b/src/py_identity_model/sync/http_client.py
@@ -21,6 +21,7 @@ from ..core.http_utils import (
     check_no_redirect,
     get_retry_config,
     get_timeout,
+    resolve_retry_delay,
     should_retry_response,
 )
 from ..logging_config import logger
@@ -85,7 +86,7 @@ def retry_with_backoff(max_retries: int | None = None, base_delay: float | None 
 
                     # Check if response needs retry (429 or 5xx with retries remaining)
                     if should_retry_response(response, attempt, retries):
-                        delay = calculate_delay(delay_base, attempt)
+                        delay = resolve_retry_delay(response, delay_base, attempt)
                         _log_retry(
                             f"HTTP {response.status_code}",
                             delay,

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -39,15 +39,9 @@ from py_identity_model import (
     request_client_credentials_token,
     validate_authorize_callback_state,
 )
-from py_identity_model.aio import token_validation as aio_tv
+from py_identity_model.aio.http_client import _reset_async_http_client
 from py_identity_model.core.discovery_policy import DiscoveryPolicy
-from py_identity_model.core.jwks_cache import (
-    DiscoCacheEntry,
-    JwksCacheEntry,
-    is_uncacheable,
-    resolve_disco_ttl,
-    resolve_ttl,
-)
+from py_identity_model.core.jwks_cache import is_uncacheable
 from py_identity_model.core.models import DiscoveryDocumentResponse
 from py_identity_model.core.parsers import (
     extract_kid_from_jwt,
@@ -55,7 +49,6 @@ from py_identity_model.core.parsers import (
 )
 from py_identity_model.core.pkce import generate_pkce_pair
 from py_identity_model.exceptions import TokenValidationException
-from py_identity_model.sync import token_validation as sync_tv
 from py_identity_model.sync.http_client import close_http_client
 
 from .test_utils import get_config
@@ -285,46 +278,36 @@ def provider_caches_responses(discovery_document, jwks_response):
     return not is_uncacheable(discovery_document.cache_control)
 
 
-@pytest.fixture(scope="session", autouse=True)
-def _prime_library_caches(discovery_document, jwks_response, test_config):
-    """Pre-populate the library's internal JWKS + discovery caches.
+@pytest.fixture(autouse=True)
+async def _clear_async_caches():
+    """Override the root fixture: reset the async HTTP client but keep caches.
 
-    The conftest already fetches discovery/JWKS once per xdist worker
-    (cross-worker-coordinated via FileLock). But ``validate_token()``
-    consults its own per-process module-level caches
-    (``sync/aio.token_validation._jwks_cache`` and ``_disco_cache``),
-    which start cold in every worker. Without priming, the *first*
-    ``validate_token`` call in each worker triggers a fresh upstream
-    fetch — and against rate-limited providers (Ory free tier) those
-    bursts produce 429s mid-test.
+    The root conftest's ``_clear_async_caches`` wipes the library's
+    discovery/JWKS caches before *every* test. For integration tests that
+    defeats the library's own per-process caching, so each test would refetch
+    discovery + JWKS live and trip provider rate limits (429). Instead we want
+    integration tests to exercise the *real* fetch once per worker and then
+    reuse the genuine cache — exactly how a real application behaves.
 
-    Inject the fixture-resolved responses directly into both sync and
-    aio caches. After this fixture runs, no test in the session needs
-    to hit the upstream for discovery or JWKS.
-
-    Keyed identically to the library: JWKS by URI; discovery by
-    ``(address, require_https)`` tuple.
+    We still reset the singleton async HTTP client so it is recreated on each
+    test's event loop (pytest-asyncio uses a fresh loop per test); only the
+    cache clears are dropped. Cache-behavior tests that need a cold cache clear
+    it explicitly via the local ``clear_validation_caches`` fixture.
     """
-    now = time.monotonic()
-    require_https = test_config.get("TEST_REQUIRE_HTTPS", True)
+    _reset_async_http_client()
 
-    jwks_uri = test_config["TEST_JWKS_ADDRESS"]
-    jwks_entry = JwksCacheEntry(
-        response=jwks_response,
-        cached_at=now,
-        ttl=resolve_ttl(jwks_response.cache_control),
-    )
-    sync_tv._jwks_cache[jwks_uri] = jwks_entry
-    aio_tv._jwks_cache[jwks_uri] = jwks_entry
 
-    disco_key = (test_config["TEST_DISCO_ADDRESS"], require_https)
-    disco_entry = DiscoCacheEntry(
-        response=discovery_document,
-        cached_at=now,
-        ttl=resolve_disco_ttl(discovery_document.cache_control),
-    )
-    sync_tv._disco_cache[disco_key] = disco_entry
-    aio_tv._disco_cache[disco_key] = disco_entry
+@pytest.fixture(autouse=True)
+def _integration_retry_backoff(monkeypatch):
+    """Give the library a real retry backoff for integration tests.
+
+    The root conftest zeroes ``HTTP_RETRY_BASE_DELAY`` so unit tests that
+    exercise retry paths don't sleep. Integration tests hit live, rate-limited
+    providers, so a genuine discovery/JWKS fetch that draws a transient 429
+    must actually back off (and honor ``Retry-After``) to recover instead of
+    hammering the endpoint with zero delay.
+    """
+    monkeypatch.setenv("HTTP_RETRY_BASE_DELAY", "1.0")
 
 
 @pytest.fixture(scope="session")

--- a/src/tests/unit/test_retry_after.py
+++ b/src/tests/unit/test_retry_after.py
@@ -1,0 +1,113 @@
+"""Tests for ``Retry-After`` handling in the HTTP retry logic."""
+
+from datetime import UTC, datetime
+from email.utils import format_datetime
+
+import httpx
+import pytest
+
+from py_identity_model.core.http_utils import (
+    MAX_RETRY_DELAY_SECONDS,
+    parse_retry_after,
+    resolve_retry_delay,
+)
+from py_identity_model.sync.http_client import retry_with_backoff
+
+
+# Reference epoch for deterministic HTTP-date parsing
+FIXED_NOW = 1_000_000.0
+RETRY_AFTER_DELTA = 45.0
+PAST_DELTA = 60.0
+
+# resolve_retry_delay expectations
+BACKOFF_BASE = 1.0
+BACKOFF_AT_ATTEMPT_1 = 2.0  # 1.0 * 2**1
+BACKOFF_AT_ATTEMPT_3 = 8.0  # 1.0 * 2**3
+RETRY_AFTER_SMALL = 10.0
+HTTP_OK = 200
+SLEEP_SECONDS = 7.0
+
+
+def _response(headers: dict[str, str] | None = None) -> httpx.Response:
+    return httpx.Response(429, headers=headers or {})
+
+
+class TestParseRetryAfter:
+    """``parse_retry_after`` covers the RFC 9110 delta-seconds + HTTP-date forms."""
+
+    def test_absent_returns_none(self):
+        assert parse_retry_after(None) is None
+
+    def test_blank_returns_none(self):
+        assert parse_retry_after("   ") is None
+
+    def test_delta_seconds(self):
+        assert parse_retry_after("30") == pytest.approx(30.0)
+
+    def test_unparseable_returns_none(self):
+        assert parse_retry_after("not-a-date") is None
+
+    def test_http_date_future(self):
+        future = datetime.fromtimestamp(FIXED_NOW + RETRY_AFTER_DELTA, tz=UTC)
+        assert parse_retry_after(
+            format_datetime(future), now=FIXED_NOW
+        ) == pytest.approx(RETRY_AFTER_DELTA, abs=1.0)
+
+    def test_http_date_in_past_clamps_to_zero(self):
+        past = datetime.fromtimestamp(FIXED_NOW - PAST_DELTA, tz=UTC)
+        assert parse_retry_after(format_datetime(past), now=FIXED_NOW) == 0.0
+
+
+class TestResolveRetryDelay:
+    """``resolve_retry_delay`` honors Retry-After but never below the backoff."""
+
+    def test_no_header_uses_backoff(self):
+        assert resolve_retry_delay(
+            _response(), base_delay=BACKOFF_BASE, attempt=1
+        ) == pytest.approx(BACKOFF_AT_ATTEMPT_1)
+
+    def test_retry_after_larger_than_backoff_wins(self):
+        delay = resolve_retry_delay(
+            _response({"Retry-After": "10"}), base_delay=BACKOFF_BASE, attempt=0
+        )
+        assert delay == pytest.approx(RETRY_AFTER_SMALL)
+
+    def test_backoff_larger_than_retry_after_wins(self):
+        delay = resolve_retry_delay(
+            _response({"Retry-After": "2"}), base_delay=BACKOFF_BASE, attempt=3
+        )
+        assert delay == pytest.approx(BACKOFF_AT_ATTEMPT_3)
+
+    def test_retry_after_capped(self):
+        delay = resolve_retry_delay(
+            _response({"Retry-After": "99999"}), base_delay=BACKOFF_BASE, attempt=0
+        )
+        assert delay == pytest.approx(MAX_RETRY_DELAY_SECONDS)
+
+
+class TestSyncRetryHonorsRetryAfter:
+    """The sync retry decorator waits for the Retry-After interval on a 429."""
+
+    def test_sleep_uses_retry_after(self, monkeypatch):
+        monkeypatch.setenv("HTTP_RETRY_MAX_ATTEMPTS", "1")
+        monkeypatch.setenv("HTTP_RETRY_BASE_DELAY", "0")
+
+        slept: list[float] = []
+        monkeypatch.setattr(
+            "py_identity_model.sync.http_client.time.sleep", slept.append
+        )
+
+        responses = [
+            httpx.Response(429, headers={"Retry-After": "7"}),
+            httpx.Response(HTTP_OK),
+        ]
+
+        @retry_with_backoff()
+        def call():
+            return responses.pop(0)
+
+        result = call()
+
+        assert result.status_code == HTTP_OK
+        # base_delay is 0, so without Retry-After the wait would be 0; it is 7.
+        assert slept == [SLEEP_SECONDS]


### PR DESCRIPTION
## Problem

Post-merge CI on `main` flaked: `integration-tests-ory` failed with HTTP 429 on a live JWKS fetch during `test_sync_claims_validator_in_async_context`.

Root cause (a test-harness bug, not the merge):
- `_prime_library_caches` injected fixture-resolved discovery/JWKS responses **directly into the library caches**, so `validate_token` never actually fetched discovery/JWKS over the wire — the integration coverage for that path was hollow.
- The root conftest's `_clear_async_caches` wipes the **aio** caches before every test (new event loop per pytest-asyncio test), defeating the priming for async tests → live refetch per test → Ory 429.
- `HTTP_RETRY_BASE_DELAY=0` (set for fast unit tests) meant the retry "backed off" for 0s, so the 429 failed instantly.

## Change

Make integration tests test the real thing:
- **Drop the fake priming.** The first `validate_token` per worker does a genuine upstream fetch; the rest reuse the library's own per-process cache — exactly how a real app behaves.
- **Override `_clear_async_caches`** in the integration conftest to reset only the async HTTP client (event-loop safety), keeping the disco/JWKS caches warm. Cache-behavior tests still clear explicitly via `clear_validation_caches`.
- **Restore a real `HTTP_RETRY_BASE_DELAY`** for integration tests so a transient 429 on that real fetch actually backs off.
- **Library: honor `Retry-After`** (RFC 9110) on 429/5xx in both sync and async clients — `max(exponential-backoff, Retry-After)`, capped at 120s. New `parse_retry_after`/`resolve_retry_delay` with unit tests.

The loop-safe per-loop locks (#405) already make the cache data safe across event loops, so the per-test cache wipe was only providing isolation — which the explicit cache fixtures already handle.

## Verification

- Full integration suite green against **Ory** (the flaking provider): 77 passed, 38 capability-skipped.
- Token-validation + token-exchange suites green against **Descope**.
- Unit suite + coverage + typecheck green; new `Retry-After` unit tests.
- node-oidc fixture not run locally (Docker unavailable here) — covered by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)