### PR TITLE
test(keycloak): full capability-gated integration suite green + x5t#S256 core fix

### DIFF
--- a/.env.keycloak
+++ b/.env.keycloak
@@ -1,0 +1,12 @@
+TEST_DISCO_ADDRESS=http://localhost:8080/realms/py-identity-model/.well-known/openid-configuration
+TEST_JWKS_ADDRESS=http://localhost:8080/realms/py-identity-model/protocol/openid-connect/certs
+TEST_CLIENT_ID=py-identity-model-client
+TEST_CLIENT_SECRET=py-identity-model-client-secret
+TEST_SCOPE=openid
+TEST_AUDIENCE=
+TEST_REQUIRE_HTTPS=false
+TEST_AUTH_CODE_CLIENT_ID=test-auth-code
+TEST_AUTH_CODE_CLIENT_SECRET=test-auth-code-secret
+TEST_AUTH_CODE_REDIRECT_URI=http://localhost:8080/callback
+TEST_PKCE_PUBLIC_CLIENT_ID=test-pkce-public
+TEST_PKCE_PUBLIC_REDIRECT_URI=http://localhost:8080/callback

--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,7 @@ dmypy.json
 *.env*
 # Allow test fixture env files (no secrets — local Docker only)
 !.env.node-oidc
+!.env.keycloak
 *.crt
 *.key
 *.pfx

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,15 @@ test-integration-node-oidc: ## Run integration tests against node-oidc-provider
 		(docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml down && exit 1)
 	docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml down
 
+.PHONY: test-integration-keycloak
+test-integration-keycloak: ## Run integration tests against Keycloak
+	@echo "Starting Keycloak fixture..."
+	docker compose -f test-fixtures/keycloak/docker-compose.yml up -d --build --wait
+	@echo "Running integration tests against Keycloak..."
+	uv run pytest src/tests -m integration --env-file=.env.keycloak -v || \
+		(docker compose -f test-fixtures/keycloak/docker-compose.yml down && exit 1)
+	docker compose -f test-fixtures/keycloak/docker-compose.yml down
+
 .PHONY: test-benchmark
 test-benchmark: ## Run benchmarks
 	uv run pytest src/tests/benchmarks -v --benchmark-only --benchmark-sort=name

--- a/src/py_identity_model/core/models.py
+++ b/src/py_identity_model/core/models.py
@@ -388,9 +388,25 @@ class JsonWebKey:
         return urlsafe_b64decode(input_str + padding)
 
     def as_dict(self):
-        """Convert the JWK to a dictionary with all available properties"""
-        # Add all non-None properties to the dictionary
-        return {key: value for key, value in self.__dict__.items() if value is not None}
+        """Convert the JWK to a dictionary with all available properties.
+
+        Python attribute names are mapped back to their RFC 7517 JWK member
+        names (e.g. ``x5t_s256`` -> ``x5t#S256``) so the result round-trips
+        through :meth:`from_json` and :func:`jwks_from_dict`. Providers such as
+        Keycloak emit ``x5t#S256`` in their JWKS; without this mapping the
+        dictionary form used ``x5t_s256`` and silently dropped the thumbprint
+        on re-parse.
+        """
+        data = {}
+        for key, value in self.__dict__.items():
+            if value is None:
+                continue
+            # Map Python field names back to JWK parameter names
+            if key == "x5t_s256":
+                data[JsonWebKeyParameterNames.X5T_S256.value] = value
+            else:
+                data[key] = value
+        return data
 
 
 # ============================================================================

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -8,11 +8,13 @@ Includes:
 
 from contextlib import suppress
 from dataclasses import dataclass
+from html import unescape
+from html.parser import HTMLParser
 import json
 import secrets
 import time
 from types import MappingProxyType
-from urllib.parse import urlencode, urlparse
+from urllib.parse import urlencode, urljoin, urlparse
 
 from filelock import FileLock
 import httpx
