### PR TITLE
build(fastapi): OIDF conformance regression for the RP router (all 3 profiles) + form_post support

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -135,3 +135,109 @@ jobs:
         if: always()
         working-directory: conformance
         run: docker compose down -v
+
+  # fastapi-identity-model package regression: the same local suite plans,
+  # driven against the real build_oidc_router via the rp-fastapi harness.
+  # Regression stage only — no hosted suite, no certification export (#242).
+  conformance-fastapi:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Start conformance suite
+        working-directory: conformance
+        run: docker compose up -d --build --wait
+        timeout-minutes: 10
+
+      - name: Wait for conformance suite
+        run: |
+          echo "Waiting for conformance suite at https://localhost.emobix.co.uk:8443..."
+          for i in $(seq 1 60); do
+            HTTP_CODE=$(curl -sk -o /dev/null -w '%{http_code}' https://localhost.emobix.co.uk:8443/ || true)
+            if [ "$HTTP_CODE" -ge 200 ] 2>/dev/null && [ "$HTTP_CODE" -lt 400 ] 2>/dev/null; then
+              echo "Conformance suite is ready (HTTP $HTTP_CODE)"
+              break
+            fi
+            if [ "$i" -eq 60 ]; then
+              echo "Timed out waiting for conformance suite"
+              docker compose -f conformance/docker-compose.yml logs server
+              exit 1
+            fi
+            sleep 5
+          done
+
+      - name: Wait for fastapi RP harness
+        run: |
+          echo "Waiting for fastapi RP harness at http://localhost:8889/health..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8889/health > /dev/null 2>&1; then
+              echo "fastapi RP harness is ready"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "Timed out waiting for fastapi RP harness"
+              docker compose -f conformance/docker-compose.yml logs rp-fastapi
+              exit 1
+            fi
+            sleep 2
+          done
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install test runner dependencies
+        run: pip install httpx
+
+      - name: Run Basic RP package regression
+        run: |
+          python conformance/run_tests.py \
+            --plan fastapi-basic-rp \
+            --rp-url http://localhost:8889 \
+            --output conformance/results/fastapi-basic-rp-latest.json \
+            --verbose
+
+      - name: Run Config RP package regression
+        # signing-key-rotation is a known pre-existing timeout — don't block other profiles
+        continue-on-error: true
+        run: |
+          python conformance/run_tests.py \
+            --plan fastapi-config-rp \
+            --rp-url http://localhost:8889 \
+            --output conformance/results/fastapi-config-rp-latest.json \
+            --verbose
+
+      - name: Run Form Post Basic RP package regression
+        run: |
+          python conformance/run_tests.py \
+            --plan fastapi-form-post-basic-rp \
+            --rp-url http://localhost:8889 \
+            --output conformance/results/fastapi-form-post-basic-rp-latest.json \
+            --verbose
+
+      - name: Collect suite and harness logs
+        if: always()
+        run: |
+          mkdir -p conformance/results/logs
+          docker compose -f conformance/docker-compose.yml logs server > conformance/results/logs/server.log 2>&1 || true
+          docker compose -f conformance/docker-compose.yml logs rp-fastapi > conformance/results/logs/rp-fastapi.log 2>&1 || true
+
+      - name: Upload conformance results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: conformance-fastapi-results
+          path: |
+            conformance/results/fastapi-*-latest.json
+            conformance/results/logs/
+          retention-days: 30
+
+      - name: Teardown
+        if: always()
+        working-directory: conformance
+        run: docker compose down -v

--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,19 @@ conformance-up: ## Start conformance suite and RP harness
 	  fi; \
 	  sleep 2; \
 	done
+	@echo "Waiting for fastapi RP harness at http://localhost:8889/health..."
+	@for i in $$(seq 1 30); do \
+	  if curl -sf http://localhost:8889/health > /dev/null 2>&1; then \
+	    echo "fastapi RP harness is ready"; \
+	    break; \
+	  fi; \
+	  if [ "$$i" -eq 30 ]; then \
+	    echo "Timed out waiting for fastapi RP harness"; \
+	    docker compose -f conformance/docker-compose.yml logs rp-fastapi; \
+	    exit 1; \
+	  fi; \
+	  sleep 2; \
+	done
 
 .PHONY: conformance-down
 conformance-down: ## Tear down conformance suite
@@ -170,6 +183,13 @@ else
 	uv run python conformance/run_tests.py --plan form-post-basic-rp --output conformance/results/form-post-basic-rp-latest.json --verbose
 	@echo "Conformance tests complete. Results in conformance/results/"
 endif
+
+.PHONY: conformance-test-fastapi
+conformance-test-fastapi: conformance-up ## Run fastapi-identity-model package regression against the local suite
+	uv run python conformance/run_tests.py --plan fastapi-basic-rp --rp-url http://localhost:8889 --output conformance/results/fastapi-basic-rp-latest.json --verbose
+	uv run python conformance/run_tests.py --plan fastapi-config-rp --rp-url http://localhost:8889 --output conformance/results/fastapi-config-rp-latest.json --verbose
+	uv run python conformance/run_tests.py --plan fastapi-form-post-basic-rp --rp-url http://localhost:8889 --output conformance/results/fastapi-form-post-basic-rp-latest.json --verbose
+	@echo "fastapi-identity-model conformance regression complete. Results in conformance/results/"
 
 .PHONY: conformance-test-harness
 conformance-test-harness: ## Run conformance harness unit tests (parser + callback)

--- a/conformance/Dockerfile.fastapi
+++ b/conformance/Dockerfile.fastapi
@@ -1,0 +1,23 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install harness dependencies
+COPY conformance/requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Install py-identity-model from source (satisfies the package's core dependency)
+COPY pyproject.toml README.md ./
+COPY src/ src/
+RUN pip install --no-cache-dir .
+
+# Install the fastapi-identity-model workspace package under test
+COPY packages/fastapi-identity-model/ packages/fastapi-identity-model/
+RUN pip install --no-cache-dir packages/fastapi-identity-model/
+
+# Copy harness apps (app_fastapi.py reuses app.py's per-test log plumbing)
+COPY conformance/app.py conformance/app_fastapi.py ./
+
+EXPOSE 8889
+
+CMD ["uvicorn", "app_fastapi:app", "--host", "0.0.0.0", "--port", "8889"]

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -6,6 +6,9 @@ Test infrastructure for running the [OpenID Foundation conformance suite](https:
 
 - **Conformance suite** — OIDF Java server + MongoDB + nginx (TLS termination)
 - **RP harness** — Thin FastAPI app using py-identity-model's sync API
+- **Package RP harness** (`app_fastapi.py`, port 8889) — drives the real
+  `fastapi_identity_model.build_oidc_router` through the same plans, one
+  in-process router per test issuer (regression stage, not a certification target)
 - **Test runner** — Python script that orchestrates test plans via the suite's REST API
 
 ## Quick Start
@@ -44,6 +47,14 @@ The conformance suite uses `localhost.emobix.co.uk` which resolves to `127.0.0.1
 |------|--------|-------------|
 | `basic-rp` | `configs/basic-rp.json` | Basic RP certification (code flow, client_secret_basic) |
 | `config-rp` | `configs/config-rp.json` | Config RP certification (discovery-based config) |
+| `form-post-basic-rp` | `configs/form-post-basic-rp.json` | Basic RP with `form_post` response mode |
+| `fastapi-basic-rp` | `configs/fastapi-basic-rp.json` | Basic RP regression for the fastapi-identity-model router (`--rp-url http://localhost:8889`) |
+| `fastapi-config-rp` | `configs/fastapi-config-rp.json` | Config RP regression for the fastapi-identity-model router |
+| `fastapi-form-post-basic-rp` | `configs/fastapi-form-post-basic-rp.json` | Form Post Basic RP regression for the fastapi-identity-model router |
+
+The `fastapi-*` plans run the identical suite plans against the package harness
+(`make conformance-test-fastapi`). They are a CI regression shield for the
+package — the core library remains the OIDF certification target (#242).
 
 ## Profile Test Counts
 

--- a/conformance/app_fastapi.py
+++ b/conformance/app_fastapi.py
@@ -1,0 +1,450 @@
+"""OIDC RP conformance harness for the fastapi-identity-model package.
+
+Exposes the same runner-facing contract as ``app.py`` (``GET /authorize``,
+``GET/POST /callback``, ``GET /discover``, ``POST /clear-cache``, ``/health``,
+per-test log routing) so ``run_tests.py`` drives it unchanged — but instead of
+re-implementing the login orchestration with the core library, it delegates
+every flow to the REAL ``fastapi_identity_model.build_oidc_router``.
+
+This is a regression stage, not a second certification (#242): the core
+library is the certification target; this harness proves the package's RP
+router survives the same OIDF RP suite (invalid iss/aud/sig, nonce,
+missing-sub, kid, key rotation, form_post) the library passes.
+
+How it works — the OIDF suite varies the issuer per test module, while the
+router binds one ``OIDCSettings.discovery_url`` at build time. So the harness
+builds a fresh FastAPI app (SessionMiddleware + router) per ``/authorize``,
+drives its ``/login`` in-process over ``httpx.ASGITransport``, and keeps the
+``(client, cookie jar)`` pair keyed by the flow's ``state`` — the same
+state-keyed recovery ``app.py`` uses for its sessions. When the OP calls back
+(query or form_post) the harness recovers the pair by ``state`` and replays
+the callback into that per-test router, flow cookie and all. The router's own
+verdict (302 = login established, 4xx/5xx = rejected) is the test outcome.
+
+The router always uses PKCE and always attempts UserInfo when available, so
+the runner's ``use_pkce``/``skip_userinfo`` hints are accepted but not acted
+on — both behaviours are safe supersets of what the suite requires.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import html
+import logging
+import os
+import secrets
+from urllib.parse import parse_qs, parse_qsl, urlparse
+
+# Shared per-test log plumbing from the library harness: the ContextVar-based
+# active-test pointer and the handler that routes records to per-test files.
+# Importing ``app`` also installs its handler on the ``py_identity_model``
+# logger (and raises it to DEBUG), so only the package loggers need wiring here.
+from app import _PerTestLogRouter, _set_active_test
+from fastapi import FastAPI, Query, Request
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+import httpx
+from starlette.middleware.sessions import SessionMiddleware
+
+from fastapi_identity_model import OIDCSettings, build_oidc_router
+from py_identity_model import parse_discovery_url
+from py_identity_model.aio.token_validation import (
+    clear_discovery_cache,
+    clear_jwks_cache,
+)
+from py_identity_model.exceptions import ConfigurationException
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("conformance-rp-fastapi")
+
+
+def _install_rp_log_router() -> None:
+    router = _PerTestLogRouter()
+    router.setFormatter(
+        logging.Formatter("%(asctime)s %(levelname)-8s %(name)s: %(message)s")
+    )
+    for name in ("conformance-rp-fastapi", "fastapi_identity_model"):
+        logging.getLogger(name).addHandler(router)
+    # Capture the package's own decision detail in the per-test logs.
+    logging.getLogger("fastapi_identity_model").setLevel(logging.DEBUG)
+
+
+_install_rp_log_router()
+
+app = FastAPI(title="fastapi-identity-model Conformance RP")
+
+RP_BASE_URL = os.environ.get("RP_BASE_URL", "http://localhost:8889")
+
+# Scopes the library harness requests by default; kept identical so the
+# scope-userinfo-claims test sees the same claim surface from the router.
+DEFAULT_SCOPE = "openid profile email address phone"
+
+HTTP_FOUND = 302
+
+# ---------------------------------------------------------------------------
+# Per-flow state — (per-test router app, ASGI client with its cookie jar)
+# keyed by the ``state`` parameter, mirroring app.py's session recovery
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FlowSession:
+    """Tracks one login flow between /authorize and /callback."""
+
+    client: httpx.AsyncClient  # bound to the per-test app; holds the flow cookie
+    issuer: str
+    test_id: str = ""
+    test_name: str = ""
+    profile: str = ""
+    result: dict = field(default_factory=dict)
+
+
+# state -> FlowSession
+flows: dict[str, FlowSession] = {}
+
+# test_id -> result dict (for /results/{test_id} debugging parity with app.py)
+test_results: dict[str, dict] = {}
+
+
+def _store_test_result(flow: FlowSession) -> None:
+    if flow.test_id:
+        flow.result.setdefault("test_id", flow.test_id)
+        test_results[flow.test_id] = flow.result
+
+
+def _record_error(test_id: str, error: str) -> None:
+    if test_id:
+        test_results[test_id] = {
+            "test_id": test_id,
+            "status": "error",
+            "error": error,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Per-test router construction
+# ---------------------------------------------------------------------------
+
+
+def _build_test_app(settings: OIDCSettings) -> FastAPI:
+    """A minimal app hosting the real OIDC router for one test's issuer."""
+    test_app = FastAPI()
+    test_app.add_middleware(SessionMiddleware, secret_key=secrets.token_urlsafe(32))
+    test_app.include_router(build_oidc_router(settings, store_tokens=True))
+
+    @test_app.get("/session")
+    async def session_view(request: Request) -> JSONResponse:
+        """Expose the router-established identity so the harness can report it."""
+        return JSONResponse(content=request.session.get("oidc") or {})
+
+    return test_app
+
+
+def _build_test_client(test_app: FastAPI) -> httpx.AsyncClient:
+    # base_url matches the public RP base so the router sees the same URLs the
+    # OP redirects to. Generous timeout: one replayed /callback wraps the whole
+    # token exchange + JWKS refresh/retry sequence.
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=test_app),
+        base_url=RP_BASE_URL,
+        timeout=httpx.Timeout(120.0),
+    )
+
+
+def _error_detail(resp: httpx.Response) -> str:
+    """Best-effort extraction of a FastAPI error detail from a router response."""
+    try:
+        payload = resp.json()
+    except ValueError:
+        return resp.text
+    if isinstance(payload, dict):
+        return str(payload.get("detail", payload))
+    return str(payload)
+
+
+# ---------------------------------------------------------------------------
+# Endpoints (same contract as app.py)
+# ---------------------------------------------------------------------------
+
+
+@app.get("/")
+@app.get("/health")
+def health() -> dict:
+    """Health check."""
+    return {"status": "ok", "service": "conformance-rp-fastapi"}
+
+
+@app.post("/clear-cache")
+async def clear_cache() -> dict:
+    """Clear library caches (and stale flows) between conformance tests.
+
+    The suite reconfigures the OP's JWKS between test modules; the router
+    validates through the ``py_identity_model.aio`` global caches, so those
+    are what must be cleared.
+    """
+    _set_active_test(None, None)
+    for state in list(flows):
+        stale = flows.pop(state)
+        await stale.client.aclose()
+    await clear_discovery_cache()
+    await clear_jwks_cache()
+    logger.info("Cleared discovery and JWKS caches")
+    return {"status": "ok", "cleared": ["discovery", "jwks"]}
+
+
+@app.get("/discover", response_model=None)
+async def discover(
+    issuer: str = Query(..., description="Issuer URL for this test"),
+    test_id: str = Query("", description="Test module ID for result tracking"),
+    test_name: str = Query("", description="Test module name for RP log capture"),
+    profile: str = Query("", description="Profile/plan name for RP log capture"),
+) -> JSONResponse:
+    """Drive the router's /login far enough to fetch + validate discovery.
+
+    The router performs discovery (with the library's issuer validation) as
+    the first step of ``/login``; a 302 back means the document was fetched
+    and its issuer matched, a 5xx means the router refused it. No redirect is
+    ever followed, so no authorization request reaches the OP — which is what
+    the discovery-only and issuer-mismatch tests observe.
+    """
+    _set_active_test(profile, test_name)
+    try:
+        disco_endpoint = parse_discovery_url(issuer)
+    except ConfigurationException as exc:
+        logger.error("REJECTED: invalid issuer URL: %s", exc)
+        _record_error(test_id, f"invalid_issuer: {exc}")
+        return JSONResponse(
+            status_code=400,
+            content={"error": "invalid_issuer", "detail": "Invalid issuer URL"},
+        )
+
+    settings = OIDCSettings(
+        discovery_url=disco_endpoint.url,
+        client_id="conformance-rp",
+        redirect_uri=f"{RP_BASE_URL}/callback",
+    )
+    client = _build_test_client(_build_test_app(settings))
+    try:
+        resp = await client.get("/login")
+    finally:
+        await client.aclose()
+
+    if resp.status_code != HTTP_FOUND:
+        detail = _error_detail(resp)
+        logger.error("REJECTED: router refused discovery: %s", detail)
+        _record_error(test_id, f"discovery_failed: {detail}")
+        return JSONResponse(
+            status_code=502,
+            content={"error": "discovery_failed", "detail": detail},
+        )
+
+    if test_id:
+        test_results[test_id] = {
+            "test_id": test_id,
+            "status": "success",
+            "issuer": issuer,
+        }
+    logger.info(
+        "ACCEPTED: discovery document fetched and validated for issuer '%s'",
+        issuer,
+    )
+    return JSONResponse(content={"status": "ok", "issuer": issuer})
+
+
+@app.get("/authorize", response_model=None)
+async def authorize(
+    issuer: str = Query(..., description="Issuer URL for this test"),
+    client_id: str = Query(..., description="Client ID registered with the suite"),
+    client_secret: str = Query("", description="Client secret"),
+    test_id: str = Query("", description="Test module ID for result tracking"),
+    test_name: str = Query("", description="Test module name for RP log capture"),
+    profile: str = Query("", description="Profile/plan name for RP log capture"),
+    use_pkce: str = Query("false", description="Ignored: the router always uses PKCE"),
+    skip_userinfo: str = Query(
+        "false", description="Ignored: the router always attempts UserInfo"
+    ),
+    scope: str = Query(DEFAULT_SCOPE, description="Requested scopes"),
+) -> RedirectResponse | JSONResponse:
+    """Build a per-test router and start its login flow.
+
+    The router owns discovery, issuer validation, state/nonce/PKCE and the
+    authorization URL; the harness only relays its 302 to the runner and
+    parks the flow client for the callback.
+    """
+    _set_active_test(profile, test_name)
+    try:
+        disco_endpoint = parse_discovery_url(issuer)
+    except ConfigurationException as exc:
+        logger.error("REJECTED: invalid issuer URL: %s", exc)
+        _record_error(test_id, f"invalid_issuer: {exc}")
+        return JSONResponse(
+            status_code=400,
+            content={"error": "invalid_issuer", "detail": "Invalid issuer URL"},
+        )
+
+    settings = OIDCSettings(
+        discovery_url=disco_endpoint.url,
+        client_id=client_id,
+        client_secret=client_secret or None,
+        redirect_uri=f"{RP_BASE_URL}/callback",
+        scope=scope,
+    )
+    client = _build_test_client(_build_test_app(settings))
+
+    resp = await client.get("/login")
+    if resp.status_code != HTTP_FOUND:
+        detail = _error_detail(resp)
+        logger.error(
+            "REJECTED: router /login failed (%d): %s", resp.status_code, detail
+        )
+        _record_error(test_id, f"login_failed: {detail}")
+        await client.aclose()
+        return JSONResponse(
+            status_code=502,
+            content={"error": "login_failed", "detail": detail},
+        )
+
+    location = resp.headers.get("location", "")
+    state_values = parse_qs(urlparse(location).query).get("state", [])
+    if not state_values:
+        logger.error("Router authorization URL missing state: %s", location)
+        _record_error(test_id, "missing_state_in_authorization_url")
+        await client.aclose()
+        return JSONResponse(
+            status_code=502,
+            content={"error": "missing_state", "detail": "No state in auth URL"},
+        )
+
+    flow = FlowSession(
+        client=client,
+        issuer=issuer,
+        test_id=test_id,
+        test_name=test_name,
+        profile=profile,
+    )
+    if test_id:
+        flow.result["test_id"] = test_id
+    flows[state_values[0]] = flow
+
+    logger.info(
+        "ACCEPTED: router validated discovery for issuer '%s'; redirecting to OP",
+        issuer,
+    )
+    logger.info("Redirecting to OP: %s", location)
+    return RedirectResponse(url=location, status_code=302)
+
+
+async def _finish_callback(flow: FlowSession, resp: httpx.Response) -> HTMLResponse:
+    """Turn the router's callback verdict into the harness response + result."""
+    if resp.status_code != HTTP_FOUND:
+        detail = _error_detail(resp)
+        flow.result["status"] = "error"
+        flow.result["error"] = f"router_rejected ({resp.status_code}): {detail}"
+        _store_test_result(flow)
+        logger.error(
+            "REJECTED: router rejected callback (%d): %s", resp.status_code, detail
+        )
+        return HTMLResponse(
+            content=f"<h1>Login Rejected</h1><p>{html.escape(detail)}</p>",
+            status_code=resp.status_code,
+        )
+
+    # The 302 to post_login_redirect means the router established a session:
+    # id_token validated (signature/iss/aud/exp/nonce) and UserInfo vetted.
+    session_data = (await flow.client.get("/session")).json()
+    claims = session_data.get("claims") or {}
+    userinfo = session_data.get("userinfo") or {}
+    tokens = session_data.get("tokens") or {}
+
+    flow.result["status"] = "success"
+    flow.result["id_token_claims"] = claims
+    flow.result["userinfo_claims"] = userinfo
+    flow.result["access_token"] = tokens.get("access_token")
+    _store_test_result(flow)
+
+    logger.info(
+        "ACCEPTED: router completed login for issuer=%s, sub=%s",
+        flow.issuer,
+        session_data.get("sub"),
+    )
+
+    claim_lines = [
+        f"<p>Subject: {html.escape(str(claims.get('sub', 'N/A')))}</p>",
+        f"<p>Issuer: {html.escape(str(claims.get('iss', 'N/A')))}</p>",
+    ]
+    if userinfo:
+        claim_lines.append("<h2>UserInfo Claims</h2>")
+        for key, value in userinfo.items():
+            claim_lines.append(
+                f"<p>{html.escape(str(key))}: {html.escape(str(value))}</p>"
+            )
+    return HTMLResponse(
+        content="<h1>Authentication Successful</h1>" + "\n".join(claim_lines),
+        status_code=200,
+    )
+
+
+def _pop_flow(state: str | None) -> FlowSession | None:
+    if not state:
+        return None
+    return flows.pop(state, None)
+
+
+@app.get("/callback", response_model=None)
+async def callback_get(request: Request) -> HTMLResponse:
+    """Replay the OP's query-mode callback into the per-test router."""
+    flow = _pop_flow(request.query_params.get("state"))
+    if flow is None:
+        logger.error("Unknown state: %s", request.query_params.get("state"))
+        return HTMLResponse(
+            content="<h1>Error</h1><p>Unknown or missing state parameter</p>",
+            status_code=400,
+        )
+    _set_active_test(flow.profile, flow.test_name)
+    try:
+        resp = await flow.client.get(f"/callback?{request.url.query}")
+        return await _finish_callback(flow, resp)
+    finally:
+        await flow.client.aclose()
+
+
+@app.post("/callback", response_model=None)
+async def callback_post(request: Request) -> HTMLResponse:
+    """Replay the OP's form_post callback into the router's POST /callback.
+
+    The raw urlencoded body is forwarded verbatim so the router's own
+    form_post handling — not a harness re-encoding — is what's under test.
+    """
+    body = await request.body()
+    fields = dict(
+        parse_qsl(body.decode("utf-8", errors="replace"), keep_blank_values=True)
+    )
+    flow = _pop_flow(fields.get("state"))
+    if flow is None:
+        logger.error("Unknown state in form_post: %s", fields.get("state"))
+        return HTMLResponse(
+            content="<h1>Error</h1><p>Unknown or missing state parameter</p>",
+            status_code=400,
+        )
+    _set_active_test(flow.profile, flow.test_name)
+    try:
+        resp = await flow.client.post(
+            "/callback",
+            content=body,
+            headers={
+                "content-type": request.headers.get(
+                    "content-type", "application/x-www-form-urlencoded"
+                )
+            },
+        )
+        return await _finish_callback(flow, resp)
+    finally:
+        await flow.client.aclose()
+
+
+@app.get("/results/{test_id}")
+def get_result(test_id: str) -> JSONResponse:
+    """Retrieve the result of a completed test flow."""
+    if test_id in test_results:
+        return JSONResponse(content=test_results[test_id])
+    return JSONResponse(status_code=404, content={"error": "not_found"})

--- a/conformance/app_fastapi.py
+++ b/conformance/app_fastapi.py
@@ -21,9 +21,11 @@ state-keyed recovery ``app.py`` uses for its sessions. When the OP calls back
 the callback into that per-test router, flow cookie and all. The router's own
 verdict (302 = login established, 4xx/5xx = rejected) is the test outcome.
 
-The router always uses PKCE and always attempts UserInfo when available, so
-the runner's ``use_pkce``/``skip_userinfo`` hints are accepted but not acted
-on — both behaviours are safe supersets of what the suite requires.
+The router always uses PKCE, so the runner's ``use_pkce`` hint is accepted
+but not acted on (a safe superset of what the suite requires). The
+``skip_userinfo`` hint maps to the router's ``fetch_userinfo`` option — the
+discovery-jwks-uri-keys module is FINISHED once the token is issued, and a
+trailing UserInfo request would be an illegal test state change.
 """
 
 from __future__ import annotations
@@ -126,11 +128,13 @@ def _record_error(test_id: str, error: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _build_test_app(settings: OIDCSettings) -> FastAPI:
+def _build_test_app(settings: OIDCSettings, *, fetch_userinfo: bool = True) -> FastAPI:
     """A minimal app hosting the real OIDC router for one test's issuer."""
     test_app = FastAPI()
     test_app.add_middleware(SessionMiddleware, secret_key=secrets.token_urlsafe(32))
-    test_app.include_router(build_oidc_router(settings, store_tokens=True))
+    test_app.include_router(
+        build_oidc_router(settings, store_tokens=True, fetch_userinfo=fetch_userinfo)
+    )
 
     @test_app.get("/session")
     async def session_view(request: Request) -> JSONResponse:
@@ -261,7 +265,7 @@ async def authorize(
     profile: str = Query("", description="Profile/plan name for RP log capture"),
     use_pkce: str = Query("false", description="Ignored: the router always uses PKCE"),
     skip_userinfo: str = Query(
-        "false", description="Ignored: the router always attempts UserInfo"
+        "false", description="Maps to the router's fetch_userinfo option"
     ),
     scope: str = Query(DEFAULT_SCOPE, description="Requested scopes"),
 ) -> RedirectResponse | JSONResponse:
@@ -289,7 +293,9 @@ async def authorize(
         redirect_uri=f"{RP_BASE_URL}/callback",
         scope=scope,
     )
-    client = _build_test_client(_build_test_app(settings))
+    client = _build_test_client(
+        _build_test_app(settings, fetch_userinfo=skip_userinfo.lower() != "true")
+    )
 
     resp = await client.get("/login")
     if resp.status_code != HTTP_FOUND:

--- a/conformance/configs/fastapi-basic-rp.json
+++ b/conformance/configs/fastapi-basic-rp.json
@@ -1,0 +1,12 @@
+{
+  "plan_name": "oidcc-client-basic-certification-test-plan",
+  "variant": {
+    "client_registration": "static_client",
+    "request_type": "plain_http_request"
+  },
+  "alias": "fastapi-identity-model-basic-rp",
+  "client": {
+    "client_id": "conformance-rp",
+    "client_secret": "conformance-rp-secret"
+  }
+}

--- a/conformance/configs/fastapi-config-rp.json
+++ b/conformance/configs/fastapi-config-rp.json
@@ -1,0 +1,14 @@
+{
+  "plan_name": "oidcc-client-config-certification-test-plan",
+  "variant": {
+    "client_registration": "static_client",
+    "client_auth_type": "client_secret_basic",
+    "request_type": "plain_http_request",
+    "response_mode": "default"
+  },
+  "alias": "fastapi-identity-model-config-rp",
+  "client": {
+    "client_id": "conformance-rp",
+    "client_secret": "conformance-rp-secret"
+  }
+}

--- a/conformance/configs/fastapi-form-post-basic-rp.json
+++ b/conformance/configs/fastapi-form-post-basic-rp.json
@@ -1,0 +1,12 @@
+{
+  "plan_name": "oidcc-client-formpost-basic-certification-test-plan",
+  "variant": {
+    "client_registration": "static_client",
+    "request_type": "plain_http_request"
+  },
+  "alias": "fastapi-identity-model-form-post-basic-rp",
+  "client": {
+    "client_id": "conformance-rp",
+    "client_secret": "conformance-rp-secret"
+  }
+}

--- a/conformance/docker-compose.yml
+++ b/conformance/docker-compose.yml
@@ -76,6 +76,28 @@ services:
       server:
         condition: service_healthy
 
+  # Same suite, second RP: the fastapi-identity-model package's real
+  # build_oidc_router driven through the identical plans (regression stage).
+  rp-fastapi:
+    build:
+      context: ..
+      dockerfile: conformance/Dockerfile.fastapi
+    ports:
+      - "8889:8889"
+    environment:
+      - RP_BASE_URL=http://localhost:8889
+      - CONFORMANCE_SUITE_BASE_URL=https://localhost.emobix.co.uk:8443
+      - SSL_CERT_FILE=/certs/nginx-selfsigned.crt
+    volumes:
+      - certs:/certs:ro
+    depends_on:
+      cert-init:
+        condition: service_completed_successfully
+      nginx:
+        condition: service_started
+      server:
+        condition: service_healthy
+
 volumes:
   mongodb-data:
   certs:

--- a/conformance/results/fastapi-basic-rp-latest.json
+++ b/conformance/results/fastapi-basic-rp-latest.json
@@ -1,0 +1,114 @@
+{
+  "plan": "fastapi-basic-rp",
+  "plan_id": "uiRdOwx1ZYbQs",
+  "suite_url": "https://localhost.emobix.co.uk:8443",
+  "results": [
+    {
+      "test": "oidcc-client-test",
+      "status": "PASSED",
+      "test_id": "RcppiXyFYiAV5DL",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=RcppiXyFYiAV5DL",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-invalid-iss",
+      "status": "PASSED",
+      "test_id": "eWixa260H3DgBoZ",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=eWixa260H3DgBoZ",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-missing-sub",
+      "status": "PASSED",
+      "test_id": "aVcBn5590H8hbwU",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=aVcBn5590H8hbwU",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-invalid-aud",
+      "status": "PASSED",
+      "test_id": "Vgs4pHiWgFP5swa",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=Vgs4pHiWgFP5swa",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-missing-iat",
+      "status": "PASSED",
+      "test_id": "KDYfM0IlRWBnE7N",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=KDYfM0IlRWBnE7N",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-kid-absent-single-jwks",
+      "status": "PASSED",
+      "test_id": "kDLzLGVwjcQrHEQ",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=kDLzLGVwjcQrHEQ",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-kid-absent-multiple-jwks",
+      "status": "PASSED",
+      "test_id": "GediYdOGYCblJOP",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=GediYdOGYCblJOP",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-idtoken-sig-rs256",
+      "status": "PASSED",
+      "test_id": "vt1KTnp01t4iyxv",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=vt1KTnp01t4iyxv",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-idtoken-sig-none",
+      "status": "SKIPPED",
+      "test_id": "2JTYleOAWTGu3OQ",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=2JTYleOAWTGu3OQ",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-invalid-sig-rs256",
+      "status": "PASSED",
+      "test_id": "esO1qbSg6rq73oM",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=esO1qbSg6rq73oM",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-userinfo-invalid-sub",
+      "status": "PASSED",
+      "test_id": "yuVCpphr6ibALjj",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=yuVCpphr6ibALjj",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-nonce-invalid",
+      "status": "PASSED",
+      "test_id": "rc4NYV0KBPx2mVR",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=rc4NYV0KBPx2mVR",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-scope-userinfo-claims",
+      "status": "PASSED",
+      "test_id": "5nrOboK4JUpfGZR",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=5nrOboK4JUpfGZR",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-client-secret-basic",
+      "status": "PASSED",
+      "test_id": "mJH0LsZGeH1rCVN",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=mJH0LsZGeH1rCVN",
+      "detail": ""
+    }
+  ],
+  "summary": {
+    "total": 14,
+    "passed": 13,
+    "warning": 0,
+    "failed": 0,
+    "review": 0,
+    "skipped": 1
+  },
+  "all_passed": true
+}

--- a/conformance/results/fastapi-config-rp-latest.json
+++ b/conformance/results/fastapi-config-rp-latest.json
@@ -1,0 +1,58 @@
+{
+  "plan": "fastapi-config-rp",
+  "plan_id": "5H0vEl86u3R6T",
+  "suite_url": "https://localhost.emobix.co.uk:8443",
+  "results": [
+    {
+      "test": "oidcc-client-test-discovery-openid-config",
+      "status": "PASSED",
+      "test_id": "gyB6RqH5hbQ6c03",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=gyB6RqH5hbQ6c03",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-discovery-jwks-uri-keys",
+      "status": "PASSED",
+      "test_id": "pKUjFKwpGWArmho",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=pKUjFKwpGWArmho",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-discovery-issuer-mismatch",
+      "status": "PASSED",
+      "test_id": "Yece5xVAT9XvJlS",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=Yece5xVAT9XvJlS",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-idtoken-sig-none",
+      "status": "SKIPPED",
+      "test_id": "Ht6j1MAHRgNyNMf",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=Ht6j1MAHRgNyNMf",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-signing-key-rotation-just-before-signing",
+      "status": "PASSED",
+      "test_id": "4ptNLeicI6dI9sO",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=4ptNLeicI6dI9sO",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-signing-key-rotation",
+      "status": "PASSED",
+      "test_id": "AKQsUsbIZRPXQWZ",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=AKQsUsbIZRPXQWZ",
+      "detail": ""
+    }
+  ],
+  "summary": {
+    "total": 6,
+    "passed": 5,
+    "warning": 0,
+    "failed": 0,
+    "review": 0,
+    "skipped": 1
+  },
+  "all_passed": true
+}

--- a/conformance/results/fastapi-form-post-basic-rp-latest.json
+++ b/conformance/results/fastapi-form-post-basic-rp-latest.json
@@ -1,0 +1,114 @@
+{
+  "plan": "fastapi-form-post-basic-rp",
+  "plan_id": "elLyYaoVYHjkn",
+  "suite_url": "https://localhost.emobix.co.uk:8443",
+  "results": [
+    {
+      "test": "oidcc-client-test",
+      "status": "PASSED",
+      "test_id": "GlKOii12o24kyPG",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=GlKOii12o24kyPG",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-invalid-iss",
+      "status": "PASSED",
+      "test_id": "8ylP97an37rRAaS",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=8ylP97an37rRAaS",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-missing-sub",
+      "status": "PASSED",
+      "test_id": "aXRwVJDTWT1ypep",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=aXRwVJDTWT1ypep",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-invalid-aud",
+      "status": "PASSED",
+      "test_id": "mcNIYiCu9JfC2uz",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=mcNIYiCu9JfC2uz",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-missing-iat",
+      "status": "PASSED",
+      "test_id": "nic3ns5EvAM8fjS",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=nic3ns5EvAM8fjS",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-kid-absent-single-jwks",
+      "status": "PASSED",
+      "test_id": "zLBbM1sV9oY7NM1",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=zLBbM1sV9oY7NM1",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-kid-absent-multiple-jwks",
+      "status": "PASSED",
+      "test_id": "DDL5n4n3JLCB3DM",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=DDL5n4n3JLCB3DM",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-idtoken-sig-rs256",
+      "status": "PASSED",
+      "test_id": "MeubHa6OJ3Dz133",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=MeubHa6OJ3Dz133",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-idtoken-sig-none",
+      "status": "SKIPPED",
+      "test_id": "z8rwYBUUopGhcXW",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=z8rwYBUUopGhcXW",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-invalid-sig-rs256",
+      "status": "PASSED",
+      "test_id": "8scC0ft6f9HpOrQ",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=8scC0ft6f9HpOrQ",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-userinfo-invalid-sub",
+      "status": "PASSED",
+      "test_id": "Q0N7kSoswEu1NZy",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=Q0N7kSoswEu1NZy",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-nonce-invalid",
+      "status": "PASSED",
+      "test_id": "u0w5Os2TtCdrSDz",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=u0w5Os2TtCdrSDz",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-scope-userinfo-claims",
+      "status": "PASSED",
+      "test_id": "ItikvUPG2Onx0yO",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=ItikvUPG2Onx0yO",
+      "detail": ""
+    },
+    {
+      "test": "oidcc-client-test-client-secret-basic",
+      "status": "PASSED",
+      "test_id": "8MOD1tCxAE4m2Bg",
+      "log_url": "https://localhost.emobix.co.uk:8443/log-detail.html?log=8MOD1tCxAE4m2Bg",
+      "detail": ""
+    }
+  ],
+  "summary": {
+    "total": 14,
+    "passed": 13,
+    "warning": 0,
+    "failed": 0,
+    "review": 0,
+    "skipped": 1
+  },
+  "all_passed": true
+}

--- a/conformance/run_tests.py
+++ b/conformance/run_tests.py
@@ -817,7 +817,16 @@ def main() -> None:
     parser.add_argument(
         "--plan",
         required=True,
-        choices=["basic-rp", "config-rp", "form-post-basic-rp"],
+        choices=[
+            "basic-rp",
+            "config-rp",
+            "form-post-basic-rp",
+            # fastapi-identity-model package regression plans (same suite
+            # plans, driven against the rp-fastapi harness on :8889)
+            "fastapi-basic-rp",
+            "fastapi-config-rp",
+            "fastapi-form-post-basic-rp",
+        ],
         help="Test plan to run",
     )
     parser.add_argument(

--- a/packages/fastapi-identity-model/fastapi_identity_model/rp.py
+++ b/packages/fastapi-identity-model/fastapi_identity_model/rp.py
@@ -87,6 +87,17 @@ def _require_session(request: Request) -> None:
         )
 
 
+_WELL_KNOWN_SUFFIX = "/.well-known/openid-configuration"
+
+
+def _expected_issuer(discovery_url: str) -> str:
+    """Issuer implied by the discovery URL (OIDC Discovery 1.0 §4.1)."""
+    base = discovery_url.rstrip("/")
+    if base.endswith(_WELL_KNOWN_SUFFIX):
+        base = base[: -len(_WELL_KNOWN_SUFFIX)]
+    return base.rstrip("/")
+
+
 async def _discover(settings: OIDCSettings) -> DiscoveryDocumentResponse:
     disco = await get_discovery_document(
         DiscoveryDocumentRequest(address=settings.discovery_url),
@@ -95,6 +106,20 @@ async def _discover(settings: OIDCSettings) -> DiscoveryDocumentResponse:
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail=f"OIDC discovery failed: {disco.error}",
+        )
+    # OIDC Discovery 1.0 §4.3: the document's issuer MUST match the URL the
+    # document was retrieved from (issuer mix-up defense). The library only
+    # validates the issuer's *format*; the equality check is the RP's job.
+    # Trailing slashes are normalized — issuer "https://op/" serves its
+    # document at "https://op/.well-known/openid-configuration".
+    expected = _expected_issuer(settings.discovery_url)
+    if (disco.issuer or "").rstrip("/") != expected:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=(
+                f"Discovery document issuer mismatch: expected '{expected}', "
+                f"got '{disco.issuer}'"
+            ),
         )
     return disco
 
@@ -231,13 +256,14 @@ async def _fetch_userinfo(
     return claims
 
 
-async def _callback(
+async def _callback(  # noqa: PLR0913  # request-scoped args + the router's build-time options
     request: Request,
     settings: OIDCSettings,
     session_key: str,
     callback_url: str,
     *,
     store_tokens: bool,
+    fetch_userinfo: bool,
 ) -> RedirectResponse:
     _require_session(request)
     # Pop the flow state so it is single-use: a failed or replayed callback
@@ -287,7 +313,9 @@ async def _callback(
         )
     claims = await _validate_id_token(settings, disco, id_token, flow["nonce"])
 
-    userinfo = await _fetch_userinfo(disco, access_token, claims.get("sub"))
+    userinfo: dict = {}
+    if fetch_userinfo:
+        userinfo = await _fetch_userinfo(disco, access_token, claims.get("sub"))
 
     session_data: dict = {
         "sub": claims.get("sub"),
@@ -313,6 +341,7 @@ def build_oidc_router(
     *,
     session_key: str = "oidc",
     store_tokens: bool = False,
+    fetch_userinfo: bool = True,
 ) -> APIRouter:
     """Build an OIDC relying-party router.
 
@@ -321,6 +350,10 @@ def build_oidc_router(
         session_key: Key under which flow + identity state is kept in the session.
         store_tokens: When True, also persist the access/refresh/id tokens in the
             session (requires an encrypted or server-side session store).
+        fetch_userinfo: When False, skip the UserInfo request after ID-token
+            validation and anchor identity on the ID token claims alone —
+            for providers without a usable UserInfo endpoint, or to avoid
+            the extra round-trip per login.
 
     Returns:
         An ``APIRouter`` with ``/login``, ``/callback`` and ``/logout`` routes.
@@ -339,7 +372,12 @@ def build_oidc_router(
     @router.get("/callback")
     async def callback(request: Request) -> RedirectResponse:
         return await _callback(
-            request, settings, session_key, str(request.url), store_tokens=store_tokens
+            request,
+            settings,
+            session_key,
+            str(request.url),
+            store_tokens=store_tokens,
+            fetch_userinfo=fetch_userinfo,
         )
 
     @router.post("/callback")
@@ -355,7 +393,12 @@ def build_oidc_router(
         params = urlencode(parse_qsl(body, keep_blank_values=True))
         callback_url = str(request.url.replace(query=params))
         return await _callback(
-            request, settings, session_key, callback_url, store_tokens=store_tokens
+            request,
+            settings,
+            session_key,
+            callback_url,
+            store_tokens=store_tokens,
+            fetch_userinfo=fetch_userinfo,
         )
 
     @router.post("/logout")

--- a/packages/fastapi-identity-model/fastapi_identity_model/rp.py
+++ b/packages/fastapi-identity-model/fastapi_identity_model/rp.py
@@ -12,14 +12,19 @@ using the async ``py_identity_model.aio`` API for all protocol work:
     app.add_middleware(SessionMiddleware, secret_key="...")   # required
     app.include_router(build_oidc_router(settings), prefix="/auth")
 
-Routes: ``GET /login`` → provider, ``GET /callback`` (exchange + validate +
-nonce + UserInfo), ``POST /logout``. The transient PKCE/state/nonce are kept
+Routes: ``GET /login`` → provider, ``GET/POST /callback`` (exchange + validate
++ nonce + UserInfo; the POST route accepts the OAuth 2.0 ``form_post`` response
+mode), ``POST /logout``. The transient PKCE/state/nonce are kept
 under a separate ``<session_key>.flow`` entry and popped on callback (single
 use); the resulting identity is written to ``session[session_key]`` only after
 a verified ID token, so reading ``session[session_key]`` never observes an
 in-flight login. Logout is POST-only so a cross-site GET cannot force it.
 
-Security note: ``SessionMiddleware`` signs but does **not** encrypt the cookie.
+Security note: browsers only send the session cookie on the cross-site POST a
+``form_post`` provider issues if it was set with ``same_site="none"`` (which
+requires ``https_only=True``); with the default ``lax`` the POST callback
+arrives without the flow cookie and fails with "No active login flow".
+``SessionMiddleware`` signs but does **not** encrypt the cookie.
 Identity claims stored there are tamper-proof but readable by the client. Raw
 tokens are stored only when ``store_tokens=True`` — enable that only with an
 encrypted or server-side session store. Logout clears the local session only;
@@ -31,6 +36,7 @@ from __future__ import annotations
 import logging
 import secrets
 from typing import TYPE_CHECKING
+from urllib.parse import parse_qsl, urlencode
 
 from fastapi import APIRouter, HTTPException, Request, status
 from starlette.responses import RedirectResponse
@@ -229,6 +235,7 @@ async def _callback(
     request: Request,
     settings: OIDCSettings,
     session_key: str,
+    callback_url: str,
     *,
     store_tokens: bool,
 ) -> RedirectResponse:
@@ -243,7 +250,7 @@ async def _callback(
         )
 
     try:
-        cb = parse_authorize_callback_response(str(request.url))
+        cb = parse_authorize_callback_response(callback_url)
     except PyIdentityModelException as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -332,7 +339,23 @@ def build_oidc_router(
     @router.get("/callback")
     async def callback(request: Request) -> RedirectResponse:
         return await _callback(
-            request, settings, session_key, store_tokens=store_tokens
+            request, settings, session_key, str(request.url), store_tokens=store_tokens
+        )
+
+    @router.post("/callback")
+    async def callback_form_post(request: Request) -> RedirectResponse:
+        # form_post response mode: the provider delivers the authorization
+        # response as an application/x-www-form-urlencoded POST body instead
+        # of query parameters. Rebuild a callback URL carrying the fields as
+        # a query string so GET and POST share the exact same validation path
+        # (parse → state → code → exchange). Parsed with stdlib parse_qsl —
+        # form_post is urlencoded by definition, so this avoids taking a
+        # python-multipart dependency for starlette's request.form().
+        body = (await request.body()).decode("utf-8", errors="replace")
+        params = urlencode(parse_qsl(body, keep_blank_values=True))
+        callback_url = str(request.url.replace(query=params))
+        return await _callback(
+            request, settings, session_key, callback_url, store_tokens=store_tokens
         )
 
     @router.post("/logout")

--- a/packages/fastapi-identity-model/tests/test_rp.py
+++ b/packages/fastapi-identity-model/tests/test_rp.py
@@ -126,6 +126,34 @@ async def test_store_tokens_persists_tokens(monkeypatch):
     assert me["tokens"]["access_token"] == "at"
 
 
+async def test_form_post_callback_full_login_flow(monkeypatch):
+    # form_post response mode: the provider POSTs code/state as form fields
+    # instead of query parameters; the flow must complete identically to GET.
+    _patch(monkeypatch)
+    async with _client(_app()) as client:
+        state, nonce = await _login(client)
+        rp.validate_token.return_value = {"sub": "user-1", "nonce": nonce}
+
+        resp = await client.post("/auth/callback", data={"code": "abc", "state": state})
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "/"
+
+        me = (await client.get("/me")).json()
+    assert me["sub"] == "user-1"
+    assert me["userinfo"] == {"sub": "user-1", "email": "u@e"}
+
+
+async def test_form_post_callback_state_mismatch(monkeypatch):
+    _patch(monkeypatch)
+    async with _client(_app()) as client:
+        await _login(client)
+        resp = await client.post(
+            "/auth/callback", data={"code": "abc", "state": "wrong"}
+        )
+    assert resp.status_code == 400
+    assert "State mismatch" in resp.json()["detail"]
+
+
 async def test_callback_without_active_flow(monkeypatch):
     _patch(monkeypatch)
     async with _client(_app()) as client:

--- a/packages/fastapi-identity-model/tests/test_rp.py
+++ b/packages/fastapi-identity-model/tests/test_rp.py
@@ -63,11 +63,14 @@ def _patch(monkeypatch, *, disco=_DISCO, token=None, claims=None, userinfo=None)
     )
 
 
-def _app(store_tokens: bool = False) -> FastAPI:
+def _app(store_tokens: bool = False, fetch_userinfo: bool = True) -> FastAPI:
     app = FastAPI()
     app.add_middleware(SessionMiddleware, secret_key="test-secret")
     app.include_router(
-        build_oidc_router(SETTINGS, store_tokens=store_tokens), prefix="/auth"
+        build_oidc_router(
+            SETTINGS, store_tokens=store_tokens, fetch_userinfo=fetch_userinfo
+        ),
+        prefix="/auth",
     )
 
     @app.get("/me")
@@ -186,6 +189,39 @@ async def test_login_discovery_failure(monkeypatch):
         resp = await client.get("/auth/login")
     assert resp.status_code == 502
     assert "discovery failed" in resp.json()["detail"].lower()
+
+
+async def test_login_rejects_discovery_issuer_mismatch(monkeypatch):
+    # OIDC Discovery 1.0 §4.3: a document whose issuer does not match the
+    # URL it was retrieved from must be rejected (issuer mix-up defense).
+    mismatched = SimpleNamespace(
+        is_successful=True,
+        error=None,
+        authorization_endpoint="https://op/authorize",
+        token_endpoint="https://op/token",
+        userinfo_endpoint="https://op/userinfo",
+        issuer="https://op/INVALID",
+    )
+    _patch(monkeypatch, disco=mismatched)
+    async with _client(_app()) as client:
+        resp = await client.get("/auth/login")
+    assert resp.status_code == 502
+    assert "issuer mismatch" in resp.json()["detail"].lower()
+
+
+async def test_fetch_userinfo_disabled_skips_userinfo(monkeypatch):
+    # fetch_userinfo=False anchors identity on the validated ID token and
+    # never calls the UserInfo endpoint.
+    _patch(monkeypatch)
+    async with _client(_app(fetch_userinfo=False)) as client:
+        state, nonce = await _login(client)
+        rp.validate_token.return_value = {"sub": "user-1", "nonce": nonce}
+        resp = await client.get(f"/auth/callback?code=abc&state={state}")
+        assert resp.status_code == 302
+        me = (await client.get("/me")).json()
+    assert me["sub"] == "user-1"
+    assert me["userinfo"] == {}
+    rp.get_userinfo.assert_not_called()
 
 
 async def test_callback_token_exchange_failure(monkeypatch):


### PR DESCRIPTION
Closes #437. Regression stage for #242 — the core library remains the certification target; this proves the `fastapi-identity-model` router passes the same local OIDF RP suite the library passes. Stacked on #434 (the package only exists on that branch); GitHub will retarget to `main` when #434 merges.

## Summary

**Router (package) changes — all non-releasing `build(fastapi)` commits:**
- `POST /callback` (form_post response mode): `_callback` refactored to take an explicit `callback_url`; the POST route parses the urlencoded body with stdlib `parse_qsl` (no python-multipart dependency) and shares the exact GET validation path. Docs note the `SameSite=None` requirement for real browsers.
- **OIDC Discovery 1.0 §4.3 issuer check** (found by the suite): `_discover` now rejects a discovery document whose issuer doesn't match the discovery URL (issuer mix-up defense) — previously the router accepted the suite's `…/INVALID` issuer document, since the library only validates issuer *format*.
- **`build_oidc_router(fetch_userinfo=False)`** skips the UserInfo round-trip and anchors identity on the validated ID token (also needed to map the runner's `skip_userinfo` — a trailing UserInfo call after `discovery-jwks-uri-keys` finishes is an illegal test state change).

**Conformance harness + wiring:**
- `conformance/app_fastapi.py`: same runner-facing contract as `app.py` (`/authorize`, `/callback` GET+POST, `/discover`, `/clear-cache`, per-test log routing) but delegating every flow to the real `build_oidc_router` — a fresh app per test issuer driven over `httpx.ASGITransport`, `(client, cookie jar)` keyed by `state`, callbacks replayed into the per-test router carrying the flow cookie.
- `fastapi-{basic,config,form-post-basic}-rp` configs, `rp-fastapi` service (port 8889) + `Dockerfile.fastapi`, `make conformance-test-fastapi`, and a `conformance-fastapi` CI job (local Docker suite only — no hosted runs, no certification exports).

## Test plan

- [x] `make lint` clean; pyrefly 1.0.0 (CI version) — 0 errors
- [x] `make test-fastapi` — 64 passed (incl. new form_post GET/POST, issuer-mismatch, fetch_userinfo tests), 95.5% coverage
- [x] **Local suite (the proof):** `make conformance-up && make conformance-test-fastapi` — Basic RP **13 pass / 1 skip** (`idtoken-sig-none`), Config RP **5 pass / 1 skip**, Form Post RP **13 pass / 1 skip** — identical to the library baselines in `conformance/results/`
- [ ] `conformance-fastapi` CI job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)