### PR TITLE
fix(conformance): stop exposing exception text in logout error response

### DIFF
--- a/conformance/app.py
+++ b/conformance/app.py
@@ -1012,7 +1012,7 @@ def _receive_backchannel_logout(logout_token: str | None) -> JSONResponse:
         logger.error("REJECTED: logout token validation error: %s", exc)
         return JSONResponse(
             status_code=400,
-            content={"error": "invalid_logout_token", "detail": str(exc)},
+            content={"error": "invalid_logout_token", "detail": exc.message},
         )
     except PyJWTError as exc:
         # A non-empty but malformed ``logout_token`` (not a well-formed JWT)


### PR DESCRIPTION
## What
The back-channel logout endpoint's catch-all `except PyIdentityModelException` returned `str(exc)` in the response `detail` field (`conformance/app.py:1015`) — a stringified exception flowing to the external caller.

## Why
CodeQL flagged this as **py/stack-trace-exposure** (medium) — [alert #17](https://github.com/jamescrowley321/py-identity-model/security/code-scanning/17).

## Fix
Return `exc.message` (the curated message set when the exception is raised) instead of `str(exc)`. This is the **same pattern the sibling handlers in this function already use** (`TokenValidationException`, logout-rules) — which CodeQL does not flag — so the caller still gets the specific failure reason, just without the stringified-exception exposure. HTTP status (400) and error code unchanged; conformance behavior unaffected.

Resolves code-scanning alert #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)