@@ -648,6 +650,109 @@ def _follow_redirects_counted(
     return None, resp
 
 
+class _LoginFormParser(HTMLParser):
+    """Extract the HTML login ``<form>`` — the one carrying a password input.
+
+    Providers that render a server-side login page (e.g. Keycloak) return an
+    HTML ``<form action=".../login-actions/authenticate?...">`` with
+    ``username``/``password`` inputs rather than node-oidc's devInteractions
+    JSON-ish endpoint. This captures that form's action plus every input
+    name/value so hidden fields (Keycloak's ``credentialId`` etc.) round-trip.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._in_form = False
+        self._current_action: str | None = None
+        self._current_inputs: dict[str, str] = {}
+        self._current_has_password = False
+        self.action: str | None = None
+        self.inputs: dict[str, str] = {}
+        self.field_names: set[str] = set()
+
+    def handle_starttag(self, tag, attrs):
+        attrs_d = {k: (v or "") for k, v in attrs}
+        if tag == "form":
+            self._in_form = True
+            self._current_action = attrs_d.get("action")
+            self._current_inputs = {}
+            self._current_has_password = False
+        elif tag == "input" and self._in_form:
+            name = attrs_d.get("name")
+            if not name:
+                return
+            self._current_inputs[name] = attrs_d.get("value", "")
+            if attrs_d.get("type", "").lower() == "password":
+                self._current_has_password = True
+
+    def handle_endtag(self, tag):
+        if tag == "form" and self._in_form:
+            # Keep the first form that actually collects a password
+            if self._current_has_password and self.action is None:
+                self.action = self._current_action
+                self.inputs = dict(self._current_inputs)
+                self.field_names = set(self._current_inputs)
+            self._in_form = False
+
+
+def _parse_login_form(html_text: str, base_url: str):
+    """Parse an HTML login form.
+
+    Returns ``(action_url, field_names, hidden)`` where ``action_url`` is the
+    absolute, HTML-entity-unescaped POST target (``&amp;`` -> ``&``), or
+    ``None`` when no password-bearing form is present. ``hidden`` holds every
+    input except the credential fields the caller fills.
+    """
+    parser = _LoginFormParser()
+    parser.feed(html_text)
+    if not parser.field_names:
+        return None
+    action = unescape(parser.action) if parser.action else base_url
+    action_url = urljoin(base_url, action)
+    hidden = {
+        k: v
+        for k, v in parser.inputs.items()
+        if k not in {"username", "login", "password"}
+    }
+    return action_url, parser.field_names, hidden
+
+
+def _submit_login(client, resp, interaction_url, config):
+    """Submit login credentials, handling both provider login styles.
+
+    node-oidc exposes a devInteractions endpoint that dispatches on a
+    ``prompt`` field; server-rendered providers (e.g. Keycloak) return an HTML
+    ``<form>`` that must be parsed for its action and field names. Returns the
+    post-login response for the caller's redirect-following loop.
+    """
+    if "/interaction/" in interaction_url:
+        # node-oidc devInteractions: a single endpoint dispatches on the
+        # `prompt` field. Left byte-for-byte identical to preserve the
+        # existing (passing) node-oidc flow.
+        return client.post(
+            interaction_url,
+            data={
+                "prompt": "login",
+                "login": config.login_hint,
+                "password": config.login_password,
+            },
+        )
+    # Generic server-rendered HTML login form (e.g. Keycloak). Parse the
+    # returned form for its action + field names, echo back any hidden
+    # fields, and fill whichever username field the form uses.
+    form = _parse_login_form(resp.text, interaction_url)
+    if form is None:
+        pytest.fail(f"Could not locate a login form at {interaction_url}")
+    action_url, field_names, hidden = form
+    data = dict(hidden)
+    if "username" in field_names:
+        data["username"] = config.login_hint
+    if "login" in field_names:
+        data["login"] = config.login_hint
+    data["password"] = config.login_password
+    return client.post(action_url, data=data)
+
+
 @dataclass(frozen=True)
 class AuthCodeFlowConfig:
     """Optional configuration for :func:`perform_auth_code_flow`."""
@@ -721,14 +826,7 @@ def perform_auth_code_flow(
             pytest.fail(f"Auth request failed: {resp.status_code} at {resp.url}")
 
         interaction_url = str(resp.url)
-        resp = client.post(
-            interaction_url,
-            data={
-                "prompt": "login",
-                "login": config.login_hint,
-                "password": config.login_password,
-            },
-        )
+        resp = _submit_login(client, resp, interaction_url, config)
 
         callback_url, resp = _follow_redirects_counted(
             client, resp, redirect_uri, total_redirects

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -8,7 +8,6 @@ Includes:
 
 from contextlib import suppress
 from dataclasses import dataclass
-from html import unescape
 from html.parser import HTMLParser
 import json
 import secrets
@@ -663,7 +662,10 @@ class _LoginFormParser(HTMLParser):
 
     def __init__(self) -> None:
         super().__init__()
-        self._in_form = False
+        # Depth counter (not a bool) so a nested <form> (invalid HTML, but
+        # defensive) neither resets the outer form on its start tag nor closes
+        # it early on its end tag — only the outermost boundary opens/commits.
+        self._form_depth = 0
         self._current_action: str | None = None
         self._current_inputs: dict[str, str] = {}
         self._current_has_password = False
@@ -674,11 +676,12 @@ class _LoginFormParser(HTMLParser):
     def handle_starttag(self, tag, attrs):
         attrs_d = {k: (v or "") for k, v in attrs}
         if tag == "form":
-            self._in_form = True
-            self._current_action = attrs_d.get("action")
-            self._current_inputs = {}
-            self._current_has_password = False
-        elif tag == "input" and self._in_form:
+            if self._form_depth == 0:
+                self._current_action = attrs_d.get("action")
+                self._current_inputs = {}
+                self._current_has_password = False
+            self._form_depth += 1
+        elif tag == "input" and self._form_depth > 0:
             name = attrs_d.get("name")
             if not name:
                 return
@@ -687,13 +690,15 @@ class _LoginFormParser(HTMLParser):
                 self._current_has_password = True
 
     def handle_endtag(self, tag):
-        if tag == "form" and self._in_form:
-            # Keep the first form that actually collects a password
+        if tag == "form" and self._form_depth > 0:
+            self._form_depth -= 1
+            if self._form_depth != 0:
+                return
+            # Outermost </form> closed: keep the first form that collects a password
             if self._current_has_password and self.action is None:
                 self.action = self._current_action
                 self.inputs = dict(self._current_inputs)
                 self.field_names = set(self._current_inputs)
-            self._in_form = False
 
 
 def _parse_login_form(html_text: str, base_url: str):
@@ -708,7 +713,10 @@ def _parse_login_form(html_text: str, base_url: str):
     parser.feed(html_text)
     if not parser.field_names:
         return None
-    action = unescape(parser.action) if parser.action else base_url
+    # ``HTMLParser`` already unescapes character references in attribute
+    # values (``&amp;`` -> ``&``), so the action is used as-is; a second
+    # ``unescape`` here would double-decode (e.g. ``&amp;amp;`` -> ``&``).
+    action = parser.action if parser.action else base_url
     action_url = urljoin(base_url, action)
     hidden = {
         k: v
@@ -797,6 +805,19 @@ def _submit_login(client, resp, interaction_url, config):
         data["username"] = config.login_hint
     if "login" in field_names:
         data["login"] = config.login_hint
+    if "username" not in field_names and "login" not in field_names:
+        # Provider names its identifier field something else (not
+        # username/login). Fall back to the sole non-password field so the
+        # identifier is still sent rather than silently dropped; if more than
+        # one non-password field exists it is ambiguous, so fail loudly.
+        identifier_fields = field_names - {"password"}
+        if len(identifier_fields) == 1:
+            data[next(iter(identifier_fields))] = config.login_hint
+        else:
+            pytest.fail(
+                f"Could not identify the username field in the login form at "
+                f"{action_url}; fields={sorted(field_names)}"
+            )
     data["password"] = config.login_password
     return client.post(action_url, data=data)
 

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -14,6 +14,7 @@ import json
 import secrets
 import time
 from types import MappingProxyType
+from typing import Any
 from urllib.parse import urlencode, urljoin, urlparse
 
 from filelock import FileLock
@@ -717,6 +718,53 @@ def _parse_login_form(html_text: str, base_url: str):
     return action_url, parser.field_names, hidden
 
 
+def _iter_set_cookies(response: httpx.Response):
+    """Yield ``(name, value)`` for every ``Set-Cookie`` on ``response``."""
+    for header in response.headers.get_list("set-cookie"):
+        name, sep, rest = header.partition("=")
+        if not sep:
+            continue
+        yield name.strip(), rest.split(";", 1)[0].strip()
+
+
+class _AuthFlowClient(httpx.Client):
+    """``httpx.Client`` that echoes cookies back over plain ``http``.
+
+    httpx rebuilds the cookie jar with the *default* stdlib policy on every
+    outgoing request (``BaseClient._merge_cookies`` wraps the client jar in a
+    fresh ``Cookies``, and ``Request.__init__`` wraps it again before calling
+    ``set_cookie_header``), so a custom ``CookiePolicy`` cannot survive to the
+    send path. That default policy refuses to send ``Secure`` cookies over an
+    ``http://`` connection. Keycloak marks its ``AUTH_SESSION_ID`` /
+    ``KC_RESTART`` auth-session cookies ``Secure; SameSite=None``
+    unconditionally, so a plain-http auth-code flow never gets them back and
+    every login POST fails with "Restart login cookie not found".
+
+    This client keeps its own ``name -> value`` store, captures every
+    ``Set-Cookie`` (``Secure`` included), and writes the ``Cookie`` header
+    itself. node-oidc's non-``Secure`` cookies round-trip identically through
+    the same store, so both providers share one code path.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._flow_cookies: dict[str, str] = {}
+
+    def send(self, request: httpx.Request, **kwargs: Any) -> httpx.Response:
+        if self._flow_cookies:
+            request.headers["Cookie"] = "; ".join(
+                f"{name}={value}" for name, value in self._flow_cookies.items()
+            )
+        response = super().send(request, **kwargs)
+        for name, value in _iter_set_cookies(response):
+            # An empty value is a deletion (Max-Age=0 / expired) — drop it.
+            if value:
+                self._flow_cookies[name] = value
+            else:
+                self._flow_cookies.pop(name, None)
+        return response
+
+
 def _submit_login(client, resp, interaction_url, config):
     """Submit login credentials, handling both provider login styles.
 
@@ -809,7 +857,7 @@ def perform_auth_code_flow(
     # Use a single redirect counter across the entire flow
     total_redirects = 0
 
-    with httpx.Client(follow_redirects=False, timeout=10.0) as client:
+    with _AuthFlowClient(follow_redirects=False, timeout=10.0) as client:
         resp = client.get(auth_url)
         while is_redirect(resp.status_code):
             location = _resolve_location(resp)

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -91,16 +91,38 @@ def retry_with_backoff():
 
 
 @pytest.fixture(scope="session")
-def test_config(env_file, tmp_path_factory):
+def provider_slug(env_file) -> str:
+    """Stable per-provider slug used to namespace cross-worker cache files.
+
+    Session cache/lock files live at a stable path
+    (``tmp_path_factory.getbasetemp().parent``) that is *not* keyed by
+    provider. Running two providers against the same base tmp dir — e.g.
+    ``make test-integration-node-oidc`` then ``...-keycloak`` — would
+    otherwise reuse the first provider's cached discovery document, JWKS and
+    tokens, pointing the second run at a dead endpoint (Errno 111) and the
+    wrong signing keys. Deriving the slug from the env file
+    (``.env.keycloak`` -> ``keycloak``) isolates each provider's caches.
+    """
+    if not env_file:
+        return "default"
+    # Strip any directory component without importing os
+    name = env_file.replace("\\", "/").rsplit("/", 1)[-1]
+    if name.startswith(".env."):
+        return name[len(".env.") :] or "default"
+    return "default"
+
+
+@pytest.fixture(scope="session")
+def test_config(env_file, provider_slug, tmp_path_factory):
     """Session-scoped test configuration with file-lock for xdist safety."""
     root_tmp_dir = tmp_path_factory.getbasetemp().parent
-    lock_file = root_tmp_dir / "test_config.lock"
+    lock_file = root_tmp_dir / f"{provider_slug}_test_config.lock"
     with FileLock(str(lock_file)):
         return get_config(env_file)
 
 
 @pytest.fixture(scope="session")
-def discovery_document(test_config, tmp_path_factory):
+def discovery_document(test_config, provider_slug, tmp_path_factory):
     """Cached discovery document, shared across xdist workers.
 
     See ``client_credentials_token`` for the cross-worker FileLock +
@@ -109,8 +131,8 @@ def discovery_document(test_config, tmp_path_factory):
     rate limits.
     """
     root_tmp_dir = tmp_path_factory.getbasetemp().parent
-    cache_file = root_tmp_dir / "discovery_document.json"
-    lock_file = root_tmp_dir / "discovery_document.lock"
+    cache_file = root_tmp_dir / f"{provider_slug}_discovery_document.json"
+    lock_file = root_tmp_dir / f"{provider_slug}_discovery_document.lock"
 
     with FileLock(str(lock_file)):
         if cache_file.exists():
@@ -132,7 +154,7 @@ def discovery_document(test_config, tmp_path_factory):
 
 
 @pytest.fixture(scope="session")
-def raw_discovery(test_config, tmp_path_factory):
+def raw_discovery(test_config, provider_slug, tmp_path_factory):
     """Raw discovery JSON for capability detection.
 
     Provides access to all RFC 8414 fields, including those not yet
@@ -141,8 +163,8 @@ def raw_discovery(test_config, tmp_path_factory):
     for the rationale.
     """
     root_tmp_dir = tmp_path_factory.getbasetemp().parent
-    cache_file = root_tmp_dir / "raw_discovery.json"
-    lock_file = root_tmp_dir / "raw_discovery.lock"
+    cache_file = root_tmp_dir / f"{provider_slug}_raw_discovery.json"
+    lock_file = root_tmp_dir / f"{provider_slug}_raw_discovery.lock"
 
     with FileLock(str(lock_file)):
         if cache_file.exists():
@@ -234,15 +256,15 @@ def provider_capabilities(raw_discovery):
 
 
 @pytest.fixture(scope="session")
-def jwks_response(test_config, tmp_path_factory):
+def jwks_response(test_config, provider_slug, tmp_path_factory):
     """Cached JWKS response, shared across xdist workers.
 
     See ``client_credentials_token`` for the cross-worker FileLock +
     JSON cache rationale.
     """
     root_tmp_dir = tmp_path_factory.getbasetemp().parent
-    cache_file = root_tmp_dir / "jwks_response.json"
-    lock_file = root_tmp_dir / "jwks_response.lock"
+    cache_file = root_tmp_dir / f"{provider_slug}_jwks_response.json"
+    lock_file = root_tmp_dir / f"{provider_slug}_jwks_response.lock"
 
     with FileLock(str(lock_file)):
         if cache_file.exists():
@@ -375,7 +397,12 @@ def _fetch_token_with_extended_backoff(
 
 
 @pytest.fixture(scope="session")
-def client_credentials_token(test_config, token_endpoint, tmp_path_factory):
+def client_credentials_token(
+    test_config,
+    token_endpoint,
+    provider_slug,
+    tmp_path_factory,
+):
     """Client credentials token, shared across xdist workers.
 
     Without cross-worker coordination, ``pytest -n auto`` fans out N
@@ -390,8 +417,8 @@ def client_credentials_token(test_config, token_endpoint, tmp_path_factory):
     the response object instead of re-fetching.
     """
     root_tmp_dir = tmp_path_factory.getbasetemp().parent
-    cache_file = root_tmp_dir / "client_credentials_token.json"
-    lock_file = root_tmp_dir / "client_credentials_token.lock"
+    cache_file = root_tmp_dir / f"{provider_slug}_client_credentials_token.json"
+    lock_file = root_tmp_dir / f"{provider_slug}_client_credentials_token.lock"
 
     with FileLock(str(lock_file)):
         if cache_file.exists():
@@ -473,7 +500,12 @@ def jwt_signing_key(jwks_response, jwt_access_token):
 
 
 @pytest.fixture(scope="session")
-def opaque_access_token(test_config, token_endpoint, tmp_path_factory):
+def opaque_access_token(
+    test_config,
+    token_endpoint,
+    provider_slug,
+    tmp_path_factory,
+):
     """Opaque access token for introspection/revocation tests.
 
     Some providers (e.g. node-oidc-provider) cannot introspect or revoke
@@ -489,8 +521,8 @@ def opaque_access_token(test_config, token_endpoint, tmp_path_factory):
         pytest.skip("TEST_OPAQUE_CLIENT_ID not configured")
 
     root_tmp_dir = tmp_path_factory.getbasetemp().parent
-    cache_file = root_tmp_dir / "opaque_access_token.json"
-    lock_file = root_tmp_dir / "opaque_access_token.lock"
+    cache_file = root_tmp_dir / f"{provider_slug}_opaque_access_token.json"
+    lock_file = root_tmp_dir / f"{provider_slug}_opaque_access_token.lock"
 
     with FileLock(str(lock_file)):
         if cache_file.exists():

--- a/src/tests/integration/test_device_token_exchange.py
+++ b/src/tests/integration/test_device_token_exchange.py
@@ -27,6 +27,10 @@ from py_identity_model.sync.token_exchange import exchange_token
 _UNSUPPORTED_GRANT_SIGNALS = (
     "unsupported_grant_type",  # RFC 6749 Section 5.2
     "grant_type field must be one of",  # Descope E011003
+    # Keycloak rejects the grant with these when standard token exchange is
+    # not permitted for the client (feature/version dependent).
+    "token exchange is not enabled",
+    "client is not allowed to exchange",
 )
 
 

--- a/src/tests/integration/test_json_web_key.py
+++ b/src/tests/integration/test_json_web_key.py
@@ -33,6 +33,10 @@ def test_jwk_deserialization(jwks_data):
 
         # Verify all fields from original are present and match
         for key, value in jwk_dict.items():
+            if key == "x5t#S256":
+                # RFC 7517 member name maps to the x5t_s256 Python attribute
+                assert jwk.x5t_s256 == value
+                continue
             attr_name = key.lower()
             assert hasattr(jwk, attr_name)
             assert getattr(jwk, attr_name) == value
@@ -121,6 +125,10 @@ def test_as_dict(jwks_data):
 
         # Verify all properties from the original JWK are in the dictionary
         for key, value in jwk_dict.items():
+            if key == "x5t#S256":
+                # as_dict() emits the RFC 7517 member name verbatim
+                assert jwk_as_dict["x5t#S256"] == value
+                continue
             attr_name = key.lower()
             assert attr_name in jwk_as_dict
             assert jwk_as_dict[attr_name] == value
@@ -128,6 +136,10 @@ def test_as_dict(jwks_data):
         # Verify that all non-None properties from the JWK object are in the dictionary
         for key, value in jwk.__dict__.items():
             if value is not None:
+                if key == "x5t_s256":
+                    # Python attr name is serialized as the JWK member name
+                    assert jwk_as_dict["x5t#S256"] == value
+                    continue
                 assert key in jwk_as_dict
                 assert jwk_as_dict[key] == value
 

--- a/src/tests/integration/test_private_key_jwt.py
+++ b/src/tests/integration/test_private_key_jwt.py
@@ -13,6 +13,7 @@ provider (remote providers in the CI matrix do not register this client).
 
 import base64
 import secrets
+from urllib.parse import urlparse
 
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.serialization import (
@@ -88,14 +89,20 @@ def _is_node_oidc_fixture(raw_discovery: dict) -> bool:
     """Whether the active provider is the local private_key_jwt fixture.
 
     The static key only matches the ``test-private-key-jwt`` client in the
-    bundled node-oidc-provider fixture, which runs on localhost and
-    advertises ``private_key_jwt`` support.
+    bundled node-oidc-provider fixture, which runs on localhost, serves
+    discovery at the host root, and advertises ``private_key_jwt`` support.
+
+    The host-root check is what distinguishes node-oidc from other local
+    providers: Keycloak also runs on localhost and advertises
+    ``private_key_jwt``, but serves discovery under ``/realms/<realm>`` and
+    does not register the static test client — so it must skip these tests.
     """
     issuer = raw_discovery.get("issuer", "")
     methods = raw_discovery.get("token_endpoint_auth_methods_supported", [])
-    return issuer.startswith(("http://localhost", "http://127.0.0.1")) and (
-        "private_key_jwt" in methods
-    )
+    parsed = urlparse(issuer)
+    is_local = parsed.hostname in ("localhost", "127.0.0.1")
+    at_host_root = parsed.path in ("", "/")
+    return is_local and at_host_root and "private_key_jwt" in methods
 
 
 def _require_node_oidc(raw_discovery: dict) -> None:

--- a/src/tests/unit/test_parsers.py
+++ b/src/tests/unit/test_parsers.py
@@ -495,3 +495,35 @@ class TestJwksFromDict:
         assert jwk.kty == "RSA"
         assert jwk.kid is None
         assert jwk.alg is None
+
+    def test_x5t_s256_round_trips_via_as_dict(self):
+        """x5t#S256 (RFC 7517) survives as_dict / from_json / jwks_from_dict.
+
+        Providers such as Keycloak emit the ``x5t#S256`` SHA-256 thumbprint in
+        their JWKS. ``as_dict()`` must serialize it under the RFC member name so
+        the dictionary form round-trips; previously it used the ``x5t_s256``
+        Python attribute name, which ``from_json``/``jwks_from_dict`` do not read.
+        """
+        key_dict = {
+            "kty": "RSA",
+            "kid": "keycloak-sig",
+            "alg": "RS256",
+            "use": "sig",
+            "n": "modulus",
+            "e": "AQAB",
+            "x5t#S256": "abc123thumbprint",
+        }
+
+        jwk = jwks_from_dict(key_dict)
+        assert jwk.x5t_s256 == "abc123thumbprint"
+
+        # as_dict() emits the RFC member name, not the Python attribute name
+        as_dict = jwk.as_dict()
+        assert as_dict["x5t#S256"] == "abc123thumbprint"
+        assert "x5t_s256" not in as_dict
+
+        # The dictionary form round-trips back through both parse paths
+        assert jwks_from_dict(as_dict).x5t_s256 == "abc123thumbprint"
+        assert JsonWebKey.from_json(json.dumps(as_dict)).x5t_s256 == (
+            "abc123thumbprint"
+        )

--- a/test-fixtures/keycloak/README.md
+++ b/test-fixtures/keycloak/README.md
@@ -45,7 +45,7 @@ pinning a key.
 
 | clientId | Type | Secret | Flows | Notes |
 | --- | --- | --- | --- | --- |
-| `py-identity-model-client` | confidential | `py-identity-model-client-secret` | client_credentials (service account) | primary `TEST_CLIENT_ID` |
+| `py-identity-model-client` | confidential | `py-identity-model-client-secret` | client_credentials (service account), device grant, token exchange | primary `TEST_CLIENT_ID`; `oauth2.device.authorization.grant.enabled` + `standard.token.exchange.enabled` |
 | `test-auth-code` | confidential | `test-auth-code-secret` | authorization_code, direct grant | back-channel logout URL + `session.required=true` configured for logout tests |
 | `test-pkce-public` | public | — | authorization_code (PKCE **S256 required**) | redirect `http://localhost:8080/callback` |
 
@@ -55,9 +55,10 @@ login page — the auth-code test login helper is wired in KC.3.
 
 ## Test user
 
-`test-user` / `test-user-password` — email `test@example.com` (verified),
-name "Test User". Needed for the auth-code login form (Keycloak has no
-auto-login equivalent to node-oidc `devInteractions`).
+`test-user` / `test` — email `test@example.com` (verified), name "Test User".
+Needed for the auth-code login form (Keycloak has no auto-login equivalent to
+node-oidc `devInteractions`). The password matches the shared
+`AuthCodeFlowConfig` default so the login helper needs no per-provider config.
 
 ## Capabilities
 
@@ -74,6 +75,14 @@ auto-login equivalent to node-oidc `devInteractions`).
 - **Opaque tokens** — Keycloak emits JWTs, not opaque tokens, so the
   introspection / opaque-token integration tests **skip cleanly** (no
   `TEST_OPAQUE_CLIENT_ID` is configured for this provider).
+- **Device authorization grant** (RFC 8628) — enabled on
+  `py-identity-model-client` via `oauth2.device.authorization.grant.enabled`.
+- **Token exchange** (RFC 8693) — standard token exchange enabled on
+  `py-identity-model-client` via `standard.token.exchange.enabled` (a
+  supported feature in Keycloak 26.2+, no server feature flag required).
+- **private_key_jwt** — advertised in discovery, but the live
+  `private_key_jwt` tests pin the static key registered only in the node-oidc
+  fixture, so they **skip cleanly** against Keycloak.
 
 ## Wiring (added in later stories)
 

--- a/test-fixtures/keycloak/realm-export.json
+++ b/test-fixtures/keycloak/realm-export.json
@@ -88,7 +88,8 @@
           "value": "test",
           "temporary": false
         }
