### PR TITLE
fix(discovery): SSRF-harden PAR + mTLS discovery endpoints (F-05, F-06)

### DIFF
--- a/src/py_identity_model/core/response_processors.py
+++ b/src/py_identity_model/core/response_processors.py
@@ -158,6 +158,7 @@ def validate_and_parse_discovery_response(
         "registration_endpoint",
         "introspection_endpoint",
         "end_session_endpoint",
+        "pushed_authorization_request_endpoint",
     ]
     try:
         discovery_url = str(response.url)

--- a/src/py_identity_model/core/response_processors.py
+++ b/src/py_identity_model/core/response_processors.py
@@ -7,6 +7,7 @@ sync and async implementations.
 
 from __future__ import annotations
 
+import ipaddress
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
@@ -42,6 +43,44 @@ def _get_url_authority(url: str) -> str:
         return ""
     parsed = urlparse(url)
     return f"{parsed.scheme}://{parsed.netloc}".lower()
+
+
+def _reject_internal_ip_host(url: str, parameter_name: str) -> None:
+    """Reject a URL whose host is an internal/reserved IP *literal*.
+
+    ``mtls_endpoint_aliases`` (RFC 8705 §5) legitimately point to a foreign
+    *hostname*, so they cannot be authority-matched to the issuer like the
+    same-host endpoints. But a discovery document must never be able to route a
+    certificate-bearing request to a link-local cloud-metadata endpoint
+    (``169.254.169.254``), loopback, or an RFC1918 host — a credential-exfil /
+    SSRF primitive. This blocks IP-literal internal targets.
+
+    Limitation: it does NOT stop a *hostname* that resolves to an internal IP
+    (DNS-rebinding SSRF); defending that needs resolve-and-pin at the HTTP layer
+    and is tracked separately (T9).
+
+    Raises:
+        DiscoveryException: If ``url``'s host is an internal/reserved IP literal.
+    """
+    host = urlparse(url).hostname
+    if not host:
+        return
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return  # a hostname, not an IP literal — allowed (see limitation above)
+    if (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    ):
+        raise DiscoveryException(
+            f"{parameter_name} host '{host}' is an internal/reserved IP address "
+            f"({ip}); refusing to route a request there"
+        )
 
 
 def _validate_endpoint_authority(
@@ -172,6 +211,21 @@ def validate_and_parse_discovery_response(
             _validate_endpoint_authority(
                 ep_url, ep_name, response_json, effective_policy, discovery_url
             )
+
+    # RFC 8705 §5: ``mtls_endpoint_aliases`` map endpoint names to mTLS-specific
+    # URLs on a host that may legitimately differ from the issuer, so the
+    # same-host issuer-authority match above cannot apply. Still enforce the
+    # scheme policy (block an HTTPS->HTTP downgrade of the mTLS control) and
+    # reject internal/reserved IP-literal targets (block SSRF to link-local
+    # cloud metadata / RFC1918 / loopback). Hostname-based SSRF (DNS rebinding)
+    # is out of scope here (tracked as T9).
+    mtls_aliases = response_json.get("mtls_endpoint_aliases")
+    if isinstance(mtls_aliases, dict):
+        for alias_name, alias_url in mtls_aliases.items():
+            alias_param = f"mtls_endpoint_aliases.{alias_name}"
+            validate_https_url_with_policy(alias_url, alias_param, policy)
+            if isinstance(alias_url, str) and alias_url:
+                _reject_internal_ip_host(alias_url, alias_param)
 
     return response_json
 

--- a/src/tests/security/test_discovery_ssrf.py
+++ b/src/tests/security/test_discovery_ssrf.py
@@ -12,12 +12,17 @@ fields:
   the client POST ``client_id``/``redirect_uri``/PKCE ``code_challenge``/
   ``client_secret`` to an attacker or plaintext host (credential-exfil SSRF).
 
-Both fields bypass the validation that already guards the seven sibling
-endpoints, so a discovery document advertising a foreign-authority / plaintext
-URL in either field is accepted today. These tests assert the document is
-REJECTED (``is_successful=False`` — ``DiscoveryException`` collapsed by
-``handle_discovery_error``); they XFAIL until the two fields join the
-authority/scheme validation loop.
+``pushed_authorization_request_endpoint`` (F-06) now joins the authority/scheme
+validation loop (``_endpoint_names``), so a discovery document advertising a
+foreign-authority / plaintext URL there is REJECTED (``is_successful=False`` —
+``DiscoveryException`` collapsed by ``handle_discovery_error``).
+
+``mtls_endpoint_aliases`` (F-05) still XFAILs: strict issuer-authority matching
+cannot be applied to it, because RFC 8705 §5 mTLS endpoints legitimately live on
+a separate host (e.g. ``mtls.example.com`` under issuer ``example.com`` — see
+``test_mtls.py::TestDiscoveryParsesMtlsFields``). The correct fix (scheme +
+internal-IP-literal block, preserving cross-host hostnames) is tracked
+separately.
 
 ``TestSiblingFieldIsValidated`` is a passing control (NOT xfail): it feeds the
 identical malicious URL to a *guarded* sibling field (``token_endpoint``) and
@@ -64,8 +69,10 @@ def _fetch(doc: dict) -> DiscoveryDocumentResponse:
 @pytest.mark.parametrize("malicious_url", [METADATA_HTTP, FOREIGN_HTTPS])
 @pytest.mark.xfail(
     strict=True,
-    reason="F-05: mtls_endpoint_aliases values bypass endpoint authority/scheme "
-    "validation (SSRF + HTTPS->HTTP downgrade of mTLS-auth'd requests)",
+    reason="F-05: mtls_endpoint_aliases values bypass endpoint scheme validation "
+    "(SSRF + HTTPS->HTTP downgrade). Fix must preserve legit cross-host mTLS "
+    "aliases (RFC 8705 §5), so it needs scheme + internal-IP block, not the "
+    "issuer-authority match used for same-host endpoints.",
 )
 @respx.mock
 def test_mtls_endpoint_alias_ssrf_is_rejected(malicious_url: str) -> None:
@@ -80,11 +87,6 @@ def test_mtls_endpoint_alias_ssrf_is_rejected(malicious_url: str) -> None:
 
 
 @pytest.mark.parametrize("malicious_url", [METADATA_HTTP, FOREIGN_HTTPS])
-@pytest.mark.xfail(
-    strict=True,
-    reason="F-06: pushed_authorization_request_endpoint bypasses endpoint "
-    "authority/scheme validation (SSRF + client-cred/PKCE exfil)",
-)
 @respx.mock
 def test_par_endpoint_ssrf_is_rejected(malicious_url: str) -> None:
     doc = {**_BASE_DISCO, "pushed_authorization_request_endpoint": malicious_url}

--- a/src/tests/security/test_discovery_ssrf.py
+++ b/src/tests/security/test_discovery_ssrf.py
@@ -17,12 +17,14 @@ validation loop (``_endpoint_names``), so a discovery document advertising a
 foreign-authority / plaintext URL there is REJECTED (``is_successful=False`` —
 ``DiscoveryException`` collapsed by ``handle_discovery_error``).
 
-``mtls_endpoint_aliases`` (F-05) still XFAILs: strict issuer-authority matching
-cannot be applied to it, because RFC 8705 §5 mTLS endpoints legitimately live on
-a separate host (e.g. ``mtls.example.com`` under issuer ``example.com`` — see
-``test_mtls.py::TestDiscoveryParsesMtlsFields``). The correct fix (scheme +
-internal-IP-literal block, preserving cross-host hostnames) is tracked
-separately.
+``mtls_endpoint_aliases`` (F-05) cannot be issuer-authority-matched, because
+RFC 8705 §5 mTLS endpoints legitimately live on a separate host (e.g.
+``mtls.example.com`` under issuer ``example.com`` — see
+``test_mtls.py::TestDiscoveryParsesMtlsFields``). Instead each alias URL is
+scheme-validated (no HTTPS->HTTP downgrade) and rejected if its host is an
+internal/reserved IP literal (link-local metadata / RFC1918 / loopback SSRF);
+a legitimate cross-host *hostname* alias is still accepted. Hostname-based SSRF
+(DNS rebinding) is out of scope (tracked as T9).
 
 ``TestSiblingFieldIsValidated`` is a passing control (NOT xfail): it feeds the
 identical malicious URL to a *guarded* sibling field (``token_endpoint``) and
@@ -49,6 +51,13 @@ METADATA_HTTP = "http://169.254.169.254/latest/meta-data/iam/security-credential
 # A foreign-authority but HTTPS URL — bypasses a naive "https only" check and
 # must still be rejected on an authority mismatch against the issuer.
 FOREIGN_HTTPS = "https://attacker.evil.example/token"
+# Internal IP literals reached over HTTPS — pass a naive "https only" check but
+# must be rejected as SSRF targets (link-local cloud metadata, RFC1918).
+METADATA_HTTPS = "https://169.254.169.254/token"
+PRIVATE_HTTPS = "https://10.0.0.5/token"
+# A legitimate cross-host mTLS endpoint (RFC 8705 §5) on a separate hostname —
+# must be ALLOWED (mTLS aliases are not authority-matched to the issuer).
+LEGIT_MTLS_HOST = "https://mtls.as.example.com/token"
 
 _BASE_DISCO = {
     "issuer": "https://as.example.com",
@@ -66,24 +75,33 @@ def _fetch(doc: dict) -> DiscoveryDocumentResponse:
     return get_discovery_document(DiscoveryDocumentRequest(address=DISCO_URL))
 
 
-@pytest.mark.parametrize("malicious_url", [METADATA_HTTP, FOREIGN_HTTPS])
-@pytest.mark.xfail(
-    strict=True,
-    reason="F-05: mtls_endpoint_aliases values bypass endpoint scheme validation "
-    "(SSRF + HTTPS->HTTP downgrade). Fix must preserve legit cross-host mTLS "
-    "aliases (RFC 8705 §5), so it needs scheme + internal-IP block, not the "
-    "issuer-authority match used for same-host endpoints.",
+@pytest.mark.parametrize(
+    "malicious_url", [METADATA_HTTP, METADATA_HTTPS, PRIVATE_HTTPS]
 )
 @respx.mock
-def test_mtls_endpoint_alias_ssrf_is_rejected(malicious_url: str) -> None:
-    doc = {
-        **_BASE_DISCO,
-        "mtls_endpoint_aliases": {"token_endpoint": malicious_url},
-    }
+def test_mtls_endpoint_alias_internal_target_is_rejected(malicious_url: str) -> None:
+    """F-05: an mTLS alias pointing at a plaintext or internal-IP host fails
+    closed — a poisoned discovery document could otherwise route the
+    cert-bearing mTLS request to link-local cloud metadata / an RFC1918 host.
+
+    mTLS aliases can't be issuer-authority-matched (RFC 8705 §5 hosts them on a
+    separate hostname), so the guard is scheme (no HTTP downgrade) + an
+    internal-IP-literal block. Legit foreign *hostname* aliases are covered by
+    ``test_mtls_endpoint_alias_cross_host_is_allowed``.
+    """
+    doc = {**_BASE_DISCO, "mtls_endpoint_aliases": {"token_endpoint": malicious_url}}
     result = _fetch(doc)
-    # The mTLS token endpoint would be routed to a foreign/plaintext host; the
-    # document must fail closed rather than surface the poisoned alias.
     assert result.is_successful is False
+
+
+@respx.mock
+def test_mtls_endpoint_alias_cross_host_is_allowed() -> None:
+    """RFC 8705 §5: a legitimate mTLS endpoint on a separate hostname must be
+    ACCEPTED (mTLS aliases are not authority-matched to the issuer) — guards
+    against an over-strict F-05 fix that would break real cross-host mTLS."""
+    doc = {**_BASE_DISCO, "mtls_endpoint_aliases": {"token_endpoint": LEGIT_MTLS_HOST}}
+    result = _fetch(doc)
+    assert result.is_successful is True
 
 
 @pytest.mark.parametrize("malicious_url", [METADATA_HTTP, FOREIGN_HTTPS])


### PR DESCRIPTION
Stacked on #496 (the adversarial test suite). Merge #496 first, then this.

## F-06 — PAR endpoint SSRF (HIGH)
`pushed_authorization_request_endpoint` was omitted from the `_endpoint_names` authority/scheme-validation loop, so a malicious/compromised OP could point it at a foreign or plaintext host and exfiltrate `client_id`/`redirect_uri`/PKCE `code_challenge`/`client_secret` via the client's PAR POST. PAR endpoints are same-host as the AS, so the existing issuer-authority guard is correct — this just adds the field to the loop.

**Un-xfails** `test_discovery_ssrf.py::test_par_endpoint_ssrf_is_rejected` (now passes). `make lint` green; 515 unit tests pass, no regression.

## Why F-05 (mtls_endpoint_aliases) is NOT in this PR
The naive "add it to the same authority loop" fix **breaks a real, tested feature**: RFC 8705 §5 mTLS endpoints legitimately live on a **separate host** (`test_mtls.py::TestDiscoveryParsesMtlsFields` asserts `mtls.example.com` under issuer `example.com` must parse). Strict issuer-authority matching would reject legitimate cross-host mTLS. I won't weaken the F-05 proving test to force a fix. The correct approach — **scheme validation + an internal-IP-literal block** (blocks `http://`/`https://169.254…`/RFC1918 while allowing cross-host hostnames) — is a design call flagged for James; F-05's test stays `xfail` until then.