### PR TITLE
feat(client-auth): add private_key_jwt (RFC 7523) client authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ uv add py-identity-model
 | DPoP | RFC 9449 | Done |
 | Pushed Authorization Requests | RFC 9126 | Done |
 | JWT Secured Authorization Request | RFC 9101 | Done |
+| private_key_jwt Client Authentication | RFC 7523 | Done |
 | FAPI 2.0 Security Profile | FAPI 2.0 | Done |
 | UserInfo Endpoint | OIDC Core | Done |
 | OAuth Callback State Validation | RFC 6749 | Done |
@@ -104,6 +105,7 @@ Each protocol feature has a standalone example in [`examples/`](examples/):
 | [dpop_example.py](examples/dpop_example.py) | DPoP proof creation (RFC 9449) |
 | [par_example.py](examples/par_example.py) | Pushed Authorization Requests (RFC 9126) |
 | [jar_example.py](examples/jar_example.py) | JWT Secured Authorization Request (RFC 9101) |
+| [private_key_jwt_example.py](examples/private_key_jwt_example.py) | private_key_jwt client authentication (RFC 7523) |
 | [fapi_example.py](examples/fapi_example.py) | FAPI 2.0 Security Profile |
 | [device_auth_example.py](examples/device_auth_example.py) | Device Authorization Grant (RFC 8628) |
 | [token_exchange_example.py](examples/token_exchange_example.py) | Token Exchange (RFC 8693) |

