### PR TITLE
fix(mtls): make CertificateBindingError a TokenValidationException subclass

### DIFF
--- a/src/py_identity_model/exceptions.py
+++ b/src/py_identity_model/exceptions.py
@@ -118,14 +118,23 @@ class JarmValidationException(AuthorizeCallbackException):
     """
 
 
-class CertificateBindingError(ValidationException):
+class CertificateBindingError(TokenValidationException):
     """Raised when mTLS certificate-bound access token validation fails.
 
     Covers the RFC 8705 §3 confirmation-method check: the token's
     ``cnf["x5t#S256"]`` thumbprint must match the client certificate
     presented at the TLS layer. Absent ``cnf``/``x5t#S256`` or a thumbprint
     mismatch raises this error.
+
+    Subclasses ``TokenValidationException`` (not ``ValidationException``
+    directly): a certificate-binding failure is a token-validation failure,
+    so callers using the idiomatic ``except TokenValidationException`` must
+    fail **closed** on it. As a sibling it would escape that handler and
+    fail open — the exact replay it is meant to stop.
     """
+
+    def __init__(self, message: str, details: dict | None = None):
+        super().__init__(message, token_part="payload", details=details)
 
 
 class NetworkException(PyIdentityModelException):

--- a/src/tests/integration/test_mtls.py
+++ b/src/tests/integration/test_mtls.py
@@ -24,6 +24,7 @@ from py_identity_model import (
     CertificateBindingError,
     ClientCredentialsTokenRequest,
     MtlsClientAuth,
+    TokenValidationException,
     compute_certificate_thumbprint,
     request_client_credentials_token,
     validate_certificate_binding,
@@ -151,3 +152,32 @@ class TestCertificateBoundTokenValidation:
             validate_certificate_binding(
                 {"cnf": {"x5t#S256": other_thumbprint}}, cert_pem
             )
+
+    def test_binding_mismatch_fails_closed_for_generic_handler(self):
+        """A resource server using the idiomatic ``except TokenValidationException``
+        must fail CLOSED on a cert-binding mismatch.
+
+        This is the behavioural proof of the exception-contract fix: because
+        ``CertificateBindingError`` was a *sibling* of ``TokenValidationException``,
+        a real RS handler that denies on ``TokenValidationException`` let a binding
+        mismatch escape and fail OPEN — accepting a stolen bound token as a bearer.
+        Exercised against a real X.509 cert + SHA-256 thumbprint, mirroring how an
+        RS confirms RFC 8705 §3 on a live token.
+        """
+        cert_pem, _ = _self_signed_cert()
+        other_pem, _ = _self_signed_cert()
+        other_thumbprint = compute_certificate_thumbprint(other_pem)
+
+        denied = False
+        try:
+            # Stolen cert-bound token replayed with the wrong client certificate.
+            validate_certificate_binding(
+                {"cnf": {"x5t#S256": other_thumbprint}}, cert_pem
+            )
+        except TokenValidationException:
+            # The RS's generic token-validation handler caught it -> 401 deny.
+            denied = True
+        assert denied, (
+            "cert-binding mismatch escaped `except TokenValidationException` and "
+            "would fail open (stolen bound token accepted as bearer)"
+        )

--- a/src/tests/unit/test_mtls.py
+++ b/src/tests/unit/test_mtls.py
@@ -34,6 +34,7 @@ from py_identity_model import (
     TokenExchangeRequest,
     TokenIntrospectionRequest,
     TokenRevocationRequest,
+    TokenValidationException,
     certificate_thumbprint_from_file,
     compute_certificate_thumbprint,
     get_discovery_document,
@@ -267,6 +268,16 @@ class TestValidateCertificateBinding:
         hmac.compare_digest (which cannot compare non-ASCII str)."""
         with pytest.raises(CertificateBindingError, match="base64url"):
             validate_certificate_binding({"cnf": {"x5t#S256": "abcé"}}, cert_pem)
+
+    def test_binding_error_is_token_validation_exception(self, cert_pem):
+        """A cert-binding failure must be catchable as ``TokenValidationException``
+        so callers using the idiomatic ``except TokenValidationException`` fail
+        CLOSED. Regression: ``CertificateBindingError`` was a *sibling* of
+        ``TokenValidationException``, so such a handler let a binding failure
+        escape and fail open — the exact replay the check is meant to stop."""
+        assert issubclass(CertificateBindingError, TokenValidationException)
+        with pytest.raises(TokenValidationException):
+            validate_certificate_binding({"sub": "user"}, cert_pem)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Problem (fail-open, MEDIUM)

`CertificateBindingError` subclassed `ValidationException` directly — a **sibling** of `TokenValidationException`, not a subclass. A resource server using the idiomatic `except TokenValidationException: deny` did **not** catch a certificate-binding failure; it escaped and **failed open**, defeating the RFC 8705 §3 sender-constraint replay protection. `core/mtls.py:149` already had a comment acknowledging the escape.

`validate_certificate_binding` is public API exported from the top-level package, so this is a **latent bug on `main`** independent of the pending SC stack.

## Fix
- Reparent `CertificateBindingError` under `TokenValidationException` (`token_part="payload"`), keeping the `(message, details)` constructor contract so every existing raise site is unchanged.
- Regression test: asserts the subclass relationship **and** that `validate_certificate_binding`'s error is caught by `except TokenValidationException`.

## Validation
`make lint` green (ruff + format + pyrefly + 80% coverage); `test_mtls.py` 72 passed.

Found by the fresh-context adversarial review of the SC security stack (#488/#489/#490).