### PR TITLE
ci(test-fixture): bump node-oidc-provider base image to node 22 LTS

### DIFF
--- a/test-fixtures/node-oidc-provider/Dockerfile
+++ b/test-fixtures/node-oidc-provider/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:22-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
Node 20 reaches end-of-maintenance (April 2026). Moves the node-oidc-provider integration-test fixture (built by the `integration-tests-node-oidc` CI job) to active LTS `node:22-alpine`, matching identity-stack's frontend image. `make lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)