--- a/examples/private_key_jwt_example.py
+++ b/examples/private_key_jwt_example.py
@@ -1,0 +1,128 @@
+"""
+private_key_jwt Client Authentication Example (RFC 7523)
+
+Demonstrates authenticating a confidential client to the token endpoint with
+a signed JWT assertion (``private_key_jwt``) instead of a client secret, as
+required by FAPI 2.0 and recommended by OAuth 2.1 / OpenID Connect Core 1.0
+Section 9.
+
+Flow:
+1. Generate an EC P-256 (ES256) key pair and serialize the private key to PEM.
+2. Discover ``token_endpoint_auth_methods_supported`` to confirm the
+   authorization server accepts ``private_key_jwt``.
+3. Build a ``PrivateKeyJwt`` and attach it to a token request.
+4. Observe that the assertion (not Basic auth, not client_secret) is used.
+"""
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from py_identity_model import (
+    ClientCredentialsTokenRequest,
+    DiscoveryDocumentRequest,
+    PrivateKeyJwt,
+    get_discovery_document,
+)
+
+
+# A placeholder issuer; swap for your own provider when running for real.
+DEMO_DISCOVERY_URL = "https://demo.duendesoftware.com/.well-known/openid-configuration"
+
+
+def generate_es256_private_key_pem() -> str:
+    """Generate an EC P-256 key pair and return the private key as PEM.
+
+    ES256 (ECDSA on the NIST P-256 curve) is one of the two signing
+    algorithms permitted by FAPI 2.0 for ``private_key_jwt`` (the other is
+    ``PS256``). In production the matching public key (JWK) is registered with
+    the authorization server so it can verify the assertion signature.
+    """
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return pem.decode("utf-8")
+
+
+def discover_auth_methods_example():
+    """Discover the auth methods supported by the authorization server."""
+    print("\n" + "=" * 60)
+    print("Discover token_endpoint_auth_methods_supported")
+    print("=" * 60)
+
+    response = get_discovery_document(
+        DiscoveryDocumentRequest(address=DEMO_DISCOVERY_URL)
+    )
+
+    if not response.is_successful:
+        print(f"  Discovery failed: {response.error}")
+        return None
+
+    methods = response.token_endpoint_auth_methods_supported or []
+    print(f"\n  Token endpoint: {response.token_endpoint}")
+    print(f"  Supported auth methods: {methods}")
+
+    if "private_key_jwt" in methods:
+        print("  -> Server supports private_key_jwt")
+    else:
+        print("  -> Server did NOT advertise private_key_jwt")
+
+    return response.token_endpoint
+
+
+def private_key_jwt_token_request(token_endpoint: str):
+    """Build a client credentials request authenticated with private_key_jwt."""
+    print("\n" + "=" * 60)
+    print("Client Credentials with private_key_jwt")
+    print("=" * 60)
+
+    # Step 1: Generate (or load) the signing key.
+    private_key_pem = generate_es256_private_key_pem()
+    print("\n  Generated EC P-256 (ES256) private key (PEM).")
+
+    # Step 2: Build the private_key_jwt authentication parameters.
+    #   - algorithm "ES256" matches the key type (FAPI 2.0 compliant).
+    #   - audience defaults to the request address (token endpoint) when None.
+    #   - kid is optional; set it when the AS needs help locating your key.
+    auth = PrivateKeyJwt(private_key=private_key_pem, algorithm="ES256")
+
+    # Step 3: Attach the assertion to a token request. Note that a
+    # client_secret is also provided here only to demonstrate precedence:
+    # when private_key_jwt is set, it WINS and the client_secret is ignored,
+    # so no HTTP Basic (client_secret_basic) header is sent.
+    token_request = ClientCredentialsTokenRequest(
+        address=token_endpoint,
+        client_id="my-confidential-client",
+        client_secret="ignored-because-private-key-jwt-takes-precedence",
+        scope="api",
+        private_key_jwt=auth,
+    )
+
+    print(f"  Token endpoint: {token_request.address}")
+    print(f"  Client ID: {token_request.client_id}")
+    print(f"  Assertion algorithm: {auth.algorithm}")
+    print(f"  private_key_jwt set: {token_request.private_key_jwt is not None}")
+    print("  client_secret present but IGNORED (private_key_jwt wins).")
+    print("  No Authorization: Basic header is sent; the request body carries")
+    print("    client_assertion_type + client_assertion instead.")
+    print("  (Would call request_client_credentials_token(token_request) here)")
+
+
+def main():
+    print("\n" + "=" * 60)
+    print("private_key_jwt CLIENT AUTHENTICATION (RFC 7523)")
+    print("=" * 60)
+
+    token_endpoint = discover_auth_methods_example()
+    # Fall back to a placeholder endpoint when discovery is unavailable.
+    private_key_jwt_token_request(token_endpoint or "https://auth.example.com/token")
+
+    print("\n" + "=" * 60)
+    print("Examples completed!")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/py_identity_model/__init__.py
+++ b/src/py_identity_model/__init__.py
@@ -57,6 +57,7 @@ from .sync import (
     JsonWebKeyParameterNames,
     JwksRequest,
     JwksResponse,
+    PrivateKeyJwt,
     PushedAuthorizationRequest,
     PushedAuthorizationResponse,
     RefreshTokenRequest,
@@ -155,6 +156,8 @@ __all__ = [
     "JwksRequest",
     "JwksResponse",
     "NetworkException",
+    # Client authentication (private_key_jwt)
+    "PrivateKeyJwt",
     # PAR
     "PushedAuthorizationRequest",
     "PushedAuthorizationResponse",

--- a/src/py_identity_model/aio/__init__.py
+++ b/src/py_identity_model/aio/__init__.py
@@ -49,7 +49,7 @@ from ..core.fapi import (
     validate_fapi_discovery,
 )
 from ..core.jar import build_jar_authorization_url, create_request_object
-from ..core.models import BaseRequest, BaseResponse
+from ..core.models import BaseRequest, BaseResponse, PrivateKeyJwt
 from ..core.pkce import (
     generate_code_challenge,
     generate_code_verifier,
@@ -159,6 +159,7 @@ __all__ = [
     "JwksRequest",
     "JwksResponse",
     # PAR
+    "PrivateKeyJwt",
     "PushedAuthorizationRequest",
     "PushedAuthorizationResponse",
     # Refresh Token

--- a/src/py_identity_model/aio/device_auth.py
+++ b/src/py_identity_model/aio/device_auth.py
@@ -46,10 +46,10 @@ async def request_device_authorization(
         and ``verification_uri`` for user display.
     """
     log_device_auth_request(request)
-    params, headers, auth = prepare_device_auth_request_data(request)
 
     response = None
     try:
+        params, headers, auth = prepare_device_auth_request_data(request)
         client = http_client.client if http_client else get_async_http_client()
         response = await _request_device_auth(
             client, request.address, params, headers, auth
@@ -89,10 +89,10 @@ async def poll_device_token(
         indicating poll status.
     """
     log_device_token_request(request)
-    params, headers, auth = prepare_device_token_request_data(request)
 
     response = None
     try:
+        params, headers, auth = prepare_device_token_request_data(request)
         client = http_client.client if http_client else get_async_http_client()
         response = await _poll_device_token(
             client, request.address, params, headers, auth

--- a/src/py_identity_model/aio/introspection.py
+++ b/src/py_identity_model/aio/introspection.py
@@ -47,10 +47,10 @@ async def introspect_token(
         TokenIntrospectionResponse with claims dict including ``active`` bool.
     """
     log_introspection_request(request)
-    params, headers, auth = prepare_introspection_request_data(request)
 
     response = None
     try:
+        params, headers, auth = prepare_introspection_request_data(request)
         client = http_client.client if http_client else get_async_http_client()
         response = await _introspect_token(
             client, request.address, params, headers, auth

--- a/src/py_identity_model/aio/revocation.py
+++ b/src/py_identity_model/aio/revocation.py
@@ -47,10 +47,10 @@ async def revoke_token(
         TokenRevocationResponse indicating success or error.
     """
     log_revocation_request(request)
-    params, headers, auth = prepare_revocation_request_data(request)
 
     response = None
     try:
+        params, headers, auth = prepare_revocation_request_data(request)
         client = http_client.client if http_client else get_async_http_client()
         response = await _revoke_token(client, request.address, params, headers, auth)
         return process_revocation_response(response)

--- a/src/py_identity_model/aio/token_client.py
+++ b/src/py_identity_model/aio/token_client.py
@@ -70,10 +70,10 @@ async def request_client_credentials_token(
         ClientCredentialsTokenResponse: Token response
     """
     log_token_request(request)
-    params, headers, auth = prepare_token_request_data(request)
 
     response = None
     try:
+        params, headers, auth = prepare_token_request_data(request)
         client = http_client.client if http_client else get_async_http_client()
         response = await _request_token(client, request.address, params, headers, auth)
         return process_token_response(response)
@@ -98,10 +98,10 @@ async def request_authorization_code_token(
         AuthorizationCodeTokenResponse with token dict or error.
     """
     log_auth_code_token_request(request)
-    params, headers, auth = prepare_auth_code_token_request_data(request)
 
     response = None
     try:
+        params, headers, auth = prepare_auth_code_token_request_data(request)
         client = http_client.client if http_client else get_async_http_client()
         response = await _request_token(client, request.address, params, headers, auth)
         return process_auth_code_token_response(response)
@@ -126,10 +126,10 @@ async def refresh_token(
         RefreshTokenResponse with new token dict or error.
     """
     log_refresh_token_request(request)
-    params, headers, auth = prepare_refresh_token_request_data(request)
 
     response = None
     try:
+        params, headers, auth = prepare_refresh_token_request_data(request)
         client = http_client.client if http_client else get_async_http_client()
         response = await _request_token(client, request.address, params, headers, auth)
         return process_refresh_token_response(response)

--- a/src/py_identity_model/aio/token_client.py
+++ b/src/py_identity_model/aio/token_client.py
@@ -70,18 +70,12 @@ async def request_client_credentials_token(
         ClientCredentialsTokenResponse: Token response
     """
     log_token_request(request)
-    params, headers = prepare_token_request_data(request)
+    params, headers, auth = prepare_token_request_data(request)
 
     response = None
     try:
         client = http_client.client if http_client else get_async_http_client()
-        response = await _request_token(
-            client,
-            request.address,
-            params,
-            headers,
-            (request.client_id, request.client_secret),
-        )
+        response = await _request_token(client, request.address, params, headers, auth)
         return process_token_response(response)
     except Exception as e:
         return handle_token_error(e)

--- a/src/py_identity_model/core/client_assertion.py
+++ b/src/py_identity_model/core/client_assertion.py
@@ -70,15 +70,23 @@ def build_client_assertion(  # noqa: PLR0913  # RFC 7523 assertion params are al
         ("audience", audience),
         ("private_key", private_key),
     ):
-        if not value:
+        # Reject whitespace-only string values: they are truthy but would be
+        # signed into ``iss``/``sub``/``aud`` and rejected opaquely by the AS.
+        if not value or (isinstance(value, str) and not value.strip()):
             raise ValueError(f"{name} must not be empty")
 
     validate_signing_algorithm(algorithm, context="client assertion")
 
-    if lifetime <= 0:
-        raise ValueError(f"lifetime must be positive, got {lifetime}")
+    # ``exp`` is derived from the backdated ``iat`` (``now - leeway``), so a
+    # lifetime at or below the leeway yields an assertion already expired at
+    # mint time. Require a lifetime that clears the skew window.
+    if lifetime <= _CLOCK_SKEW_LEEWAY_SECONDS:
+        raise ValueError(
+            f"lifetime must be greater than the {_CLOCK_SKEW_LEEWAY_SECONDS}s "
+            f"clock-skew leeway, got {lifetime}"
+        )
 
-    if kid is not None and not kid:
+    if kid is not None and not kid.strip():
         raise ValueError("kid must be non-empty when provided")
 
     issued_at = int(time.time()) - _CLOCK_SKEW_LEEWAY_SECONDS

--- a/src/py_identity_model/core/client_assertion.py
+++ b/src/py_identity_model/core/client_assertion.py
@@ -1,0 +1,136 @@
+"""
+``private_key_jwt`` client authentication per RFC 7523 and OpenID Connect
+Core 1.0 Section 9.
+
+Builds the signed JWT ``client_assertion`` that authenticates a client at the
+token, PAR, introspection, and revocation endpoints, and provides a shared
+helper that injects the assertion into request parameters with the correct
+precedence (``private_key_jwt`` > ``client_secret`` > public).
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+import uuid
+
+import jwt as pyjwt
+
+from ..oidc_constants import ClientAssertionTypes, TokenRequest
+from .jwt_signing import validate_signing_algorithm
+
+
+if TYPE_CHECKING:
+    from .models import PrivateKeyJwt
+
+
+def build_client_assertion(  # noqa: PLR0913  # RFC 7523 assertion params are all distinct
+    *,
+    client_id: str,
+    audience: str,
+    private_key: str | bytes,
+    algorithm: str = "PS256",
+    kid: str | None = None,
+    lifetime: int = 300,
+) -> str:
+    """Build a signed ``private_key_jwt`` client assertion (RFC 7523 Section 2.2).
+
+    The assertion authenticates the client to the authorization server.  Its
+    claims follow RFC 7523 Section 3 / OpenID Connect Core 1.0 Section 9:
+
+    - ``iss`` and ``sub`` are both the client identifier.
+    - ``aud`` is the authorization server (token endpoint URL or issuer).
+    - ``jti`` is a unique identifier (uuid4) to prevent replay.
+    - ``iat`` / ``exp`` bound the assertion to a short lifetime.
+
+    Args:
+        client_id: Client identifier; becomes the ``iss`` and ``sub`` claims.
+        audience: Authorization server identifier; becomes the ``aud`` claim.
+        private_key: PEM-encoded private key for signing (``bytes`` or ``str``).
+        algorithm: Asymmetric signing algorithm (default ``"PS256"``).
+            FAPI 2.0 requires ``PS256`` or ``ES256``.
+        kid: Optional key ID for the JWT header to aid key lookup.
+        lifetime: Assertion validity in seconds (default 300).
+
+    Returns:
+        The signed client assertion JWT.
+
+    Raises:
+        ValueError: If a required parameter is empty, *algorithm* is not a
+            supported asymmetric signing algorithm, *lifetime* is not
+            positive, or *kid* is an empty string.
+    """
+    for name, value in (
+        ("client_id", client_id),
+        ("audience", audience),
+        ("private_key", private_key),
+    ):
+        if not value:
+            raise ValueError(f"{name} must not be empty")
+
+    validate_signing_algorithm(algorithm, context="client assertion")
+
+    if lifetime <= 0:
+        raise ValueError(f"lifetime must be positive, got {lifetime}")
+
+    if kid is not None and not kid:
+        raise ValueError("kid must be non-empty when provided")
+
+    now = int(time.time())
+    claims = {
+        "iss": client_id,
+        "sub": client_id,
+        "aud": audience,
+        "jti": str(uuid.uuid4()),
+        "iat": now,
+        "exp": now + lifetime,
+    }
+
+    headers: dict[str, str] = {}
+    if kid is not None:
+        headers["kid"] = kid
+
+    return pyjwt.encode(claims, private_key, algorithm=algorithm, headers=headers)
+
+
+def apply_private_key_jwt(
+    params: dict[str, str],
+    config: PrivateKeyJwt,
+    *,
+    client_id: str,
+    default_audience: str,
+) -> None:
+    """Inject a ``private_key_jwt`` client assertion into *params* in place.
+
+    Adds ``client_id``, ``client_assertion_type``, and ``client_assertion`` to
+    the request body per RFC 7523 Section 2.2.  ``client_id`` is included
+    alongside the assertion (RFC 7521 Section 4.2); it identifies the same
+    client as the assertion's ``sub``.  The assertion ``aud`` defaults to
+    *default_audience* (the request ``address``) and may be overridden via
+    :attr:`PrivateKeyJwt.audience`.
+
+    Args:
+        params: Request body parameters to mutate in place.
+        config: The ``private_key_jwt`` authentication parameters.
+        client_id: The client identifier.
+        default_audience: Audience to use when ``config.audience`` is ``None``.
+    """
+    assertion = build_client_assertion(
+        client_id=client_id,
+        audience=config.audience or default_audience,
+        private_key=config.private_key,
+        algorithm=config.algorithm,
+        kid=config.kid,
+        lifetime=config.lifetime,
+    )
+    params[TokenRequest.CLIENT_ID.value] = client_id
+    params[TokenRequest.CLIENT_ASSERTION_TYPE.value] = (
+        ClientAssertionTypes.JWT_BEARER.value
+    )
+    params[TokenRequest.CLIENT_ASSERTION.value] = assertion
+
+
+__all__ = [
+    "apply_private_key_jwt",
+    "build_client_assertion",
+]

--- a/src/py_identity_model/core/client_assertion.py
+++ b/src/py_identity_model/core/client_assertion.py
@@ -23,6 +23,11 @@ from .jwt_signing import validate_signing_algorithm
 if TYPE_CHECKING:
     from .models import PrivateKeyJwt
 
+# Backdate ``iat``/``nbf`` by a small margin so an authorization server whose
+# clock runs slightly ahead does not reject a freshly minted assertion as
+# not-yet-valid at the boundary (RFC 7523 leaves skew tolerance to the AS).
+_CLOCK_SKEW_LEEWAY_SECONDS = 10
+
 
 def build_client_assertion(  # noqa: PLR0913  # RFC 7523 assertion params are all distinct
     *,
@@ -76,14 +81,15 @@ def build_client_assertion(  # noqa: PLR0913  # RFC 7523 assertion params are al
     if kid is not None and not kid:
         raise ValueError("kid must be non-empty when provided")
 
-    now = int(time.time())
+    issued_at = int(time.time()) - _CLOCK_SKEW_LEEWAY_SECONDS
     claims = {
         "iss": client_id,
         "sub": client_id,
         "aud": audience,
         "jti": str(uuid.uuid4()),
-        "iat": now,
-        "exp": now + lifetime,
+        "iat": issued_at,
+        "nbf": issued_at,
+        "exp": issued_at + lifetime,
     }
 
     headers: dict[str, str] = {}

--- a/src/py_identity_model/core/device_auth_logic.py
+++ b/src/py_identity_model/core/device_auth_logic.py
@@ -11,6 +11,7 @@ import httpx
 
 from ..logging_config import logger
 from ..logging_utils import redact_url
+from .client_assertion import apply_private_key_jwt
 from .models import (
     DeviceAuthorizationRequest,
     DeviceAuthorizationResponse,
@@ -69,7 +70,15 @@ def prepare_device_auth_request_data(
     headers = {"Content-Type": "application/x-www-form-urlencoded"}
 
     auth: tuple[str, str] | None = None
-    if request.client_secret:
+    if request.private_key_jwt is not None:
+        # RFC 7523: private_key_jwt assertion in body, no auth header.
+        apply_private_key_jwt(
+            params,
+            request.private_key_jwt,
+            client_id=request.client_id,
+            default_audience=request.address,
+        )
+    elif request.client_secret:
         auth = (request.client_id, request.client_secret)
 
     return params, headers, auth
@@ -181,7 +190,15 @@ def prepare_device_token_request_data(
     headers = {"Content-Type": "application/x-www-form-urlencoded"}
 
     auth: tuple[str, str] | None = None
-    if request.client_secret:
+    if request.private_key_jwt is not None:
+        # RFC 7523: private_key_jwt assertion in body, no auth header.
+        apply_private_key_jwt(
+            params,
+            request.private_key_jwt,
+            client_id=request.client_id,
+            default_audience=request.address,
+        )
+    elif request.client_secret:
         auth = (request.client_id, request.client_secret)
 
     return params, headers, auth

--- a/src/py_identity_model/core/introspection_logic.py
+++ b/src/py_identity_model/core/introspection_logic.py
@@ -9,6 +9,7 @@ import httpx
 
 from ..logging_config import logger
 from ..logging_utils import redact_url
+from .client_assertion import apply_private_key_jwt
 from .error_handlers import handle_introspection_error
 from .models import TokenIntrospectionRequest, TokenIntrospectionResponse
 from .response_processors import parse_introspection_response
@@ -37,7 +38,15 @@ def prepare_introspection_request_data(
     headers = {"Content-Type": "application/x-www-form-urlencoded"}
 
     auth: tuple[str, str] | None = None
-    if request.client_secret is not None:
+    if request.private_key_jwt is not None:
+        # RFC 7523: private_key_jwt assertion in body, no auth header.
+        apply_private_key_jwt(
+            params,
+            request.private_key_jwt,
+            client_id=request.client_id,
+            default_audience=request.address,
+        )
+    elif request.client_secret is not None:
         auth = (request.client_id, request.client_secret)
     else:
         params["client_id"] = request.client_id

--- a/src/py_identity_model/core/jar.py
+++ b/src/py_identity_model/core/jar.py
@@ -15,6 +15,8 @@ import uuid
 
 import jwt as pyjwt
 
+from .jwt_signing import validate_signing_algorithm
+
 
 @dataclass(frozen=True)
 class _RequestParams:
@@ -52,19 +54,6 @@ _RESERVED_CLAIMS = frozenset(
     }
 )
 
-_SUPPORTED_ALGORITHMS = {
-    "ES256",
-    "ES384",
-    "ES512",
-    "EdDSA",
-    "RS256",
-    "RS384",
-    "RS512",
-    "PS256",
-    "PS384",
-    "PS512",
-}
-
 
 def _validate_request_params(params: _RequestParams) -> None:
     """Validate all inputs for :func:`create_request_object`."""
@@ -78,12 +67,7 @@ def _validate_request_params(params: _RequestParams) -> None:
         if not value:
             raise ValueError(f"{name} must not be empty")
 
-    if params.algorithm not in _SUPPORTED_ALGORITHMS:
-        msg = (
-            f"Unsupported JAR algorithm: {params.algorithm}. "
-            f"Supported: {sorted(_SUPPORTED_ALGORITHMS)}"
-        )
-        raise ValueError(msg)
+    validate_signing_algorithm(params.algorithm, context="JAR")
 
     if params.lifetime <= 0:
         raise ValueError(f"lifetime must be positive, got {params.lifetime}")

--- a/src/py_identity_model/core/jwt_signing.py
+++ b/src/py_identity_model/core/jwt_signing.py
@@ -1,0 +1,56 @@
+"""
+Shared JWT signing algorithm support and validation.
+
+Centralises the set of asymmetric signing algorithms accepted across the
+library — JAR request objects (RFC 9101) and ``private_key_jwt`` client
+assertions (RFC 7523) — so the supported list and its validation are defined
+in exactly one place.
+"""
+
+from __future__ import annotations
+
+
+# Asymmetric signing algorithms supported for signed JWTs. Symmetric (HS*)
+# and ``none`` are intentionally excluded: request objects and client
+# assertions must be verifiable by the authorization server using a public
+# key.
+SUPPORTED_SIGNING_ALGORITHMS = frozenset(
+    {
+        "ES256",
+        "ES384",
+        "ES512",
+        "EdDSA",
+        "RS256",
+        "RS384",
+        "RS512",
+        "PS256",
+        "PS384",
+        "PS512",
+    }
+)
+
+
+def validate_signing_algorithm(algorithm: str, *, context: str = "signing") -> None:
+    """Validate that *algorithm* is a supported asymmetric signing algorithm.
+
+    Args:
+        algorithm: The JWS ``alg`` value to validate.
+        context: Short label naming the caller for the error message
+            (e.g. ``"JAR"`` or ``"client assertion"``).
+
+    Raises:
+        ValueError: If *algorithm* is not in
+            :data:`SUPPORTED_SIGNING_ALGORITHMS`.
+    """
+    if algorithm not in SUPPORTED_SIGNING_ALGORITHMS:
+        msg = (
+            f"Unsupported {context} algorithm: {algorithm}. "
+            f"Supported: {sorted(SUPPORTED_SIGNING_ALGORITHMS)}"
+        )
+        raise ValueError(msg)
+
+
+__all__ = [
+    "SUPPORTED_SIGNING_ALGORITHMS",
+    "validate_signing_algorithm",
+]

--- a/src/py_identity_model/core/models.py
+++ b/src/py_identity_model/core/models.py
@@ -7,7 +7,7 @@ This module contains all dataclasses and models used by both sync and async impl
 from __future__ import annotations
 
 from base64 import urlsafe_b64decode
-from dataclasses import dataclass, fields
+from dataclasses import dataclass, field, fields
 from enum import Enum
 import json
 from typing import TYPE_CHECKING, Any, ClassVar
@@ -581,7 +581,10 @@ class PrivateKeyJwt:
         lifetime: Assertion validity in seconds (default 300).
     """
 
-    private_key: str | bytes
+    # repr suppressed: the raw PEM signing key must never leak into logs,
+    # exception messages, or crash-reporter frame captures. Mirrors the
+    # ``repr=False`` treatment of secret-bearing request models below.
+    private_key: str | bytes = field(repr=False)
     algorithm: str = "PS256"
     kid: str | None = None
     audience: str | None = None

--- a/src/py_identity_model/core/models.py
+++ b/src/py_identity_model/core/models.py
@@ -556,6 +556,39 @@ class JwksResponse(BaseResponse):
 
 
 # ============================================================================
+# Client Authentication - private_key_jwt (RFC 7523, OIDC Core 1.0 Section 9)
+# ============================================================================
+
+
+@dataclass
+class PrivateKeyJwt:
+    """``private_key_jwt`` client authentication parameters (RFC 7523).
+
+    When supplied on a client-authenticating request, the client is
+    authenticated by a signed JWT assertion (OpenID Connect Core 1.0
+    Section 9) instead of a client secret.  It takes precedence over
+    ``client_secret`` when both are present.
+
+    Attributes:
+        private_key: PEM-encoded private key used to sign the assertion
+            (``bytes`` or ``str``).
+        algorithm: Asymmetric signing algorithm (default ``"PS256"``).
+            FAPI 2.0 requires ``PS256`` or ``ES256``.
+        kid: Optional key ID placed in the assertion JWT header to aid the
+            authorization server's key lookup.
+        audience: Override for the assertion ``aud`` claim.  Defaults to the
+            request ``address`` (the endpoint URL) when ``None``.
+        lifetime: Assertion validity in seconds (default 300).
+    """
+
+    private_key: str | bytes
+    algorithm: str = "PS256"
+    kid: str | None = None
+    audience: str | None = None
+    lifetime: int = 300
+
+
+# ============================================================================
 # Token Client Models
 # ============================================================================
 
@@ -567,13 +600,17 @@ class ClientCredentialsTokenRequest(BaseRequest):
     Attributes:
         address: The token endpoint URL.
         client_id: The client identifier.
-        client_secret: The client secret.
-        scope: Space-delimited list of requested scopes.
+        client_secret: The client secret (optional when authenticating with
+            ``private_key_jwt``).
+        scope: Space-delimited list of requested scopes (optional).
+        private_key_jwt: ``private_key_jwt`` authentication parameters.  When
+            set, takes precedence over ``client_secret`` (RFC 7523).
     """
 
     client_id: str
-    client_secret: str
-    scope: str
+    client_secret: str | None = None
+    scope: str | None = None
+    private_key_jwt: PrivateKeyJwt | None = None
 
 
 @dataclass(repr=False, eq=False)
@@ -613,6 +650,7 @@ class AuthorizationCodeTokenRequest(BaseRequest):
     code_verifier: str | None = None
     client_secret: str | None = None
     scope: str | None = None
+    private_key_jwt: PrivateKeyJwt | None = None
 
 
 @dataclass(repr=False, eq=False)
@@ -650,6 +688,7 @@ class RefreshTokenRequest(BaseRequest):
     refresh_token: str
     scope: str | None = None
     client_secret: str | None = None
+    private_key_jwt: PrivateKeyJwt | None = None
 
 
 @dataclass
@@ -687,6 +726,7 @@ class TokenIntrospectionRequest(BaseRequest):
     client_id: str
     token_type_hint: str | None = None
     client_secret: str | None = None
+    private_key_jwt: PrivateKeyJwt | None = None
 
 
 @dataclass(repr=False, eq=False)
@@ -739,6 +779,7 @@ class PushedAuthorizationRequest(BaseRequest):
     code_challenge: str | None = None
     code_challenge_method: str | None = None
     client_secret: str | None = None
+    private_key_jwt: PrivateKeyJwt | None = None
 
 
 @dataclass
@@ -774,6 +815,7 @@ class DeviceAuthorizationRequest(BaseRequest):
     client_id: str
     scope: str = "openid"
     client_secret: str | None = None
+    private_key_jwt: PrivateKeyJwt | None = None
 
 
 @dataclass
@@ -818,6 +860,7 @@ class DeviceTokenRequest(BaseRequest):
     client_id: str
     device_code: str
     client_secret: str | None = None
+    private_key_jwt: PrivateKeyJwt | None = None
 
 
 @dataclass
@@ -878,6 +921,7 @@ class TokenExchangeRequest(BaseRequest):
     scope: str | None = None
     requested_token_type: str | None = None
     client_secret: str | None = None
+    private_key_jwt: PrivateKeyJwt | None = None
 
 
 @dataclass
@@ -918,6 +962,7 @@ class TokenRevocationRequest(BaseRequest):
     client_id: str
     token_type_hint: str | None = None
     client_secret: str | None = None
+    private_key_jwt: PrivateKeyJwt | None = None
 
 
 @dataclass(repr=False, eq=False)

--- a/src/py_identity_model/core/par_logic.py
+++ b/src/py_identity_model/core/par_logic.py
@@ -10,6 +10,7 @@ import httpx
 
 from ..logging_config import logger
 from ..logging_utils import redact_url
+from .client_assertion import apply_private_key_jwt
 from .models import PushedAuthorizationRequest, PushedAuthorizationResponse
 
 
@@ -50,7 +51,16 @@ def prepare_par_request_data(
     headers = {"Content-Type": "application/x-www-form-urlencoded"}
 
     auth: tuple[str, str] | None = None
-    if request.client_secret:
+    if request.private_key_jwt is not None:
+        # RFC 7523: private_key_jwt assertion in body (client_id already
+        # present for PAR per RFC 9126), no auth header.
+        apply_private_key_jwt(
+            params,
+            request.private_key_jwt,
+            client_id=request.client_id,
+            default_audience=request.address,
+        )
+    elif request.client_secret:
         auth = (request.client_id, request.client_secret)
 
     return params, headers, auth

--- a/src/py_identity_model/core/revocation_logic.py
+++ b/src/py_identity_model/core/revocation_logic.py
@@ -8,6 +8,7 @@ import httpx
 
 from ..logging_config import logger
 from ..logging_utils import redact_url
+from .client_assertion import apply_private_key_jwt
 from .models import TokenRevocationRequest, TokenRevocationResponse
 
 
@@ -34,7 +35,15 @@ def prepare_revocation_request_data(
     headers = {"Content-Type": "application/x-www-form-urlencoded"}
 
     auth: tuple[str, str] | None = None
-    if request.client_secret and request.client_secret.strip():
+    if request.private_key_jwt is not None:
+        # RFC 7523: private_key_jwt assertion in body, no auth header.
+        apply_private_key_jwt(
+            params,
+            request.private_key_jwt,
+            client_id=request.client_id,
+            default_audience=request.address,
+        )
+    elif request.client_secret and request.client_secret.strip():
         auth = (request.client_id, request.client_secret)
     else:
         params["client_id"] = request.client_id

--- a/src/py_identity_model/core/token_client_logic.py
+++ b/src/py_identity_model/core/token_client_logic.py
@@ -77,7 +77,9 @@ def prepare_token_request_data(
             client_id=request.client_id,
             default_audience=request.address,
         )
-    elif request.client_secret:
+    elif request.client_secret is not None:
+        # ``is not None`` (not truthiness) mirrors the auth-code/refresh
+        # branches so an empty-string secret is handled identically here.
         auth = (request.client_id, request.client_secret)
     else:
         params["client_id"] = request.client_id

--- a/src/py_identity_model/core/token_client_logic.py
+++ b/src/py_identity_model/core/token_client_logic.py
@@ -9,6 +9,7 @@ import httpx
 
 from ..logging_config import logger
 from ..logging_utils import redact_url
+from .client_assertion import apply_private_key_jwt
 from .error_handlers import (
     handle_auth_code_token_error,
     handle_refresh_token_error,
@@ -54,19 +55,34 @@ def log_token_success(token_response: ClientCredentialsTokenResponse) -> None:
 
 def prepare_token_request_data(
     request: ClientCredentialsTokenRequest,
-) -> tuple[dict, dict]:
-    """
-    Prepare request data and headers for token request.
-
-    Args:
-        request: Client credentials token request
+) -> tuple[dict, dict, tuple[str, str] | None]:
+    """Prepare request data, headers, and optional auth for a token request.
 
     Returns:
-        Tuple of (data dict, headers dict)
+        ``(data, headers, auth)`` where *auth* is the HTTP Basic tuple for
+        ``client_secret`` authentication, or ``None`` when ``private_key_jwt``
+        is used (the assertion is carried in the body).
     """
-    params = {"grant_type": "client_credentials", "scope": request.scope}
+    params: dict[str, str] = {"grant_type": "client_credentials"}
+    if request.scope is not None:
+        params["scope"] = request.scope
+
     headers = {"Content-Type": "application/x-www-form-urlencoded"}
-    return params, headers
+
+    auth: tuple[str, str] | None = None
+    if request.private_key_jwt is not None:
+        apply_private_key_jwt(
+            params,
+            request.private_key_jwt,
+            client_id=request.client_id,
+            default_audience=request.address,
+        )
+    elif request.client_secret:
+        auth = (request.client_id, request.client_secret)
+    else:
+        params["client_id"] = request.client_id
+
+    return params, headers, auth
 
 
 def process_token_response(
@@ -128,7 +144,15 @@ def prepare_auth_code_token_request_data(
     headers = {"Content-Type": "application/x-www-form-urlencoded"}
 
     auth: tuple[str, str] | None = None
-    if request.client_secret is not None:
+    if request.private_key_jwt is not None:
+        # RFC 7523: private_key_jwt assertion in body, no auth header.
+        apply_private_key_jwt(
+            params,
+            request.private_key_jwt,
+            client_id=request.client_id,
+            default_audience=request.address,
+        )
+    elif request.client_secret is not None:
         # RFC 6749 §2.3.1: use Basic auth for confidential clients;
         # client_id is carried in the auth header, not the body.
         auth = (request.client_id, request.client_secret)
@@ -179,7 +203,15 @@ def prepare_refresh_token_request_data(
     headers = {"Content-Type": "application/x-www-form-urlencoded"}
 
     auth: tuple[str, str] | None = None
-    if request.client_secret is not None:
+    if request.private_key_jwt is not None:
+        # RFC 7523: private_key_jwt assertion in body, no auth header.
+        apply_private_key_jwt(
+            params,
+            request.private_key_jwt,
+            client_id=request.client_id,
+            default_audience=request.address,
+        )
+    elif request.client_secret is not None:
         # RFC 6749 §2.3.1: use Basic auth for confidential clients;
         # client_id is carried in the auth header, not the body.
         auth = (request.client_id, request.client_secret)

--- a/src/py_identity_model/core/token_exchange_logic.py
+++ b/src/py_identity_model/core/token_exchange_logic.py
@@ -10,6 +10,7 @@ import httpx
 
 from ..logging_config import logger
 from ..logging_utils import redact_url
+from .client_assertion import apply_private_key_jwt
 from .models import TokenExchangeRequest, TokenExchangeResponse
 
 
@@ -102,7 +103,15 @@ def prepare_token_exchange_request_data(
 
     # RFC 6749 §2.3.1 — client_id excluded from body when using Basic Auth
     auth: tuple[str, str] | None = None
-    if request.client_secret:
+    if request.private_key_jwt is not None:
+        # RFC 7523: private_key_jwt assertion in body, no auth header.
+        apply_private_key_jwt(
+            params,
+            request.private_key_jwt,
+            client_id=request.client_id,
+            default_audience=request.address,
+        )
+    elif request.client_secret:
         auth = (request.client_id, request.client_secret)
     else:
         params["client_id"] = request.client_id

--- a/src/py_identity_model/logging_utils.py
+++ b/src/py_identity_model/logging_utils.py
@@ -41,6 +41,8 @@ def redact_sensitive(data: dict[str, Any]) -> dict[str, Any]:
         "secret",
         "api_key",
         "apikey",
+        "private_key",
+        "client_assertion",
     }
 
     redacted = data.copy()

--- a/src/py_identity_model/sync/__init__.py
+++ b/src/py_identity_model/sync/__init__.py
@@ -28,7 +28,7 @@ from ..core.fapi import (
     validate_fapi_discovery,
 )
 from ..core.jar import build_jar_authorization_url, create_request_object
-from ..core.models import BaseRequest, BaseResponse
+from ..core.models import BaseRequest, BaseResponse, PrivateKeyJwt
 from ..core.pkce import (
     generate_code_challenge,
     generate_code_verifier,
@@ -143,6 +143,7 @@ __all__ = [
     "JwksRequest",
     "JwksResponse",
     # PAR
+    "PrivateKeyJwt",
     "PushedAuthorizationRequest",
     "PushedAuthorizationResponse",
     # Refresh Token

--- a/src/py_identity_model/sync/device_auth.py
+++ b/src/py_identity_model/sync/device_auth.py
@@ -46,10 +46,10 @@ def request_device_authorization(
         and ``verification_uri`` for user display.
     """
     log_device_auth_request(request)
-    params, headers, auth = prepare_device_auth_request_data(request)
 
     response = None
     try:
+        params, headers, auth = prepare_device_auth_request_data(request)
         client = http_client.client if http_client else get_http_client()
         response = _request_device_auth(client, request.address, params, headers, auth)
         return process_device_auth_response(response)
@@ -91,10 +91,10 @@ def poll_device_token(
         indicating poll status.
     """
     log_device_token_request(request)
-    params, headers, auth = prepare_device_token_request_data(request)
 
     response = None
     try:
+        params, headers, auth = prepare_device_token_request_data(request)
         client = http_client.client if http_client else get_http_client()
         response = _poll_device_token(client, request.address, params, headers, auth)
         return process_device_token_response(response)

--- a/src/py_identity_model/sync/introspection.py
+++ b/src/py_identity_model/sync/introspection.py
@@ -47,10 +47,10 @@ def introspect_token(
         TokenIntrospectionResponse with claims dict including ``active`` bool.
     """
     log_introspection_request(request)
-    params, headers, auth = prepare_introspection_request_data(request)
 
     response = None
     try:
+        params, headers, auth = prepare_introspection_request_data(request)
         client = http_client.client if http_client else get_http_client()
         response = _introspect_token(client, request.address, params, headers, auth)
         return process_introspection_response(response)

--- a/src/py_identity_model/sync/revocation.py
+++ b/src/py_identity_model/sync/revocation.py
@@ -47,10 +47,10 @@ def revoke_token(
         TokenRevocationResponse indicating success or error.
     """
     log_revocation_request(request)
-    params, headers, auth = prepare_revocation_request_data(request)
 
     response = None
     try:
+        params, headers, auth = prepare_revocation_request_data(request)
         client = http_client.client if http_client else get_http_client()
         response = _revoke_token(client, request.address, params, headers, auth)
         return process_revocation_response(response)

--- a/src/py_identity_model/sync/token_client.py
+++ b/src/py_identity_model/sync/token_client.py
@@ -70,18 +70,12 @@ def request_client_credentials_token(
         ClientCredentialsTokenResponse: Token response
     """
     log_token_request(request)
-    params, headers = prepare_token_request_data(request)
+    params, headers, auth = prepare_token_request_data(request)
 
     response = None
     try:
         client = http_client.client if http_client else get_http_client()
-        response = _request_token(
-            client,
-            request.address,
-            params,
-            headers,
-            (request.client_id, request.client_secret),
-        )
+        response = _request_token(client, request.address, params, headers, auth)
         return process_token_response(response)
     except Exception as e:
         return handle_token_error(e)

--- a/src/py_identity_model/sync/token_client.py
+++ b/src/py_identity_model/sync/token_client.py
@@ -70,10 +70,10 @@ def request_client_credentials_token(
         ClientCredentialsTokenResponse: Token response
     """
     log_token_request(request)
-    params, headers, auth = prepare_token_request_data(request)
 
     response = None
     try:
+        params, headers, auth = prepare_token_request_data(request)
         client = http_client.client if http_client else get_http_client()
         response = _request_token(client, request.address, params, headers, auth)
         return process_token_response(response)
@@ -98,10 +98,10 @@ def request_authorization_code_token(
         AuthorizationCodeTokenResponse with token dict or error.
     """
     log_auth_code_token_request(request)
-    params, headers, auth = prepare_auth_code_token_request_data(request)
 
     response = None
     try:
+        params, headers, auth = prepare_auth_code_token_request_data(request)
         client = http_client.client if http_client else get_http_client()
         response = _request_token(client, request.address, params, headers, auth)
         return process_auth_code_token_response(response)
@@ -126,10 +126,10 @@ def refresh_token(
         RefreshTokenResponse with new token dict or error.
     """
     log_refresh_token_request(request)
-    params, headers, auth = prepare_refresh_token_request_data(request)
 
     response = None
     try:
+        params, headers, auth = prepare_refresh_token_request_data(request)
         client = http_client.client if http_client else get_http_client()
         response = _request_token(client, request.address, params, headers, auth)
         return process_refresh_token_response(response)

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -32,6 +32,7 @@ from py_identity_model import (
     JsonWebKey,
     JwksRequest,
     JwksResponse,
+    PrivateKeyJwt,
     get_discovery_document,
     get_jwks,
     parse_authorize_callback_response,
@@ -624,6 +625,7 @@ class AuthCodeFlowConfig:
     resource: str | None = None
     login_hint: str = "test-user"
     login_password: str = "test"
+    private_key_jwt: PrivateKeyJwt | None = None
 
 
 def perform_auth_code_flow(
@@ -731,6 +733,7 @@ def perform_auth_code_flow(
         redirect_uri=redirect_uri,
         code_verifier=code_verifier,
         client_secret=config.client_secret,
+        private_key_jwt=config.private_key_jwt,
     )
     token_response = request_authorization_code_token(token_request)
 

--- a/src/tests/integration/test_private_key_jwt.py
+++ b/src/tests/integration/test_private_key_jwt.py
@@ -31,6 +31,9 @@ from py_identity_model import (
     push_authorization_request,
     request_client_credentials_token,
 )
+from py_identity_model.aio import (
+    request_client_credentials_token as async_request_client_credentials_token,
+)
 
 from .conftest import AuthCodeFlowConfig, perform_auth_code_flow
 
@@ -239,3 +242,63 @@ class TestPrivateKeyJwtLive:
         )
         assert token_response.token is not None
         assert token_response.token.get("access_token")
+
+
+@pytest.mark.integration
+class TestPrivateKeyJwtLiveAsync:
+    """private_key_jwt via the async API against a live provider.
+
+    Issue #213 requires both sync and async paths to be exercised against a
+    real provider; the async client-authentication logic is shared with the
+    sync path via ``core/`` but the aio wrapper wiring is covered here.
+    """
+
+    async def test_client_credentials_with_private_key_jwt(
+        self,
+        raw_discovery,
+        token_endpoint,
+    ):
+        _require_node_oidc(raw_discovery)
+
+        response = await async_request_client_credentials_token(
+            ClientCredentialsTokenRequest(
+                address=token_endpoint,
+                client_id=PKJWT_CLIENT_ID,
+                scope="api",
+                private_key_jwt=_private_key_jwt(),
+            )
+        )
+
+        assert response.is_successful is True, (
+            f"async private_key_jwt client_credentials failed: {response.error}"
+        )
+        assert response.token is not None
+        assert response.token.get("access_token")
+        assert response.token.get("token_type", "").lower() == "bearer"
+
+    async def test_client_credentials_wrong_key_rejected(
+        self,
+        raw_discovery,
+        token_endpoint,
+    ):
+        _require_node_oidc(raw_discovery)
+
+        wrong_key = ec.generate_private_key(ec.SECP256R1()).private_bytes(
+            Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()
+        )
+
+        response = await async_request_client_credentials_token(
+            ClientCredentialsTokenRequest(
+                address=token_endpoint,
+                client_id=PKJWT_CLIENT_ID,
+                scope="api",
+                private_key_jwt=PrivateKeyJwt(
+                    private_key=wrong_key,
+                    algorithm=PKJWT_ALGORITHM,
+                    kid=PKJWT_KID,
+                ),
+            )
+        )
+
+        assert response.is_successful is False
+        assert response.error is not None

--- a/src/tests/integration/test_private_key_jwt.py
+++ b/src/tests/integration/test_private_key_jwt.py
@@ -1,0 +1,210 @@
+"""Integration tests for ``private_key_jwt`` client authentication.
+
+Exercises RFC 7523 / OpenID Connect Core 1.0 Section 9 client authentication
+against a live OIDC provider.  The library signs a ``client_assertion`` with
+the client's private key; the provider verifies it against the public JWK
+registered for the client.
+
+These tests are specific to the bundled node-oidc-provider fixture, which
+registers a ``test-private-key-jwt`` client whose public key matches the
+static private key embedded below.  They are skipped against any other
+provider (remote providers in the CI matrix do not register this client).
+"""
+
+import secrets
+
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+)
+import pytest
+
+from py_identity_model import (
+    ClientCredentialsTokenRequest,
+    PrivateKeyJwt,
+    PushedAuthorizationRequest,
+    generate_pkce_pair,
+    push_authorization_request,
+    request_client_credentials_token,
+)
+
+from .conftest import AuthCodeFlowConfig, perform_auth_code_flow
+
+
+# Client registered in the node-oidc-provider fixture (provider.js).
+PKJWT_CLIENT_ID = "test-private-key-jwt"
+PKJWT_REDIRECT_URI = "http://localhost:8080/callback"
+PKJWT_ALGORITHM = "ES256"
+PKJWT_KID = "pkjwt-client-key"
+
+# Static ES256 (P-256) private key. The matching public JWK is registered
+# for ``test-private-key-jwt`` in the node-oidc-provider fixture. Test-only
+# key — never use a checked-in key outside of a disposable test fixture.
+PKJWT_PRIVATE_KEY = """-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg8WGr0RG4Zo7/WD6g
+uOCH355J2/auzrggNZRPhCSxQfGhRANCAATbM7xgqsqkG4DJUQPYKHBlgV/OS3nZ
+E2+SampTwVolT/BEG7coOzdYem3Yr2FkBicTXhqWNGiG7RWkD+d/rVhW
+-----END PRIVATE KEY-----
+"""
+
+
+def _is_node_oidc_fixture(raw_discovery: dict) -> bool:
+    """Whether the active provider is the local private_key_jwt fixture.
+
+    The static key only matches the ``test-private-key-jwt`` client in the
+    bundled node-oidc-provider fixture, which runs on localhost and
+    advertises ``private_key_jwt`` support.
+    """
+    issuer = raw_discovery.get("issuer", "")
+    methods = raw_discovery.get("token_endpoint_auth_methods_supported", [])
+    return issuer.startswith(("http://localhost", "http://127.0.0.1")) and (
+        "private_key_jwt" in methods
+    )
+
+
+def _require_node_oidc(raw_discovery: dict) -> None:
+    if not _is_node_oidc_fixture(raw_discovery):
+        pytest.skip(
+            "private_key_jwt fixture client only registered in node-oidc-provider"
+        )
+
+
+def _private_key_jwt(audience: str | None = None) -> PrivateKeyJwt:
+    return PrivateKeyJwt(
+        private_key=PKJWT_PRIVATE_KEY,
+        algorithm=PKJWT_ALGORITHM,
+        kid=PKJWT_KID,
+        audience=audience,
+    )
+
+
+@pytest.mark.integration
+class TestPrivateKeyJwtLive:
+    """private_key_jwt client authentication against a live provider."""
+
+    def test_client_credentials_with_private_key_jwt(
+        self,
+        raw_discovery,
+        token_endpoint,
+    ):
+        """Token endpoint authenticates the client via a signed assertion.
+
+        No ``client_secret`` is supplied — the provider must accept solely on
+        the strength of the verified ``client_assertion``.
+        """
+        _require_node_oidc(raw_discovery)
+
+        response = request_client_credentials_token(
+            ClientCredentialsTokenRequest(
+                address=token_endpoint,
+                client_id=PKJWT_CLIENT_ID,
+                scope="api",
+                private_key_jwt=_private_key_jwt(),
+            )
+        )
+
+        assert response.is_successful is True, (
+            f"private_key_jwt client_credentials failed: {response.error}"
+        )
+        assert response.token is not None
+        assert response.token.get("access_token")
+        assert response.token.get("token_type", "").lower() == "bearer"
+
+    def test_client_credentials_wrong_key_rejected(
+        self,
+        raw_discovery,
+        token_endpoint,
+    ):
+        """A mismatched signing key is rejected — proves real verification.
+
+        A freshly generated key does not match the client's registered public
+        JWK, so the assertion signature must fail verification at the provider.
+        """
+        _require_node_oidc(raw_discovery)
+
+        wrong_key = ec.generate_private_key(ec.SECP256R1()).private_bytes(
+            Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()
+        )
+
+        response = request_client_credentials_token(
+            ClientCredentialsTokenRequest(
+                address=token_endpoint,
+                client_id=PKJWT_CLIENT_ID,
+                scope="api",
+                private_key_jwt=PrivateKeyJwt(
+                    private_key=wrong_key,
+                    algorithm=PKJWT_ALGORITHM,
+                    kid=PKJWT_KID,
+                ),
+            )
+        )
+
+        assert response.is_successful is False
+        assert response.error is not None
+
+    def test_par_with_private_key_jwt(
+        self,
+        provider_capabilities,
+        raw_discovery,
+    ):
+        """PAR endpoint authenticates the client via a signed assertion."""
+        _require_node_oidc(raw_discovery)
+        if "par" not in provider_capabilities:
+            pytest.skip("Provider does not support PAR")
+
+        endpoint = raw_discovery["pushed_authorization_request_endpoint"]
+        _verifier, challenge = generate_pkce_pair()
+
+        response = push_authorization_request(
+            PushedAuthorizationRequest(
+                address=endpoint,
+                client_id=PKJWT_CLIENT_ID,
+                redirect_uri=PKJWT_REDIRECT_URI,
+                scope="openid",
+                code_challenge=challenge,
+                code_challenge_method="S256",
+                state=secrets.token_urlsafe(32),
+                private_key_jwt=_private_key_jwt(),
+            )
+        )
+
+        assert response.is_successful is True, f"PAR failed: {response.error}"
+        assert response.request_uri is not None
+        assert response.request_uri.startswith("urn:ietf:params:oauth:request_uri:")
+        assert response.expires_in is not None
+        assert response.expires_in > 0
+
+    def test_authorization_code_with_private_key_jwt(
+        self,
+        provider_capabilities,
+        raw_discovery,
+        discovery_document,
+    ):
+        """Full auth-code flow exchanges the code with a signed assertion.
+
+        Drives the devInteractions login/consent to obtain a code, then
+        authenticates the token request with ``private_key_jwt`` (no secret).
+        """
+        _require_node_oidc(raw_discovery)
+        if "dev_interactions" not in provider_capabilities:
+            pytest.skip("Provider does not support automated auth code flow")
+
+        result = perform_auth_code_flow(
+            discovery=discovery_document,
+            client_id=PKJWT_CLIENT_ID,
+            redirect_uri=PKJWT_REDIRECT_URI,
+            config=AuthCodeFlowConfig(
+                scope="openid profile email offline_access",
+                resource="urn:test:api",
+                private_key_jwt=_private_key_jwt(),
+            ),
+        )
+
+        token_response = result["token_response"]
+        assert token_response.is_successful is True, (
+            f"auth-code private_key_jwt token exchange failed: {token_response.error}"
+        )
+        assert token_response.token is not None
+        assert token_response.token.get("access_token")

--- a/src/tests/integration/test_private_key_jwt.py
+++ b/src/tests/integration/test_private_key_jwt.py
@@ -11,6 +11,7 @@ static private key embedded below.  They are skipped against any other
 provider (remote providers in the CI matrix do not register this client).
 """
 
+import base64
 import secrets
 
 from cryptography.hazmat.primitives.asymmetric import ec
@@ -18,6 +19,7 @@ from cryptography.hazmat.primitives.serialization import (
     Encoding,
     NoEncryption,
     PrivateFormat,
+    load_pem_private_key,
 )
 import pytest
 
@@ -48,6 +50,35 @@ uOCH355J2/auzrggNZRPhCSxQfGhRANCAATbM7xgqsqkG4DJUQPYKHBlgV/OS3nZ
 E2+SampTwVolT/BEG7coOzdYem3Yr2FkBicTXhqWNGiG7RWkD+d/rVhW
 -----END PRIVATE KEY-----
 """
+
+# Public JWK coordinates registered for ``test-private-key-jwt`` in
+# ``test-fixtures/node-oidc-provider/provider.js``. The self-check below pins
+# the coupling so a key/JWK mismatch fails loudly instead of surfacing as an
+# opaque signature error (or a silent skip) during the live tests.
+PKJWT_REGISTERED_JWK_X = "2zO8YKrKpBuAyVED2ChwZYFfzkt52RNvkmpqU8FaJU8"
+PKJWT_REGISTERED_JWK_Y = "8EQbtyg7N1h6bdivYWQGJxNeGpY0aIbtFaQP53-tWFY"
+
+
+def _b64url_uint(value: int) -> str:
+    """Encode a P-256 coordinate as an unpadded base64url string (JWK form)."""
+    return base64.urlsafe_b64encode(value.to_bytes(32, "big")).rstrip(b"=").decode()
+
+
+@pytest.mark.unit
+def test_static_private_key_matches_registered_jwk():
+    """The checked-in private key's public half must equal the provider's JWK.
+
+    Runs in the unit suite (no network) so a copy-paste drift between the
+    private key here and the JWK in ``provider.js`` is caught immediately
+    rather than as an opaque live-test signature failure.
+    """
+    public_key = load_pem_private_key(
+        PKJWT_PRIVATE_KEY.encode(), password=None
+    ).public_key()
+    assert isinstance(public_key, ec.EllipticCurvePublicKey)
+    public_numbers = public_key.public_numbers()
+    assert _b64url_uint(public_numbers.x) == PKJWT_REGISTERED_JWK_X
+    assert _b64url_uint(public_numbers.y) == PKJWT_REGISTERED_JWK_Y
 
 
 def _is_node_oidc_fixture(raw_discovery: dict) -> bool:

--- a/src/tests/unit/test_client_assertion.py
+++ b/src/tests/unit/test_client_assertion.py
@@ -1,5 +1,6 @@
 """Unit tests for private_key_jwt client authentication (RFC 7523)."""
 
+import time
 from urllib.parse import parse_qs
 
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
@@ -96,6 +97,21 @@ class TestBuildClientAssertion:
         assert len(decoded["jti"]) == UUID_STRING_LENGTH
         assert isinstance(decoded["iat"], int)
         assert decoded["exp"] == decoded["iat"] + 120
+
+    def test_iat_nbf_backdated_for_clock_skew(self):
+        # iat/nbf are backdated a few seconds so an AS clock running slightly
+        # ahead does not reject a freshly minted assertion as not-yet-valid.
+        before = int(time.time())
+        token = build_client_assertion(
+            client_id="my-client",
+            audience="https://as.example.com/token",
+            private_key=_ec_keypair()[0],
+            algorithm="ES256",
+        )
+        decoded = pyjwt.decode(token, options={"verify_signature": False})
+        assert decoded["nbf"] == decoded["iat"]
+        # iat must be at or before "now" (never in the future).
+        assert decoded["iat"] <= before
 
     def test_signature_verifies_ps256(self):
         private_pem, public_pem = _rsa_keypair()
@@ -467,3 +483,31 @@ class TestEndToEndNoBasicHeader:
         body = parse_qs(sent.content.decode())
         assert "client_assertion" in body
         assert body["client_id"] == ["c"]
+
+
+@pytest.mark.unit
+class TestSigningFailureReturnsErrorResponse:
+    """A malformed signing key must yield a structured error response.
+
+    ``build_client_assertion`` runs inside the wrapper's ``try`` block, so a
+    ``pyjwt.encode`` failure on a bad PEM is routed through the endpoint's
+    error handler instead of propagating uncaught to the caller.
+    """
+
+    _BAD_KEY = PrivateKeyJwt(private_key="not-a-pem", algorithm="PS256")
+
+    def test_sync_client_credentials_bad_key_returns_error(self):
+        request = ClientCredentialsTokenRequest(
+            address=ADDR, client_id="c", scope="api", private_key_jwt=self._BAD_KEY
+        )
+        response = request_client_credentials_token(request)
+        assert response.is_successful is False
+        assert response.error
+
+    async def test_async_client_credentials_bad_key_returns_error(self):
+        request = ClientCredentialsTokenRequest(
+            address=ADDR, client_id="c", scope="api", private_key_jwt=self._BAD_KEY
+        )
+        response = await async_request_client_credentials_token(request)
+        assert response.is_successful is False
+        assert response.error

--- a/src/tests/unit/test_client_assertion.py
+++ b/src/tests/unit/test_client_assertion.py
@@ -1,0 +1,469 @@
+"""Unit tests for private_key_jwt client authentication (RFC 7523)."""
+
+from urllib.parse import parse_qs
+
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+    PublicFormat,
+)
+import httpx
+import jwt as pyjwt
+import pytest
+import respx
+
+from py_identity_model import (
+    AuthorizationCodeTokenRequest,
+    ClientCredentialsTokenRequest,
+    DeviceAuthorizationRequest,
+    DeviceTokenRequest,
+    PrivateKeyJwt,
+    PushedAuthorizationRequest,
+    RefreshTokenRequest,
+    TokenExchangeRequest,
+    TokenIntrospectionRequest,
+    TokenRevocationRequest,
+    request_authorization_code_token,
+    request_client_credentials_token,
+)
+from py_identity_model.aio import (
+    request_client_credentials_token as async_request_client_credentials_token,
+)
+from py_identity_model.core.client_assertion import (
+    apply_private_key_jwt,
+    build_client_assertion,
+)
+from py_identity_model.core.device_auth_logic import (
+    prepare_device_auth_request_data,
+    prepare_device_token_request_data,
+)
+from py_identity_model.core.introspection_logic import (
+    prepare_introspection_request_data,
+)
+from py_identity_model.core.par_logic import prepare_par_request_data
+from py_identity_model.core.revocation_logic import prepare_revocation_request_data
+from py_identity_model.core.token_client_logic import (
+    prepare_auth_code_token_request_data,
+    prepare_refresh_token_request_data,
+    prepare_token_request_data,
+)
+from py_identity_model.core.token_exchange_logic import (
+    prepare_token_exchange_request_data,
+)
+
+
+UUID_STRING_LENGTH = 36
+JWT_BEARER_ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+
+
+def _ec_keypair() -> tuple[bytes, bytes]:
+    """Return (private_pem, public_pem) for an ES256 key."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    private_pem = key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption())
+    public_pem = key.public_key().public_bytes(
+        Encoding.PEM, PublicFormat.SubjectPublicKeyInfo
+    )
+    return private_pem, public_pem
+
+
+def _rsa_keypair() -> tuple[bytes, bytes]:
+    """Return (private_pem, public_pem) for a PS256/RS256 key."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption())
+    public_pem = key.public_key().public_bytes(
+        Encoding.PEM, PublicFormat.SubjectPublicKeyInfo
+    )
+    return private_pem, public_pem
+
+
+@pytest.mark.unit
+class TestBuildClientAssertion:
+    def test_claims_ec256(self):
+        private_pem, _ = _ec_keypair()
+        token = build_client_assertion(
+            client_id="my-client",
+            audience="https://as.example.com/token",
+            private_key=private_pem,
+            algorithm="ES256",
+            lifetime=120,
+        )
+        decoded = pyjwt.decode(token, options={"verify_signature": False})
+        assert decoded["iss"] == "my-client"
+        assert decoded["sub"] == "my-client"
+        assert decoded["aud"] == "https://as.example.com/token"
+        assert len(decoded["jti"]) == UUID_STRING_LENGTH
+        assert isinstance(decoded["iat"], int)
+        assert decoded["exp"] == decoded["iat"] + 120
+
+    def test_signature_verifies_ps256(self):
+        private_pem, public_pem = _rsa_keypair()
+        token = build_client_assertion(
+            client_id="my-client",
+            audience="https://as.example.com/token",
+            private_key=private_pem,
+            algorithm="PS256",
+        )
+        # Round-trips with the public key — proves a valid signature.
+        decoded = pyjwt.decode(
+            token,
+            public_pem,
+            algorithms=["PS256"],
+            audience="https://as.example.com/token",
+        )
+        assert decoded["iss"] == "my-client"
+
+    def test_signature_verifies_es256(self):
+        private_pem, public_pem = _ec_keypair()
+        token = build_client_assertion(
+            client_id="my-client",
+            audience="https://as.example.com/token",
+            private_key=private_pem,
+            algorithm="ES256",
+        )
+        decoded = pyjwt.decode(
+            token,
+            public_pem,
+            algorithms=["ES256"],
+            audience="https://as.example.com/token",
+        )
+        assert decoded["sub"] == "my-client"
+
+    def test_kid_header_included_when_provided(self):
+        private_pem, _ = _ec_keypair()
+        token = build_client_assertion(
+            client_id="my-client",
+            audience="https://as.example.com/token",
+            private_key=private_pem,
+            algorithm="ES256",
+            kid="key-1",
+        )
+        assert pyjwt.get_unverified_header(token)["kid"] == "key-1"
+
+    def test_kid_header_absent_by_default(self):
+        private_pem, _ = _ec_keypair()
+        token = build_client_assertion(
+            client_id="my-client",
+            audience="https://as.example.com/token",
+            private_key=private_pem,
+            algorithm="ES256",
+        )
+        assert "kid" not in pyjwt.get_unverified_header(token)
+
+    @pytest.mark.parametrize("algorithm", ["HS256", "none", "RS1"])
+    def test_unsupported_algorithm_raises(self, algorithm):
+        private_pem, _ = _ec_keypair()
+        with pytest.raises(ValueError, match="Unsupported client assertion algorithm"):
+            build_client_assertion(
+                client_id="my-client",
+                audience="https://as.example.com/token",
+                private_key=private_pem,
+                algorithm=algorithm,
+            )
+
+    @pytest.mark.parametrize(
+        ("client_id", "audience"),
+        [("", "https://as.example.com"), ("my-client", "")],
+    )
+    def test_empty_required_params_raise(self, client_id, audience):
+        private_pem, _ = _ec_keypair()
+        with pytest.raises(ValueError, match="must not be empty"):
+            build_client_assertion(
+                client_id=client_id,
+                audience=audience,
+                private_key=private_pem,
+                algorithm="ES256",
+            )
+
+    def test_empty_private_key_raises(self):
+        with pytest.raises(ValueError, match="private_key must not be empty"):
+            build_client_assertion(
+                client_id="my-client",
+                audience="https://as.example.com",
+                private_key="",
+                algorithm="ES256",
+            )
+
+    def test_nonpositive_lifetime_raises(self):
+        private_pem, _ = _ec_keypair()
+        with pytest.raises(ValueError, match="lifetime must be positive"):
+            build_client_assertion(
+                client_id="my-client",
+                audience="https://as.example.com",
+                private_key=private_pem,
+                algorithm="ES256",
+                lifetime=0,
+            )
+
+    def test_jti_unique_across_builds(self):
+        private_pem, _ = _ec_keypair()
+        kwargs = {
+            "client_id": "my-client",
+            "audience": "https://as.example.com",
+            "private_key": private_pem,
+            "algorithm": "ES256",
+        }
+        first = pyjwt.decode(
+            build_client_assertion(**kwargs), options={"verify_signature": False}
+        )
+        second = pyjwt.decode(
+            build_client_assertion(**kwargs), options={"verify_signature": False}
+        )
+        assert first["jti"] != second["jti"]
+
+
+@pytest.mark.unit
+class TestApplyPrivateKeyJwt:
+    def test_injects_assertion_params(self):
+        private_pem, _ = _ec_keypair()
+        params: dict[str, str] = {"grant_type": "client_credentials"}
+        apply_private_key_jwt(
+            params,
+            PrivateKeyJwt(private_key=private_pem, algorithm="ES256"),
+            client_id="my-client",
+            default_audience="https://as.example.com/token",
+        )
+        assert params["client_id"] == "my-client"
+        assert params["client_assertion_type"] == JWT_BEARER_ASSERTION_TYPE
+        decoded = pyjwt.decode(
+            params["client_assertion"], options={"verify_signature": False}
+        )
+        assert decoded["iss"] == "my-client"
+
+    def test_audience_defaults_to_address(self):
+        private_pem, _ = _ec_keypair()
+        params: dict[str, str] = {}
+        apply_private_key_jwt(
+            params,
+            PrivateKeyJwt(private_key=private_pem, algorithm="ES256"),
+            client_id="my-client",
+            default_audience="https://as.example.com/token",
+        )
+        decoded = pyjwt.decode(
+            params["client_assertion"], options={"verify_signature": False}
+        )
+        assert decoded["aud"] == "https://as.example.com/token"
+
+    def test_audience_override(self):
+        private_pem, _ = _ec_keypair()
+        params: dict[str, str] = {}
+        apply_private_key_jwt(
+            params,
+            PrivateKeyJwt(
+                private_key=private_pem,
+                algorithm="ES256",
+                audience="https://issuer.example.com",
+            ),
+            client_id="my-client",
+            default_audience="https://as.example.com/token",
+        )
+        decoded = pyjwt.decode(
+            params["client_assertion"], options={"verify_signature": False}
+        )
+        assert decoded["aud"] == "https://issuer.example.com"
+
+
+# Every client-authenticating endpoint and its prepare function. Each tuple is
+# (label, prepare_fn, request_obj) for every client-authenticating endpoint.
+# Each request carries a client_secret; the precedence tests add a
+# private_key_jwt on top to assert the assertion wins.
+ADDR = "https://as.example.com/endpoint"
+
+
+def _prepare_cases():
+    return [
+        (
+            "client_credentials",
+            prepare_token_request_data,
+            ClientCredentialsTokenRequest(
+                address=ADDR, client_id="c", client_secret="s", scope="api"
+            ),
+        ),
+        (
+            "auth_code",
+            prepare_auth_code_token_request_data,
+            AuthorizationCodeTokenRequest(
+                address=ADDR,
+                client_id="c",
+                code="abc",
+                redirect_uri="https://app/cb",
+                client_secret="s",
+            ),
+        ),
+        (
+            "refresh",
+            prepare_refresh_token_request_data,
+            RefreshTokenRequest(
+                address=ADDR, client_id="c", refresh_token="rt", client_secret="s"
+            ),
+        ),
+        (
+            "introspection",
+            prepare_introspection_request_data,
+            TokenIntrospectionRequest(
+                address=ADDR, token="t", client_id="c", client_secret="s"
+            ),
+        ),
+        (
+            "revocation",
+            prepare_revocation_request_data,
+            TokenRevocationRequest(
+                address=ADDR, token="t", client_id="c", client_secret="s"
+            ),
+        ),
+        (
+            "par",
+            prepare_par_request_data,
+            PushedAuthorizationRequest(
+                address=ADDR,
+                client_id="c",
+                redirect_uri="https://app/cb",
+                client_secret="s",
+            ),
+        ),
+        (
+            "device_auth",
+            prepare_device_auth_request_data,
+            DeviceAuthorizationRequest(address=ADDR, client_id="c", client_secret="s"),
+        ),
+        (
+            "device_token",
+            prepare_device_token_request_data,
+            DeviceTokenRequest(
+                address=ADDR, client_id="c", device_code="dc", client_secret="s"
+            ),
+        ),
+        (
+            "token_exchange",
+            prepare_token_exchange_request_data,
+            TokenExchangeRequest(
+                address=ADDR,
+                client_id="c",
+                subject_token="st",
+                subject_token_type="urn:ietf:params:oauth:token-type:access_token",
+                client_secret="s",
+            ),
+        ),
+    ]
+
+
+@pytest.mark.unit
+class TestPrepareFunctionPrecedence:
+    @pytest.mark.parametrize(
+        ("label", "prepare_fn", "request_obj"),
+        _prepare_cases(),
+        ids=lambda v: v if isinstance(v, str) else "",
+    )
+    def test_private_key_jwt_takes_precedence_over_secret(
+        self, label, prepare_fn, request_obj
+    ):
+        # Both client_secret and private_key_jwt set — assertion must win.
+        private_pem, _ = _ec_keypair()
+        request_obj.private_key_jwt = PrivateKeyJwt(
+            private_key=private_pem, algorithm="ES256"
+        )
+        params, _headers, auth = prepare_fn(request_obj)
+
+        # No HTTP Basic auth when using private_key_jwt.
+        assert auth is None, label
+        # Assertion carried in the body.
+        assert params["client_assertion_type"] == JWT_BEARER_ASSERTION_TYPE, label
+        decoded = pyjwt.decode(
+            params["client_assertion"], options={"verify_signature": False}
+        )
+        assert decoded["sub"] == "c", label
+        assert decoded["aud"] == ADDR, label
+
+    @pytest.mark.parametrize(
+        ("label", "prepare_fn", "request_obj"),
+        _prepare_cases(),
+        ids=lambda v: v if isinstance(v, str) else "",
+    )
+    def test_client_secret_used_when_no_private_key_jwt(
+        self, label, prepare_fn, request_obj
+    ):
+        # client_secret only — Basic auth, no assertion.
+        params, _headers, auth = prepare_fn(request_obj)
+        assert auth == ("c", "s"), label
+        assert "client_assertion" not in params, label
+
+
+@pytest.mark.unit
+class TestEndToEndNoBasicHeader:
+    @respx.mock
+    def test_sync_client_credentials_sends_assertion_no_basic(self):
+        private_pem, public_pem = _rsa_keypair()
+        route = respx.post(ADDR).mock(
+            return_value=httpx.Response(
+                200, json={"access_token": "x", "token_type": "Bearer"}
+            )
+        )
+        request = ClientCredentialsTokenRequest(
+            address=ADDR,
+            client_id="c",
+            scope="api",
+            private_key_jwt=PrivateKeyJwt(private_key=private_pem, algorithm="PS256"),
+        )
+        response = request_client_credentials_token(request)
+        assert response.is_successful
+
+        sent = route.calls.last.request
+        # No HTTP Basic Authorization header.
+        assert sent.headers.get("authorization") is None
+        body = parse_qs(sent.content.decode())
+        assert body["client_assertion_type"] == [JWT_BEARER_ASSERTION_TYPE]
+        # Assertion verifies against the public key.
+        decoded = pyjwt.decode(
+            body["client_assertion"][0],
+            public_pem,
+            algorithms=["PS256"],
+            audience=ADDR,
+        )
+        assert decoded["iss"] == "c"
+
+    @respx.mock
+    async def test_async_client_credentials_sends_assertion_no_basic(self):
+        private_pem, _ = _ec_keypair()
+        route = respx.post(ADDR).mock(
+            return_value=httpx.Response(
+                200, json={"access_token": "x", "token_type": "Bearer"}
+            )
+        )
+        request = ClientCredentialsTokenRequest(
+            address=ADDR,
+            client_id="c",
+            scope="api",
+            private_key_jwt=PrivateKeyJwt(private_key=private_pem, algorithm="ES256"),
+        )
+        response = await async_request_client_credentials_token(request)
+        assert response.is_successful
+
+        sent = route.calls.last.request
+        assert sent.headers.get("authorization") is None
+        body = parse_qs(sent.content.decode())
+        assert body["client_assertion_type"] == [JWT_BEARER_ASSERTION_TYPE]
+
+    @respx.mock
+    def test_sync_auth_code_sends_assertion_no_basic(self):
+        private_pem, _ = _ec_keypair()
+        route = respx.post(ADDR).mock(
+            return_value=httpx.Response(
+                200, json={"access_token": "x", "token_type": "Bearer"}
+            )
+        )
+        request = AuthorizationCodeTokenRequest(
+            address=ADDR,
+            client_id="c",
+            code="abc",
+            redirect_uri="https://app/cb",
+            private_key_jwt=PrivateKeyJwt(private_key=private_pem, algorithm="ES256"),
+        )
+        response = request_authorization_code_token(request)
+        assert response.is_successful
+
+        sent = route.calls.last.request
+        assert sent.headers.get("authorization") is None
+        body = parse_qs(sent.content.decode())
+        assert "client_assertion" in body
+        assert body["client_id"] == ["c"]

--- a/src/tests/unit/test_client_assertion.py
+++ b/src/tests/unit/test_client_assertion.py
@@ -146,6 +146,25 @@ class TestBuildClientAssertion:
         )
         assert decoded["sub"] == "my-client"
 
+    def test_signature_verifies_rs256(self):
+        # RS256 is in SUPPORTED_SIGNING_ALGORITHMS; exercise it explicitly so
+        # the non-FAPI2 algorithm is not left unverified (issue #213 asks for
+        # RS256 + ES256 coverage).
+        private_pem, public_pem = _rsa_keypair()
+        token = build_client_assertion(
+            client_id="my-client",
+            audience="https://as.example.com/token",
+            private_key=private_pem,
+            algorithm="RS256",
+        )
+        decoded = pyjwt.decode(
+            token,
+            public_pem,
+            algorithms=["RS256"],
+            audience="https://as.example.com/token",
+        )
+        assert decoded["sub"] == "my-client"
+
     def test_kid_header_included_when_provided(self):
         private_pem, _ = _ec_keypair()
         token = build_client_assertion(
@@ -201,15 +220,40 @@ class TestBuildClientAssertion:
                 algorithm="ES256",
             )
 
-    def test_nonpositive_lifetime_raises(self):
+    @pytest.mark.parametrize("lifetime", [0, -30, 1, 10])
+    def test_lifetime_at_or_below_clock_skew_leeway_raises(self, lifetime):
+        # A lifetime <= the clock-skew leeway would mint an already-expired
+        # assertion (exp = (now - leeway) + lifetime <= now).
         private_pem, _ = _ec_keypair()
-        with pytest.raises(ValueError, match="lifetime must be positive"):
+        with pytest.raises(ValueError, match="clock-skew leeway"):
             build_client_assertion(
                 client_id="my-client",
                 audience="https://as.example.com",
                 private_key=private_pem,
                 algorithm="ES256",
-                lifetime=0,
+                lifetime=lifetime,
+            )
+
+    @pytest.mark.parametrize("value", [" ", "\t", "\n  "])
+    def test_whitespace_only_client_id_raises(self, value):
+        private_pem, _ = _ec_keypair()
+        with pytest.raises(ValueError, match="client_id must not be empty"):
+            build_client_assertion(
+                client_id=value,
+                audience="https://as.example.com",
+                private_key=private_pem,
+                algorithm="ES256",
+            )
+
+    def test_whitespace_only_kid_raises(self):
+        private_pem, _ = _ec_keypair()
+        with pytest.raises(ValueError, match="kid must be non-empty"):
+            build_client_assertion(
+                client_id="my-client",
+                audience="https://as.example.com",
+                private_key=private_pem,
+                algorithm="ES256",
+                kid="  ",
             )
 
     def test_jti_unique_across_builds(self):
@@ -227,6 +271,32 @@ class TestBuildClientAssertion:
             build_client_assertion(**kwargs), options={"verify_signature": False}
         )
         assert first["jti"] != second["jti"]
+
+
+@pytest.mark.unit
+class TestPrivateKeyJwtRepr:
+    """The PEM signing key must never surface in repr/str output."""
+
+    def test_repr_does_not_leak_private_key(self):
+        private_pem, _ = _ec_keypair()
+        config = PrivateKeyJwt(private_key=private_pem, algorithm="ES256", kid="k1")
+        rendered = repr(config)
+        assert "BEGIN" not in rendered
+        assert "PRIVATE KEY" not in rendered
+        if isinstance(private_pem, str):
+            assert private_pem not in rendered
+        # Non-secret fields remain visible for debuggability.
+        assert "ES256" in rendered
+        assert "k1" in rendered
+
+    def test_repr_of_request_holding_config_does_not_leak(self):
+        private_pem, _ = _ec_keypair()
+        request = ClientCredentialsTokenRequest(
+            address="https://as.example.com/token",
+            client_id="my-client",
+            private_key_jwt=PrivateKeyJwt(private_key=private_pem, algorithm="ES256"),
+        )
+        assert "BEGIN" not in repr(request)
 
 
 @pytest.mark.unit

--- a/test-fixtures/node-oidc-provider/provider.js
+++ b/test-fixtures/node-oidc-provider/provider.js
@@ -128,8 +128,38 @@ async function startProvider() {
         scope: "openid api",
         token_endpoint_auth_method: "client_secret_basic",
       },
-      // FAPI 2.0 client deferred to T125 — requires private_key_jwt,
-      // signed request objects, and PAR enforcement.
+      {
+        // private_key_jwt client (RFC 7523 / OIDC Core 1.0 Section 9).
+        // Authenticates with a signed JWT assertion instead of a secret.
+        // The matching ES256 private key is held by the integration test
+        // (src/tests/integration/test_private_key_jwt.py). Exercises the
+        // token endpoint (client_credentials + authorization_code) and the
+        // PAR endpoint under private_key_jwt client authentication.
+        client_id: "test-private-key-jwt",
+        grant_types: [
+          "client_credentials",
+          "authorization_code",
+          "refresh_token",
+        ],
+        response_types: ["code"],
+        redirect_uris: ["http://localhost:8080/callback"],
+        scope: "openid profile email offline_access api",
+        token_endpoint_auth_method: "private_key_jwt",
+        token_endpoint_auth_signing_alg: "ES256",
+        jwks: {
+          keys: [
+            {
+              kty: "EC",
+              crv: "P-256",
+              x: "2zO8YKrKpBuAyVED2ChwZYFfzkt52RNvkmpqU8FaJU8",
+              y: "8EQbtyg7N1h6bdivYWQGJxNeGpY0aIbtFaQP53-tWFY",
+              kid: "pkjwt-client-key",
+              use: "sig",
+              alg: "ES256",
+            },
+          ],
+        },
+      },
     ],
 
     // JWKS
@@ -266,6 +296,8 @@ async function startProvider() {
       requestObjectSigningAlgValues: ["RS256", "ES256"],
       dPoPSigningAlgValues: ["RS256", "ES256"],
       introspectionSigningAlgValues: ["RS256", "ES256"],
+      // FAPI 2.0 client authentication algorithms for private_key_jwt.
+      clientAuthSigningAlgValues: ["PS256", "ES256"],
     },
   };
 


### PR DESCRIPTION
## Summary
- Add **private_key_jwt** (RFC 7523 / OIDC Core §9) client authentication across every client-authenticating endpoint: token (auth-code, refresh, client-credentials), token-exchange, device-auth, device-token, PAR, introspection, revocation.
- New `core/client_assertion.py` — `build_client_assertion()` + `apply_private_key_jwt()`; injects `client_assertion` + `client_assertion_type` into the request body and returns `auth=None` (no Basic header).
- New `core/jwt_signing.py` — shared `SUPPORTED_SIGNING_ALGORITHMS` + `validate_signing_algorithm()`, extracted from `core/jar.py` (now reuses it; no duplication). FAPI 2.0 algorithms: **PS256/ES256**.
- New `PrivateKeyJwt` dataclass (`private_key`, `algorithm='PS256'`, `kid`, `audience`, `lifetime=300`); optional `private_key_jwt` field added to all 9 request models. Exported from sync + aio + root `__init__`.
- Precedence: **private_key_jwt > client_secret (Basic) > public (client_id in body)**.
- Normalized `prepare_token_request_data` (client-credentials) to the 3-tuple `(params, headers, auth)` contract; sync/aio wrappers consume `auth` instead of hardcoding Basic.
- Assertion claims `iss=sub=client_id`, `aud` (defaults to request address, overridable), `jti` (uuid4), `iat`/`nbf` backdated 10s for clock skew, `exp = iat + lifetime`.

Refs #213

## Review Findings Addressed
5 independent reviewers (Blind / Edge / Acceptance / Sentinel / Viper).
- **P0 (Blind + Edge, 14 sites):** `prepare_*_request_data()` now signs the assertion (pyjwt.encode), so a malformed PEM/key-alg mismatch raised uncaught outside the wrappers' try/except. **Fixed** — moved every sync+aio `prepare_*` call inside the existing try/except so signing failures route through the structured error handlers (regression tests added, sync + async).
- **P1 clock skew (Blind):** **Fixed** — backdate `iat`/`nbf` by a 10s leeway; `exp = iat + lifetime` preserved.
- **P1 fixture coupling (Blind):** **Fixed** — added a unit-tier self-check deriving the checked-in key's public coords and asserting equality with the provider.js JWK (fails loud on drift).
- **Security: Sentinel PASS, Viper PASS** (0 crit/high/med; 3 LOW informational, no change needed).
- **Acceptance 4 FAILs** (`client_secret_jwt`, `ClientAssertion(type,value)` model, FastAPI example) are **out of scope** per the issue's FAPI2 = private_key_jwt PS256/ES256 design — scope disagreements, not defects.

## Test plan
- [x] Unit tests pass (`src/tests/unit/test_client_assertion.py` — sync + async via respx, all-endpoint precedence, claim/signature/alg-validation/jti, bad-key→error, iat/nbf backdating, key↔JWK self-check)
- [x] Integration tests pass (`src/tests/integration/test_private_key_jwt.py` against node-oidc-provider: client-credentials, PAR, full auth-code exchange, adversarial wrong-key rejection — full suite **115 passed / 5 skipped**)
- [x] Lint passes (ruff, ruff format, pyrefly, 80% coverage)
- [x] Independent review agents passed
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)