### PR TITLE
docs(fastapi): stamp 0.1.0 release notes for the first PyPI release

### DIFF
--- a/packages/fastapi-identity-model/CHANGELOG.md
+++ b/packages/fastapi-identity-model/CHANGELOG.md
@@ -4,9 +4,12 @@ All notable changes to `fastapi-identity-model` are documented here. This projec
 adheres to [Semantic Versioning](https://semver.org/) and is released
 independently of the core `py-identity-model` library.
 
-## 0.1.0 (unreleased)
+## 0.1.0 (2026-07-08)
 
-Initial release. Extracted and hardened from the `py-identity-model` FastAPI example.
+Initial release. Extracted and hardened from the `py-identity-model` FastAPI
+example, then driven through the OIDF conformance suite: the RP router passes
+the same local Basic RP, Config RP, and Form Post RP plans the core library is
+certified against (13/13, 5/5, 13/13 — regression stage, see #437).
 
 ### Added
 - `TokenValidationMiddleware` — resource-server Bearer-token validation that
@@ -15,6 +18,12 @@ Initial release. Extracted and hardened from the `py-identity-model` FastAPI exa
   `get_claim_value`, `get_claim_values`, `require_claim`, `require_scope`.
 - `build_oidc_router` — mountable relying-party login flow (authorization code +
   PKCE) with state/nonce, ID-token validation, and UserInfo `sub` verification.
+- `POST /callback` on the RP router — OAuth 2.0 `form_post` response mode,
+  sharing the exact GET validation path (parsed with stdlib `parse_qsl`; no
+  `python-multipart` dependency). Requires the session cookie to be issued
+  with `same_site="none"` in real browsers.
+- `build_oidc_router(fetch_userinfo=False)` — skip the UserInfo round-trip and
+  anchor identity on the validated ID token.
 - `OIDCSettings` — typed configuration with `from_env()`.
 - `TokenManager` — access-token refresh lifecycle over the native async refresh grant.
 
@@ -25,6 +34,8 @@ Initial release. Extracted and hardened from the `py-identity-model` FastAPI exa
   (removes a blocking sync call in async context and a hand-rolled token POST).
 
 ### Security
+- The RP router rejects a discovery document whose issuer does not match the
+  URL it was retrieved from (OIDC Discovery 1.0 §4.3 issuer mix-up defense).
 - The RP router refuses to establish a session when the token response has no
   ID token, and enforces the UserInfo `sub` match as a hard gate (a mismatch
   fails the login instead of being swallowed).


### PR DESCRIPTION
Pre-release housekeeping for `fastapi-identity-model-v0.1.0`: date the 0.1.0 CHANGELOG entry and fold in what landed via #438 (form_post `POST /callback`, `fetch_userinfo` option, §4.3 issuer-mismatch rejection, OIDF regression results). Version in `pyproject.toml` is already `0.1.0` — the tag follows this merge.

Refs #437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)