### PR TITLE
fix(jwks-cache): switch JWKS/disco caches to LRU eviction (T236, #397)

### DIFF
--- a/src/py_identity_model/aio/token_validation.py
+++ b/src/py_identity_model/aio/token_validation.py
@@ -6,6 +6,7 @@ with automatic cache expiry and forced JWKS refresh on key rotation.
 """
 
 import asyncio
+from collections import OrderedDict
 import threading
 import time
 from weakref import WeakKeyDictionary
@@ -18,6 +19,7 @@ from ..core.jwks_cache import (
     apply_jwks_cache_outcome,
     is_cache_expired,
     should_attempt_kid_miss_refresh,
+    touch_cache_entry,
 )
 from ..core.models import (
     DiscoveryDocumentRequest,
@@ -53,8 +55,10 @@ from .managed_client import AsyncHTTPClient
 # Discovery TTL cache
 # ============================================================================
 
-# Discovery TTL cache — keyed by (address, require_https) to prevent policy bypass
-_disco_cache: dict[tuple[str, bool], DiscoCacheEntry] = {}
+# Discovery TTL cache — keyed by (address, require_https) to prevent policy bypass.
+# OrderedDict (not a plain dict) so read hits can refresh LRU recency via
+# ``touch_cache_entry``; eviction targets the least recently *used* entry (#397).
+_disco_cache: OrderedDict[tuple[str, bool], DiscoCacheEntry] = OrderedDict()
 
 # Per-event-loop lock storage. Module-level ``asyncio.Lock()`` instances bind
 # to whichever event loop first calls ``.acquire()`` (Python 3.10+), so any
@@ -123,12 +127,18 @@ async def _get_disco_response(
     cache_key = (disco_doc_address, require_https)
     entry = _disco_cache.get(cache_key)
     if entry is not None and not is_cache_expired(entry):
+        # Refresh LRU recency under the write lock — move_to_end mutates order
+        # and must serialize against _enforce_size_limit's iteration (#397).
+        async with _get_disco_cache_write_lock():
+            touch_cache_entry(_disco_cache, cache_key)
         return entry.response
 
     fetch_lock = _get_disco_fetch_lock(cache_key)
     async with fetch_lock:
         entry = _disco_cache.get(cache_key)
         if entry is not None and not is_cache_expired(entry):
+            async with _get_disco_cache_write_lock():
+                touch_cache_entry(_disco_cache, cache_key)
             return entry.response
 
         policy = DiscoveryPolicy(require_https=require_https)
@@ -166,7 +176,7 @@ async def clear_discovery_cache() -> None:
 # TTL-aware JWKS cache (replaces @alru_cache for JWKS)
 # ============================================================================
 
-_jwks_cache: dict[str, JwksCacheEntry] = {}
+_jwks_cache: OrderedDict[str, JwksCacheEntry] = OrderedDict()
 
 # See sync._kid_miss_last_attempt for rationale. Guarded by the per-loop
 # JWKS cache write lock.
@@ -204,12 +214,17 @@ async def _get_cached_jwks(jwks_uri: str, require_https: bool = True) -> JwksRes
     """
     entry = _jwks_cache.get(jwks_uri)
     if entry is not None and not is_cache_expired(entry):
+        # Refresh LRU recency under the write lock (see _get_disco_response).
+        async with _get_jwks_cache_write_lock():
+            touch_cache_entry(_jwks_cache, jwks_uri)
         return entry.response
 
     fetch_lock = _get_jwks_fetch_lock(jwks_uri)
     async with fetch_lock:
         entry = _jwks_cache.get(jwks_uri)
         if entry is not None and not is_cache_expired(entry):
+            async with _get_jwks_cache_write_lock():
+                touch_cache_entry(_jwks_cache, jwks_uri)
             return entry.response
 
         # The jwks_uri was already vetted against this policy when the

--- a/src/py_identity_model/aio/token_validation.py
+++ b/src/py_identity_model/aio/token_validation.py
@@ -17,6 +17,7 @@ from ..core.jwks_cache import (
     JwksCacheEntry,
     apply_disco_cache_outcome,
     apply_jwks_cache_outcome,
+    clear_cache_locked,
     is_cache_expired,
     should_attempt_kid_miss_refresh,
     touch_cache_entry,
@@ -170,7 +171,7 @@ async def clear_discovery_cache() -> None:
     per-loop lock plumbing for #399.
     """
     async with _get_disco_cache_write_lock():
-        _disco_cache.clear()
+        clear_cache_locked(_disco_cache)
 
 
 # ============================================================================
@@ -310,7 +311,7 @@ async def clear_jwks_cache() -> None:
     for the cross-loop semantics added in the #399 per-loop lock plumbing.
     """
     async with _get_jwks_cache_write_lock():
-        _jwks_cache.clear()
+        clear_cache_locked(_jwks_cache)
         _kid_miss_last_attempt.clear()
 
 

--- a/src/py_identity_model/aio/token_validation.py
+++ b/src/py_identity_model/aio/token_validation.py
@@ -127,18 +127,19 @@ async def _get_disco_response(
     cache_key = (disco_doc_address, require_https)
     entry = _disco_cache.get(cache_key)
     if entry is not None and not is_cache_expired(entry):
-        # Refresh LRU recency under the write lock — move_to_end mutates order
-        # and must serialize against _enforce_size_limit's iteration (#397).
-        async with _get_disco_cache_write_lock():
-            touch_cache_entry(_disco_cache, cache_key)
+        # Refresh LRU recency — touch_cache_entry serializes the reorder against
+        # _enforce_size_limit via the process-wide structure lock. The async
+        # write locks are keyed per event loop, so they cannot guard reordering
+        # against an eviction on another loop sharing this module-global cache;
+        # the process-wide lock inside touch_cache_entry does (#397).
+        touch_cache_entry(_disco_cache, cache_key)
         return entry.response
 
     fetch_lock = _get_disco_fetch_lock(cache_key)
     async with fetch_lock:
         entry = _disco_cache.get(cache_key)
         if entry is not None and not is_cache_expired(entry):
-            async with _get_disco_cache_write_lock():
-                touch_cache_entry(_disco_cache, cache_key)
+            touch_cache_entry(_disco_cache, cache_key)
             return entry.response
 
         policy = DiscoveryPolicy(require_https=require_https)
@@ -214,17 +215,16 @@ async def _get_cached_jwks(jwks_uri: str, require_https: bool = True) -> JwksRes
     """
     entry = _jwks_cache.get(jwks_uri)
     if entry is not None and not is_cache_expired(entry):
-        # Refresh LRU recency under the write lock (see _get_disco_response).
-        async with _get_jwks_cache_write_lock():
-            touch_cache_entry(_jwks_cache, jwks_uri)
+        # Refresh LRU recency (see _get_disco_response) — self-serializing via
+        # the process-wide structure lock, no per-loop write lock needed.
+        touch_cache_entry(_jwks_cache, jwks_uri)
         return entry.response
 
     fetch_lock = _get_jwks_fetch_lock(jwks_uri)
     async with fetch_lock:
         entry = _jwks_cache.get(jwks_uri)
         if entry is not None and not is_cache_expired(entry):
-            async with _get_jwks_cache_write_lock():
-                touch_cache_entry(_jwks_cache, jwks_uri)
+            touch_cache_entry(_jwks_cache, jwks_uri)
             return entry.response
 
         # The jwks_uri was already vetted against this policy when the

--- a/src/py_identity_model/core/jwks_cache.py
+++ b/src/py_identity_model/core/jwks_cache.py
@@ -31,6 +31,8 @@ from ..logging_config import logger
 
 
 if TYPE_CHECKING:
+    from collections import OrderedDict
+
     from ..core.models import DiscoveryDocumentResponse, JwksResponse
 
 DEFAULT_JWKS_CACHE_TTL_SECONDS: float = 86400.0  # 24 hours
@@ -64,9 +66,13 @@ DEFAULT_KID_MISS_REFRESH_COOLDOWN_SECONDS: float = 5.0
 # attacker-supplied issuer headers) accumulate cache entries forever — at
 # ~5KB per DiscoveryDocumentResponse, a few thousand unique entries is tens
 # of MB of memory leak. Default 64 covers any realistic multi-IdP deployment
-# while keeping worst-case memory bounded. Eviction is FIFO by insertion
-# order (Python dicts preserve insertion order since 3.7) — adequate for a
-# JWKS cache where all entries are roughly equally "hot."
+# while keeping worst-case memory bounded. Eviction is LRU by access order:
+# the cache is an ``OrderedDict`` whose entries are moved to the end on every
+# read hit (see ``touch_cache_entry``) and on every write, so the least
+# *recently used* entry sorts first and is evicted first. FIFO would let an
+# attacker who controls the discovery address (multi-tenant gateway,
+# attacker-supplied issuer header) evict a legitimately-hot JWKS entry merely
+# by reading distinct addresses in insertion order (issue #397).
 DEFAULT_MAX_CACHE_ENTRIES: int = 64
 
 _env_ttl: float | None = None
@@ -190,10 +196,32 @@ def get_max_cache_entries() -> int:
     return _max_cache_entries
 
 
-def _enforce_size_limit(cache: dict) -> list:
-    """Evict oldest entries (by insertion order) until the cache fits.
+def touch_cache_entry(cache: OrderedDict, key: object) -> None:
+    """Refresh an entry's LRU recency by moving it to the end (most-recent).
 
-    Returns the list of evicted keys (in eviction order, oldest first) so
+    Called on read cache hits so a fresh lookup counts as "recently used" and
+    is therefore evicted last. ``next(iter(cache))`` in :func:`_enforce_size_limit`
+    then always points at the *least recently used* entry rather than the
+    least recently *inserted* one — the FIFO→LRU switch that closes #397.
+
+    No-op when ``key`` is absent: the entry may have been evicted between the
+    lock-free ``.get()`` on the read hot-path and acquiring the write lock, so
+    ``move_to_end`` would otherwise raise ``KeyError``. Must be called while
+    holding the same write lock as :func:`_enforce_size_limit` so the reorder
+    cannot race the eviction iteration.
+    """
+    if key in cache:
+        cache.move_to_end(key)
+
+
+def _enforce_size_limit(cache: dict) -> list:
+    """Evict least-recently-used entries until the cache fits.
+
+    With an ``OrderedDict`` reordered on every read hit (see
+    :func:`touch_cache_entry`) and every write, ``next(iter(cache))`` is the
+    least recently *used* entry, so this evicts LRU rather than FIFO.
+
+    Returns the list of evicted keys (in eviction order, LRU first) so
     callers can clean up sidecar state keyed by the same identifiers — e.g.,
     ``_kid_miss_last_attempt`` in the token_validation modules, which would
     otherwise grow unbounded even though the JWKS cache itself is bounded.
@@ -205,7 +233,7 @@ def _enforce_size_limit(cache: dict) -> list:
         cache.pop(oldest_key)
         evicted.append(oldest_key)
         logger.debug(
-            "Cache size %d exceeds max %d; evicted oldest entry",
+            "Cache size %d exceeds max %d; evicted least-recently-used entry",
             len(cache) + 1,
             max_size,
         )
@@ -459,8 +487,8 @@ def apply_jwks_cache_outcome(
         if cooldown is not None:
             cooldown.pop(jwks_uri, None)
         return
-    # Pop-and-reinsert so a refreshed URI moves to the end of insertion order
-    # (FIFO eviction will not target it next when the cache is under pressure).
+    # Pop-and-reinsert so a refreshed URI moves to the most-recently-used end
+    # (LRU eviction will not target it next when the cache is under pressure).
     cache.pop(jwks_uri, None)
     cache[jwks_uri] = JwksCacheEntry(
         response=response,
@@ -521,4 +549,5 @@ __all__ = [
     "resolve_disco_ttl",
     "resolve_ttl",
     "should_attempt_kid_miss_refresh",
+    "touch_cache_entry",
 ]

--- a/src/py_identity_model/core/jwks_cache.py
+++ b/src/py_identity_model/core/jwks_cache.py
@@ -197,20 +197,28 @@ def get_max_cache_entries() -> int:
     return _max_cache_entries
 
 
-# Serializes structural reordering (:func:`touch_cache_entry`) against the
-# eviction scan (:func:`_enforce_size_limit`) for the process-shared JWKS and
-# discovery ``OrderedDict``s. A single *process-wide* ``threading.Lock`` is used
-# deliberately rather than the callers' per-domain locks: the sync path guards
-# writes with a global ``threading.Lock`` while the async path uses a lock keyed
-# per event loop, but both concurrency domains mutate the *same* module-global
-# cache objects. A per-loop async lock cannot serialize a reorder on loop A
-# against an eviction on loop B (nor against a sync thread), so the read-hit
-# ``move_to_end`` would race ``next(iter(cache))``/``pop`` and evict the wrong
-# (possibly hot) entry. Holding this leaf lock around both operations closes
-# that cross-loop/cross-thread race (#397). It is always acquired last (inside
-# any caller-held write lock), never wraps I/O, and guards only O(1)/O(overflow)
+# Serializes ALL structural mutation of the process-shared JWKS and discovery
+# ``OrderedDict``s — the read-hit reorder (:func:`touch_cache_entry`), the write
+# reinsert/pop (:func:`apply_jwks_cache_outcome` / :func:`apply_disco_cache_outcome`),
+# and the eviction scan (:func:`_enforce_size_limit`) — against each other.
+#
+# A single *process-wide* lock is used deliberately rather than the callers'
+# per-domain locks: the sync path guards writes with a global ``threading.Lock``
+# while the async path uses a lock keyed per event loop, but both concurrency
+# domains mutate the *same* module-global cache objects. A per-loop async lock
+# cannot serialize a mutation on loop A against the eviction scan on loop B (nor
+# against a sync thread), so without this lock a read-hit ``move_to_end`` or a
+# write reinsert on one loop could race ``next(iter(cache))``/``pop`` on another
+# — evicting the wrong (possibly hot) entry or raising ``RuntimeError:
+# OrderedDict mutated during iteration``, and a concurrent write ``pop`` could
+# turn a read-hit ``move_to_end`` into a ``KeyError``. Holding this lock around
+# every structural mutation closes those cross-loop/cross-thread races (#397).
+#
+# It is reentrant so a write can hold it across its reinsert *and* the nested
+# :func:`_enforce_size_limit` call. It is always acquired last (inside any
+# caller-held write lock), never wraps I/O, and guards only O(1)/O(overflow)
 # dict operations, so it adds no deadlock risk and negligible contention.
-_CACHE_STRUCTURE_LOCK = threading.Lock()
+_CACHE_STRUCTURE_LOCK = threading.RLock()
 
 
 def touch_cache_entry(cache: OrderedDict, key: object) -> None:
@@ -511,19 +519,24 @@ def apply_jwks_cache_outcome(
     if not response.keys:
         return
     if is_uncacheable_for_jwks(response.cache_control):
-        cache.pop(jwks_uri, None)
+        with _CACHE_STRUCTURE_LOCK:
+            cache.pop(jwks_uri, None)
         if cooldown is not None:
             cooldown.pop(jwks_uri, None)
         return
     # Pop-and-reinsert so a refreshed URI moves to the most-recently-used end
     # (LRU eviction will not target it next when the cache is under pressure).
-    cache.pop(jwks_uri, None)
-    cache[jwks_uri] = JwksCacheEntry(
-        response=response,
-        cached_at=now,
-        ttl=resolve_ttl(response.cache_control),
-    )
-    evicted = _enforce_size_limit(cache)
+    # The whole structural transaction (reinsert + eviction scan) runs under
+    # _CACHE_STRUCTURE_LOCK so it is atomic w.r.t. read-hit reorders and the
+    # eviction scan on any other thread/event loop (#397).
+    with _CACHE_STRUCTURE_LOCK:
+        cache.pop(jwks_uri, None)
+        cache[jwks_uri] = JwksCacheEntry(
+            response=response,
+            cached_at=now,
+            ttl=resolve_ttl(response.cache_control),
+        )
+        evicted = _enforce_size_limit(cache)
     if cooldown is not None:
         for key in evicted:
             cooldown.pop(key, None)
@@ -544,15 +557,19 @@ def apply_disco_cache_outcome(
     if not response.is_successful:
         return
     if is_uncacheable(response.cache_control):
-        cache.pop(cache_key, None)
+        with _CACHE_STRUCTURE_LOCK:
+            cache.pop(cache_key, None)
         return
-    cache.pop(cache_key, None)
-    cache[cache_key] = DiscoCacheEntry(
-        response=response,
-        cached_at=now,
-        ttl=resolve_disco_ttl(response.cache_control),
-    )
-    _enforce_size_limit(cache)
+    # Structural transaction under _CACHE_STRUCTURE_LOCK — see
+    # apply_jwks_cache_outcome for the cross-loop/cross-thread rationale (#397).
+    with _CACHE_STRUCTURE_LOCK:
+        cache.pop(cache_key, None)
+        cache[cache_key] = DiscoCacheEntry(
+            response=response,
+            cached_at=now,
+            ttl=resolve_disco_ttl(response.cache_control),
+        )
+        _enforce_size_limit(cache)
 
 
 __all__ = [

--- a/src/py_identity_model/core/jwks_cache.py
+++ b/src/py_identity_model/core/jwks_cache.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass, field
 import math
 import os
 import re
+import threading
 import time
 from typing import TYPE_CHECKING
 
@@ -196,6 +197,22 @@ def get_max_cache_entries() -> int:
     return _max_cache_entries
 
 
+# Serializes structural reordering (:func:`touch_cache_entry`) against the
+# eviction scan (:func:`_enforce_size_limit`) for the process-shared JWKS and
+# discovery ``OrderedDict``s. A single *process-wide* ``threading.Lock`` is used
+# deliberately rather than the callers' per-domain locks: the sync path guards
+# writes with a global ``threading.Lock`` while the async path uses a lock keyed
+# per event loop, but both concurrency domains mutate the *same* module-global
+# cache objects. A per-loop async lock cannot serialize a reorder on loop A
+# against an eviction on loop B (nor against a sync thread), so the read-hit
+# ``move_to_end`` would race ``next(iter(cache))``/``pop`` and evict the wrong
+# (possibly hot) entry. Holding this leaf lock around both operations closes
+# that cross-loop/cross-thread race (#397). It is always acquired last (inside
+# any caller-held write lock), never wraps I/O, and guards only O(1)/O(overflow)
+# dict operations, so it adds no deadlock risk and negligible contention.
+_CACHE_STRUCTURE_LOCK = threading.Lock()
+
+
 def touch_cache_entry(cache: OrderedDict, key: object) -> None:
     """Refresh an entry's LRU recency by moving it to the end (most-recent).
 
@@ -205,13 +222,18 @@ def touch_cache_entry(cache: OrderedDict, key: object) -> None:
     least recently *inserted* one — the FIFO→LRU switch that closes #397.
 
     No-op when ``key`` is absent: the entry may have been evicted between the
-    lock-free ``.get()`` on the read hot-path and acquiring the write lock, so
-    ``move_to_end`` would otherwise raise ``KeyError``. Must be called while
-    holding the same write lock as :func:`_enforce_size_limit` so the reorder
-    cannot race the eviction iteration.
+    lock-free ``.get()`` on the read hot-path and this call, so ``move_to_end``
+    would otherwise raise ``KeyError``.
+
+    Self-serializing: the reorder runs under the process-wide
+    ``_CACHE_STRUCTURE_LOCK`` so it cannot race :func:`_enforce_size_limit`'s
+    eviction iteration on any thread or event loop. Callers therefore need not
+    (and should not) hold a write lock solely to call this — that would only add
+    contention to the read hot-path.
     """
-    if key in cache:
-        cache.move_to_end(key)
+    with _CACHE_STRUCTURE_LOCK:
+        if key in cache:
+            cache.move_to_end(key)
 
 
 def _enforce_size_limit(cache: dict) -> list:
@@ -221,6 +243,11 @@ def _enforce_size_limit(cache: dict) -> list:
     :func:`touch_cache_entry`) and every write, ``next(iter(cache))`` is the
     least recently *used* entry, so this evicts LRU rather than FIFO.
 
+    The eviction scan holds ``_CACHE_STRUCTURE_LOCK`` so it is mutually
+    exclusive with concurrent read-hit reorders across all threads and event
+    loops — otherwise a ``move_to_end`` on another loop could shift the order
+    mid-scan and evict a recently-used entry (#397).
+
     Returns the list of evicted keys (in eviction order, LRU first) so
     callers can clean up sidecar state keyed by the same identifiers — e.g.,
     ``_kid_miss_last_attempt`` in the token_validation modules, which would
@@ -228,15 +255,16 @@ def _enforce_size_limit(cache: dict) -> list:
     """
     max_size = get_max_cache_entries()
     evicted: list = []
-    while len(cache) > max_size:
-        oldest_key = next(iter(cache))
-        cache.pop(oldest_key)
-        evicted.append(oldest_key)
-        logger.debug(
-            "Cache size %d exceeds max %d; evicted least-recently-used entry",
-            len(cache) + 1,
-            max_size,
-        )
+    with _CACHE_STRUCTURE_LOCK:
+        while len(cache) > max_size:
+            oldest_key = next(iter(cache))
+            cache.pop(oldest_key)
+            evicted.append(oldest_key)
+            logger.debug(
+                "Cache size %d exceeds max %d; evicted least-recently-used entry",
+                len(cache) + 1,
+                max_size,
+            )
     return evicted
 
 

--- a/src/py_identity_model/core/jwks_cache.py
+++ b/src/py_identity_model/core/jwks_cache.py
@@ -244,6 +244,24 @@ def touch_cache_entry(cache: OrderedDict, key: object) -> None:
             cache.move_to_end(key)
 
 
+def clear_cache_locked(cache: dict) -> None:
+    """Empty a shared cache under ``_CACHE_STRUCTURE_LOCK``.
+
+    ``clear_jwks_cache`` / ``clear_discovery_cache`` hold their per-domain write
+    lock, but that lock is per-event-loop on the async side while the cache is
+    process-global — so it does not serialize the structural ``clear()`` against
+    a read-hit :func:`touch_cache_entry` or the eviction scan in
+    :func:`_enforce_size_limit` running on another loop/thread. Routing the
+    ``clear()`` through this leaf lock keeps the "every structural mutation
+    holds the structure lock" invariant intact (#397): a concurrent ``clear()``
+    can no longer race ``next(iter(cache))`` (``RuntimeError``) or ``move_to_end``
+    (``KeyError``). Sidecar dicts (e.g. ``_kid_miss_last_attempt``) are cleared
+    separately by the caller — they are never touched under the structure lock.
+    """
+    with _CACHE_STRUCTURE_LOCK:
+        cache.clear()
+
+
 def _enforce_size_limit(cache: dict) -> list:
     """Evict least-recently-used entries until the cache fits.
 
@@ -585,6 +603,7 @@ __all__ = [
     "JwksCacheEntry",
     "apply_disco_cache_outcome",
     "apply_jwks_cache_outcome",
+    "clear_cache_locked",
     "get_kid_miss_cooldown",
     "get_max_cache_entries",
     "is_cache_expired",

--- a/src/py_identity_model/sync/token_validation.py
+++ b/src/py_identity_model/sync/token_validation.py
@@ -93,10 +93,10 @@ def _get_disco_response(
     # Cheap atomic dict read — no lock required for a single .get() in CPython.
     entry = _disco_cache.get(cache_key)
     if entry is not None and not is_cache_expired(entry):
-        # Refresh LRU recency under the write lock — move_to_end mutates order
-        # and must serialize against _enforce_size_limit's iteration (#397).
-        with _disco_cache_write_lock:
-            touch_cache_entry(_disco_cache, cache_key)
+        # Refresh LRU recency — touch_cache_entry self-serializes the reorder
+        # against _enforce_size_limit via the process-wide structure lock, so
+        # the read hot-path takes no write lock (#397).
+        touch_cache_entry(_disco_cache, cache_key)
         return entry.response
 
     fetch_lock = _get_disco_fetch_lock(cache_key)
@@ -105,8 +105,7 @@ def _get_disco_response(
         # the entry while we waited.
         entry = _disco_cache.get(cache_key)
         if entry is not None and not is_cache_expired(entry):
-            with _disco_cache_write_lock:
-                touch_cache_entry(_disco_cache, cache_key)
+            touch_cache_entry(_disco_cache, cache_key)
             return entry.response
 
         policy = DiscoveryPolicy(require_https=require_https)
@@ -157,17 +156,16 @@ def _get_cached_jwks(jwks_uri: str, require_https: bool = True) -> JwksResponse:
     """
     entry = _jwks_cache.get(jwks_uri)
     if entry is not None and not is_cache_expired(entry):
-        # Refresh LRU recency under the write lock (see _get_disco_response).
-        with _jwks_cache_write_lock:
-            touch_cache_entry(_jwks_cache, jwks_uri)
+        # Refresh LRU recency (see _get_disco_response) — self-serializing, no
+        # write lock on the read hot-path.
+        touch_cache_entry(_jwks_cache, jwks_uri)
         return entry.response
 
     fetch_lock = _get_jwks_fetch_lock(jwks_uri)
     with fetch_lock:
         entry = _jwks_cache.get(jwks_uri)
         if entry is not None and not is_cache_expired(entry):
-            with _jwks_cache_write_lock:
-                touch_cache_entry(_jwks_cache, jwks_uri)
+            touch_cache_entry(_jwks_cache, jwks_uri)
             return entry.response
 
         # The jwks_uri was already vetted against this policy when the

--- a/src/py_identity_model/sync/token_validation.py
+++ b/src/py_identity_model/sync/token_validation.py
@@ -18,6 +18,7 @@ from ..core.jwks_cache import (
     JwksCacheEntry,
     apply_disco_cache_outcome,
     apply_jwks_cache_outcome,
+    clear_cache_locked,
     is_cache_expired,
     should_attempt_kid_miss_refresh,
     touch_cache_entry,
@@ -122,7 +123,7 @@ def _get_disco_response(
 def clear_discovery_cache() -> None:
     """Clear the discovery cache."""
     with _disco_cache_write_lock:
-        _disco_cache.clear()
+        clear_cache_locked(_disco_cache)
 
 
 # ============================================================================
@@ -247,7 +248,7 @@ def _refresh_jwks(
 def clear_jwks_cache() -> None:
     """Clear the JWKS cache. Useful for testing."""
     with _jwks_cache_write_lock:
-        _jwks_cache.clear()
+        clear_cache_locked(_jwks_cache)
         _kid_miss_last_attempt.clear()
 
 

--- a/src/py_identity_model/sync/token_validation.py
+++ b/src/py_identity_model/sync/token_validation.py
@@ -8,6 +8,7 @@ with automatic cache expiry and forced JWKS refresh on key rotation.
 # ============================================================================
 # Discovery TTL cache
 # ============================================================================
+from collections import OrderedDict
 import threading
 import time
 
@@ -19,6 +20,7 @@ from ..core.jwks_cache import (
     apply_jwks_cache_outcome,
     is_cache_expired,
     should_attempt_kid_miss_refresh,
+    touch_cache_entry,
 )
 from ..core.models import (
     DiscoveryDocumentRequest,
@@ -50,8 +52,10 @@ from .jwks import get_jwks
 from .managed_client import HTTPClient
 
 
-# Discovery TTL cache — keyed by (address, require_https) to prevent policy bypass
-_disco_cache: dict[tuple[str, bool], DiscoCacheEntry] = {}
+# Discovery TTL cache — keyed by (address, require_https) to prevent policy bypass.
+# OrderedDict (not a plain dict) so read hits can refresh LRU recency via
+# ``touch_cache_entry``; eviction targets the least recently *used* entry (#397).
+_disco_cache: OrderedDict[tuple[str, bool], DiscoCacheEntry] = OrderedDict()
 # Global lock used only for the brief cache write + eviction critical section.
 # It does NOT span the upstream HTTP fetch — see ``_get_disco_response`` for
 # the cache-aside pattern that lets fetches for distinct addresses proceed in
@@ -89,6 +93,10 @@ def _get_disco_response(
     # Cheap atomic dict read — no lock required for a single .get() in CPython.
     entry = _disco_cache.get(cache_key)
     if entry is not None and not is_cache_expired(entry):
+        # Refresh LRU recency under the write lock — move_to_end mutates order
+        # and must serialize against _enforce_size_limit's iteration (#397).
+        with _disco_cache_write_lock:
+            touch_cache_entry(_disco_cache, cache_key)
         return entry.response
 
     fetch_lock = _get_disco_fetch_lock(cache_key)
@@ -97,6 +105,8 @@ def _get_disco_response(
         # the entry while we waited.
         entry = _disco_cache.get(cache_key)
         if entry is not None and not is_cache_expired(entry):
+            with _disco_cache_write_lock:
+                touch_cache_entry(_disco_cache, cache_key)
             return entry.response
 
         policy = DiscoveryPolicy(require_https=require_https)
@@ -120,7 +130,7 @@ def clear_discovery_cache() -> None:
 # TTL-aware JWKS cache (replaces @lru_cache for JWKS)
 # ============================================================================
 
-_jwks_cache: dict[str, JwksCacheEntry] = {}
+_jwks_cache: OrderedDict[str, JwksCacheEntry] = OrderedDict()
 # See _disco_cache_write_lock — same factoring: brief CPU-only write lock,
 # per-URI fetch locks for the actual single-flight semantics.
 _jwks_cache_write_lock = threading.Lock()
@@ -147,12 +157,17 @@ def _get_cached_jwks(jwks_uri: str, require_https: bool = True) -> JwksResponse:
     """
     entry = _jwks_cache.get(jwks_uri)
     if entry is not None and not is_cache_expired(entry):
+        # Refresh LRU recency under the write lock (see _get_disco_response).
+        with _jwks_cache_write_lock:
+            touch_cache_entry(_jwks_cache, jwks_uri)
         return entry.response
 
     fetch_lock = _get_jwks_fetch_lock(jwks_uri)
     with fetch_lock:
         entry = _jwks_cache.get(jwks_uri)
         if entry is not None and not is_cache_expired(entry):
+            with _jwks_cache_write_lock:
+                touch_cache_entry(_jwks_cache, jwks_uri)
             return entry.response
 
         # The jwks_uri was already vetted against this policy when the

--- a/src/tests/unit/test_aio_token_validation.py
+++ b/src/tests/unit/test_aio_token_validation.py
@@ -13,6 +13,7 @@ import httpx
 import pytest
 import respx
 
+from py_identity_model.aio import token_validation as aio_tv
 from py_identity_model.aio.managed_client import AsyncHTTPClient
 from py_identity_model.aio.token_validation import (
     _get_cached_jwks,
@@ -20,6 +21,7 @@ from py_identity_model.aio.token_validation import (
     clear_jwks_cache,
     validate_token,
 )
+from py_identity_model.core.jwks_cache import _reset_env_for_testing
 from py_identity_model.core.models import TokenValidationConfig
 from py_identity_model.exceptions import (
     ConfigurationException,
@@ -666,3 +668,54 @@ class TestAsyncSubjectValidation:
 
         decoded = await validate_token(jwt=token, token_validation_config=config)
         assert decoded["sub"] == "anyone"
+
+
+class TestAsyncLruReadHitEviction:
+    """Async twin of the sync LRU eviction test (#397): a read cache hit on
+    the async ``_get_cached_jwks`` refreshes recency so an attacker driving
+    distinct-address reads cannot evict a legitimately-hot entry."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_read_hit_protects_hot_entry_from_eviction(self, monkeypatch):
+        monkeypatch.setenv("JWKS_CACHE_MAX_ENTRIES", "4")
+        _reset_env_for_testing()
+        try:
+            urls = [f"https://op-{i}.example/jwks" for i in range(5)]
+            key_dict = generate_rsa_keypair()[0]
+            for url in urls:
+                respx.get(url).mock(
+                    return_value=httpx.Response(
+                        200,
+                        json={"keys": [key_dict]},
+                        headers={"Cache-Control": "max-age=3600"},
+                    )
+                )
+
+            # Fill to capacity: op-0 (oldest) .. op-3 (newest).
+            for url in urls[:4]:
+                await _get_cached_jwks(url)
+            assert list(aio_tv._jwks_cache.keys()) == urls[:4]
+
+            # Re-read op-0 — a cache hit (no network) that refreshes recency.
+            await _get_cached_jwks(urls[0])
+            assert list(aio_tv._jwks_cache.keys()) == [
+                urls[1],
+                urls[2],
+                urls[3],
+                urls[0],
+            ]
+
+            # A fifth distinct URI overflows; eviction targets op-1 (oldest
+            # unread), NOT the recently-read op-0.
+            await _get_cached_jwks(urls[4])
+            assert urls[0] in aio_tv._jwks_cache
+            assert urls[1] not in aio_tv._jwks_cache
+            assert set(aio_tv._jwks_cache.keys()) == {
+                urls[0],
+                urls[2],
+                urls[3],
+                urls[4],
+            }
+        finally:
+            _reset_env_for_testing()

--- a/src/tests/unit/test_cache_env_and_bounds.py
+++ b/src/tests/unit/test_cache_env_and_bounds.py
@@ -56,6 +56,7 @@ from py_identity_model.core.models import JsonWebKey, JwksResponse
 from py_identity_model.sync import token_validation as sync_tv
 from py_identity_model.sync.token_validation import (
     _get_cached_jwks,
+    _get_disco_response,
     clear_discovery_cache,
     clear_jwks_cache,
 )
@@ -424,3 +425,58 @@ class TestLruReadHitEviction:
         assert urls[0] in sync_tv._jwks_cache
         assert urls[1] not in sync_tv._jwks_cache
         assert set(sync_tv._jwks_cache.keys()) == {urls[0], urls[2], urls[3], urls[4]}
+
+    @respx.mock
+    def test_read_hit_protects_hot_disco_entry_from_eviction(self, monkeypatch):
+        """The discovery cache is LRU too (#397 calls out "same for the
+        discovery cache"). End-to-end via ``_get_disco_response``: an attacker
+        driving distinct ``disco_doc_address`` reads must NOT evict a discovery
+        entry that was just read.
+
+        Mirrors the JWKS end-to-end test but through the disco read path, so a
+        regression that adds the read-hit touch to only one of the two caches is
+        caught. The cache key is ``(address, require_https)`` — a tuple, exactly
+        the shape a multi-tenant gateway attacker influences."""
+        monkeypatch.setenv("JWKS_CACHE_MAX_ENTRIES", "4")
+        _reset_env_for_testing()
+
+        bases = [f"https://op-{i}.example" for i in range(5)]
+        addresses = [f"{b}/.well-known/openid-configuration" for b in bases]
+        for base, address in zip(bases, addresses, strict=True):
+            respx.get(address).mock(
+                return_value=httpx.Response(
+                    200,
+                    json={
+                        "issuer": base,
+                        "authorization_endpoint": f"{base}/authorize",
+                        "token_endpoint": f"{base}/token",
+                        "jwks_uri": f"{base}/jwks",
+                        "response_types_supported": ["code"],
+                        "subject_types_supported": ["public"],
+                        "id_token_signing_alg_values_supported": ["RS256"],
+                    },
+                )
+            )
+
+        keys = [(addr, True) for addr in addresses]
+
+        # Fill to capacity: op-0 (oldest) .. op-3 (newest).
+        for address in addresses[:4]:
+            _get_disco_response(address)
+        assert list(sync_tv._disco_cache.keys()) == keys[:4]
+
+        # Re-read op-0 — a cache hit (no network) that must refresh recency.
+        _get_disco_response(addresses[0])
+        assert list(sync_tv._disco_cache.keys()) == [
+            keys[1],
+            keys[2],
+            keys[3],
+            keys[0],
+        ]
+
+        # A fifth distinct address overflows the cache; eviction targets op-1
+        # (oldest unread), NOT the recently-read op-0.
+        _get_disco_response(addresses[4])
+        assert keys[0] in sync_tv._disco_cache
+        assert keys[1] not in sync_tv._disco_cache
+        assert set(sync_tv._disco_cache.keys()) == {keys[0], keys[2], keys[3], keys[4]}

--- a/src/tests/unit/test_cache_env_and_bounds.py
+++ b/src/tests/unit/test_cache_env_and_bounds.py
@@ -18,11 +18,15 @@ Two pre-existing structural bugs the cache primitive shipped with:
 These tests pin the fixes:
 - TTL env values clamped to [MIN, MAX]; garbage falls back to default.
 - Cache size capped at ``JWKS_CACHE_MAX_ENTRIES`` (default 64).
-- FIFO eviction targets the oldest entry, not the newest or a random one.
+- LRU eviction targets the least recently *used* entry, not the newest or a
+  random one.
 - Re-storing a URI (refresh) moves it to "newest" so subsequent eviction
   doesn't target a just-refreshed entry.
+- A read cache hit refreshes recency (``touch_cache_entry``) so an attacker
+  driving distinct-address reads cannot evict a legitimately-hot entry (#397).
 """
 
+from collections import OrderedDict
 import time
 
 import httpx
@@ -39,12 +43,14 @@ from py_identity_model.core.jwks_cache import (
     MIN_CACHE_TTL_SECONDS,
     MIN_KID_MISS_COOLDOWN_SECONDS,
     JwksCacheEntry,
+    _enforce_size_limit,
     _reset_env_for_testing,
     apply_jwks_cache_outcome,
     get_kid_miss_cooldown,
     get_max_cache_entries,
     resolve_disco_ttl,
     resolve_ttl,
+    touch_cache_entry,
 )
 from py_identity_model.core.models import JsonWebKey, JwksResponse
 from py_identity_model.sync import token_validation as sync_tv
@@ -326,3 +332,95 @@ class TestBoundedCacheSize:
         assert len(sync_tv._jwks_cache) == 4  # noqa: PLR2004
         # Newest four URIs are the survivors.
         assert set(sync_tv._jwks_cache.keys()) == set(urls_to_visit[-4:])
+
+
+# ============================================================================
+# LRU eviction: a read cache hit refreshes recency so an attacker driving
+# distinct-address reads cannot evict a legitimately-hot entry (#397).
+# ============================================================================
+
+
+class TestLruReadHitEviction:
+    def test_touch_cache_entry_moves_key_to_most_recent(self):
+        """The shared helper reorders an OrderedDict so the touched key sorts
+        last (most-recently-used); ``_enforce_size_limit`` then evicts what
+        sorts first. Deterministic — OrderedDict order is access/insertion
+        order, independent of PYTHONHASHSEED."""
+        cache: OrderedDict[str, int] = OrderedDict((f"k{i}", i) for i in range(3))
+        assert list(cache.keys()) == ["k0", "k1", "k2"]
+
+        touch_cache_entry(cache, "k0")
+        assert list(cache.keys()) == ["k1", "k2", "k0"]
+
+    def test_touch_cache_entry_absent_key_is_noop(self):
+        """The read hot-path does a lock-free ``.get()`` then touches under the
+        write lock; the entry may have been evicted in between, so touching an
+        absent key must be a silent no-op, not a KeyError."""
+        cache: OrderedDict[str, int] = OrderedDict((("k0", 0), ("k1", 1)))
+        touch_cache_entry(cache, "missing")
+        assert list(cache.keys()) == ["k0", "k1"]
+
+    def test_lru_evicts_least_recently_used_not_least_recently_inserted(
+        self, monkeypatch
+    ):
+        """After a touch, ``_enforce_size_limit`` evicts the untouched-oldest
+        entry, proving eviction is by *use* not by *insertion* (tuple keys,
+        mirroring the discovery cache)."""
+        monkeypatch.setenv("JWKS_CACHE_MAX_ENTRIES", "4")
+        _reset_env_for_testing()
+        cache: OrderedDict[tuple[str, bool], int] = OrderedDict()
+        for i in range(4):
+            cache[(f"https://op-{i}.example", True)] = i
+
+        # op-0 is oldest by insertion; a read hit touches it to most-recent.
+        touch_cache_entry(cache, ("https://op-0.example", True))
+        # A fifth distinct address arrives (attacker-controlled tenant).
+        cache[("https://op-4.example", True)] = 4
+
+        evicted = _enforce_size_limit(cache)
+        # LRU evicts op-1 (oldest *untouched*), NOT the recently-read op-0.
+        assert evicted == [("https://op-1.example", True)]
+        assert ("https://op-0.example", True) in cache
+
+    @respx.mock
+    def test_read_hit_protects_hot_entry_from_eviction(self, monkeypatch):
+        """End-to-end via ``_get_cached_jwks``: an attacker driving distinct
+        JWKS-URI reads must NOT evict a JWKS entry that was just read.
+
+        Fill the cache to capacity, re-read the oldest-by-insertion entry (a
+        cache hit → LRU touch), then push one more distinct URI. FIFO would
+        evict the just-read entry; LRU evicts the oldest *unread* one."""
+        monkeypatch.setenv("JWKS_CACHE_MAX_ENTRIES", "4")
+        _reset_env_for_testing()
+
+        urls = [f"https://op-{i}.example/jwks" for i in range(5)]
+        key_dict, _ = generate_rsa_keypair()
+        for url in urls:
+            respx.get(url).mock(
+                return_value=httpx.Response(
+                    200,
+                    json={"keys": [key_dict]},
+                    headers={"Cache-Control": "max-age=3600"},
+                )
+            )
+
+        # Fill to capacity: op-0 (oldest) .. op-3 (newest).
+        for url in urls[:4]:
+            _get_cached_jwks(url)
+        assert list(sync_tv._jwks_cache.keys()) == urls[:4]
+
+        # Re-read op-0 — a cache hit (no network) that must refresh recency.
+        _get_cached_jwks(urls[0])
+        assert list(sync_tv._jwks_cache.keys()) == [
+            urls[1],
+            urls[2],
+            urls[3],
+            urls[0],
+        ]
+
+        # A fifth distinct URI overflows the cache; eviction targets op-1
+        # (oldest unread), NOT the recently-read op-0.
+        _get_cached_jwks(urls[4])
+        assert urls[0] in sync_tv._jwks_cache
+        assert urls[1] not in sync_tv._jwks_cache
+        assert set(sync_tv._jwks_cache.keys()) == {urls[0], urls[2], urls[3], urls[4]}


### PR DESCRIPTION
## Summary
JWKS/discovery caches were FIFO — `_enforce_size_limit` evicts oldest-by-insertion, and pop+reinsert only happened on *write*, never on *read*. In a multi-tenant gateway where an attacker can influence `disco_doc_address`→`jwks_uri`, distinct-address reads could evict a legitimately-hot entry.

Fix = LRU-by-access: switch caches from plain `dict` to `collections.OrderedDict` and `move_to_end()` on read hits (guarded by the existing write lock). Also serializes cache `clear()` under the structure lock.

Touches `core/jwks_cache.py`, `sync/token_validation.py`, `aio/token_validation.py`.

Closes #397.

🤖 Generated with [Claude Code](https://claude.com/claude-code)