-      ]
+      ],
+      "realmRoles": ["offline_access", "uma_authorization"]
     }
   ]
 }

--- a/test-fixtures/keycloak/realm-export.json
+++ b/test-fixtures/keycloak/realm-export.json
@@ -24,7 +24,11 @@
       "standardFlowEnabled": false,
       "implicitFlowEnabled": false,
       "directAccessGrantsEnabled": false,
-      "fullScopeAllowed": true
+      "fullScopeAllowed": true,
+      "attributes": {
+        "oauth2.device.authorization.grant.enabled": "true",
+        "standard.token.exchange.enabled": "true"
+      }
     },
     {
       "clientId": "test-auth-code",
@@ -81,7 +85,7 @@
       "credentials": [
         {
           "type": "password",
-          "value": "test-user-password",
+          "value": "test",
           "temporary": false
         }
       ]


### PR DESCRIPTION
## Summary

Makes the full integration suite run **green against live Keycloak** (KC.3), fixing one genuine `core/` serialization gap plus the test-infra/fixture wiring that live Keycloak surfaced. Capability-gated skips remain clean.

**Core library fix (sync+async shared model):**
- `fix(jwks)` — `JsonWebKey.as_dict()` now emits the RFC 7517 member name `x5t#S256` (was the Python attr name `x5t_s256`), so it round-trips with `to_json()`/`jwks_from_dict()`. Keycloak JWKS carries `x5t#S256`; node-oidc never did, so it was never exercised. Added a unit round-trip test in `test_parsers.py`.

**Test-infra / fixture (Keycloak-specific, node-oidc kept byte-identical):**
- `test(keycloak)` — key all 5 cross-worker session caches/locks by a `provider_slug` derived from the env file, killing cross-provider cache poisoning (`/var/tmp/pytest-of-*` reuse of stale node-oidc issuer/kid/tokens).
- `test(keycloak)` — generalize the auth-code login helper to parse the returned HTML `<form>` (action + field names) for Keycloak while preserving the node-oidc devInteractions path (branch on `/interaction/`).
- `test(keycloak)` — `_AuthFlowClient` sends Keycloak's `Secure;SameSite=None` auth-session cookies over http (httpx 0.28.1 refuses to and can't be forced).
- `test(keycloak)` — gate `private_key_jwt` tests to the node-oidc fixture (DEC-007 option B); skip KC token-exchange rejection cleanly.
- `build(keycloak)` — realm-export: enable device grant + standard token exchange on the client, set test-user password to `test` (matches `AuthCodeFlowConfig` default), grant `offline_access`/`uma_authorization` roles.

Refs KC.3 (Keycloak provider integration epic)

## Base

Stacked on **#447** (`feat/keycloak-provider-wiring`), which is stacked on **#446** (`feat/keycloak-fixture`). Recommend merging #446 → #447 → this, bottom-up.

## Review Findings Addressed

Reviewers (KC.x): Blind Hunter + Edge Case Hunter + Acceptance Auditor.
- **Acceptance:** 4/4 ACs PASS — full capability-gated suite green vs Keycloak; only prod-code change is the `x5t#S256` serialization fix with a unit test.
- **P0:** 0.
- **P1:** 3 fixed (double-unescape of form action; identifier-field fallback with loud pytest.fail; nested-`<form>` depth counter), 1 skipped-with-rationale (`_AuthFlowClient` cookie replay — single-host localhost fixtures only).
- **Delta re-review (iter-2):** 0 MUST / 0 SHOULD, no regressions.

## Test plan
- [x] Unit tests pass (1223 passed, 95.5% cov)
- [x] Integration tests pass — Keycloak 93 passed / 29 clean skips / 0 fail; node-oidc regression 117 passed / 5 skip / 0 fail
- [x] Lint passes (ruff + ruff format + pyrefly + coverage gate)
- [x] Independent review agents passed
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)