### PR TITLE
feat(integration): wire Keycloak fixture into integration harness

### DIFF
--- a/.env.keycloak
+++ b/.env.keycloak
@@ -1,0 +1,12 @@
+TEST_DISCO_ADDRESS=http://localhost:8080/realms/py-identity-model/.well-known/openid-configuration
+TEST_JWKS_ADDRESS=http://localhost:8080/realms/py-identity-model/protocol/openid-connect/certs
+TEST_CLIENT_ID=py-identity-model-client
+TEST_CLIENT_SECRET=py-identity-model-client-secret
+TEST_SCOPE=openid
+TEST_AUDIENCE=
+TEST_REQUIRE_HTTPS=false
+TEST_AUTH_CODE_CLIENT_ID=test-auth-code
+TEST_AUTH_CODE_CLIENT_SECRET=test-auth-code-secret
+TEST_AUTH_CODE_REDIRECT_URI=http://localhost:8080/callback
+TEST_PKCE_PUBLIC_CLIENT_ID=test-pkce-public
+TEST_PKCE_PUBLIC_REDIRECT_URI=http://localhost:8080/callback

--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,7 @@ dmypy.json
 *.env*
 # Allow test fixture env files (no secrets — local Docker only)
 !.env.node-oidc
+!.env.keycloak
 *.crt
 *.key
 *.pfx

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,15 @@ test-integration-node-oidc: ## Run integration tests against node-oidc-provider
 		(docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml down && exit 1)
 	docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml down
 
+.PHONY: test-integration-keycloak
+test-integration-keycloak: ## Run integration tests against Keycloak
+	@echo "Starting Keycloak fixture..."
+	docker compose -f test-fixtures/keycloak/docker-compose.yml up -d --build --wait
+	@echo "Running integration tests against Keycloak..."
+	uv run pytest src/tests -m integration --env-file=.env.keycloak -v || \
+		(docker compose -f test-fixtures/keycloak/docker-compose.yml down && exit 1)
+	docker compose -f test-fixtures/keycloak/docker-compose.yml down
+
 .PHONY: test-benchmark
 test-benchmark: ## Run benchmarks
 	uv run pytest src/tests/benchmarks -v --benchmark-only --benchmark-sort=name


### PR DESCRIPTION
## Summary
Wires the KC.1 Keycloak fixture into the integration harness. No library/core changes (that is KC.3 scope).

- **`.env.keycloak`** (new, tracked) — mirrors the `.env.node-oidc` contract; discovery + JWKS URLs, `py-identity-model-client` client-credentials creds, `test-auth-code` / `test-pkce-public` client vars, `TEST_SCOPE=openid`, `TEST_REQUIRE_HTTPS=false`. Opaque vars omitted (Keycloak emits JWTs → `TEST_OPAQUE_*` tests skip cleanly).
- **`.gitignore`** — add `!.env.keycloak` after the `!.env.node-oidc` allow-rule so the tracked fixture env escapes the `*.env*` blanket ignore.
- **`Makefile`** — add `test-integration-keycloak` target, an exact mirror of `test-integration-node-oidc` (`docker compose ... up -d --build --wait` → `pytest -m integration --env-file=.env.keycloak` → teardown).
- **`provider_matrix.py`** — no code change needed; `find_env_files()` globs `.env*` (skipping `.example`/`.bak`), so the tracked `.env.keycloak` is auto-discovered. Confirmed live: a `keycloak` column appears in `make provider-matrix`.

Story: KC.2 (Keycloak provider wiring). AC source: issue #244.

> **Recommend:** base this on top of the KC.1 fixture PR #446 (this PR is stacked on `feat/keycloak-fixture`). Merge #446 first, then this.

## ACs covered (KC.2 wiring)
- AC — env file for the harness → `.env.keycloak`
- AC — `make test-integration-keycloak` target (mirror node-oidc) → `Makefile`
- AC — `provider_matrix.py` discovers Keycloak → confirmed live (`keycloak` column, 12/13 caps ✓, DPoP ✗ as expected)

The full capability-gated suite going green vs Keycloak (36 currently-red tests: httpx pool intermittent connection-refused, hardcoded node-oidc tokens, dev-login helper, DPoP capability-skip) is **deferred to KC.3** by design — this PR is wiring only.

## Review Findings Addressed
Reviewers (KC.x override): Blind Hunter + Edge Case Hunter + Acceptance Auditor.
- **P0: 0** (Blind 0 MUST FIX / Acceptance 0 FAIL / Edge 0 critical).
- **P1: 3, all skipped-with-rationale** — (1) committed fixture secrets = intentional exact mirror of `.env.node-oidc` throwaway-creds pattern (local-only Docker realm); (2) Makefile `up --wait` teardown gap = exact mirror of `test-integration-node-oidc` which PROMPT mandates mirroring; (3) auth-code/PKCE tests red-not-skip vs Keycloak = correctly KC.3 scope (login-helper/capability gating is a conftest/core gap KC.3 owns).
- **P2 nitpicks:** node-oidc parity. Skipped.

## Test plan
- [x] Unit tests pass (`make test-unit` = 1222 passed, 95.54% cov)
- [x] Integration wiring verified live (fixture boots, discovery+JWKS pass, client_credentials → RS256 JWT, `provider_matrix` keycloak column)
- [x] Lint passes (`make lint` @934c2e6)
- [x] Independent review agents passed (0 blocking)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)