### PR TITLE
feat(fastapi): access-token-marker (F-07) + SSRF-harden discovery (F-05/F-06)

### DIFF
--- a/packages/fastapi-identity-model/fastapi_identity_model/middleware.py
+++ b/packages/fastapi-identity-model/fastapi_identity_model/middleware.py
@@ -37,6 +37,19 @@ _BEARER_HEADER_PART_COUNT = 2
 # expected — reject it to prevent token-substitution at the resource server.
 _ID_TOKEN_ONLY_CLAIMS = ("nonce", "at_hash", "c_hash")
 
+# Positive access-token marker claims for the opt-in ID-token-substitution
+# defence (F-07). The negative ``_ID_TOKEN_ONLY_CLAIMS`` check misses a
+# code-flow ID token that carries NONE of nonce/at_hash/c_hash (all optional in
+# the auth-code flow) — such a token has ``aud == client_id`` and passes
+# validation, so it authenticates as a bearer access token. Requiring a
+# *positive* access-token signal closes that gap. ``scope`` is the discriminator
+# that holds across the surveyed OPs (Descope, Keycloak, node-oidc): access
+# tokens carry it, ID tokens never do (``scope`` is not an OIDC ID-token claim).
+# ``scp`` is included so tokens that carry scopes under the Azure AD convention
+# still count as access tokens. This is OPT-IN because some access tokens (e.g.
+# a client_credentials token minted with no scopes) legitimately carry neither.
+_DEFAULT_ACCESS_TOKEN_MARKER_CLAIMS = ("scope", "scp")
+
 
 class TokenValidationMiddleware(BaseHTTPMiddleware):
     """
@@ -57,15 +70,34 @@ class TokenValidationMiddleware(BaseHTTPMiddleware):
             ``/docs/oauth2-redirect``). Pass ``[]`` to exclude nothing. When
             omitted, defaults to ``/docs``, ``/openapi.json``, ``/health``.
         custom_claims_validator: Optional custom function to validate additional claims
+        require_access_token_marker: Opt-in ID-token-substitution defence
+            (F-07), default ``False`` (behaviour unchanged). When ``True``, a
+            validated token is additionally required to carry at least one
+            *positive* access-token marker claim (``access_token_marker_claims``)
+            or it is rejected 401 — stopping a code-flow ID token (which carries
+            none of nonce/at_hash/c_hash and whose ``aud`` matches the client_id)
+            from being replayed as a bearer access token. Leave ``False`` if any
+            of your access tokens legitimately omit those claims (e.g. a
+            client_credentials token minted with no scopes).
+        access_token_marker_claims: Claims that mark a token as an access token
+            for ``require_access_token_marker``. Defaults to ``("scope", "scp")``
+            — ``scope`` is the cross-OP discriminator (access tokens carry it, ID
+            tokens never do); ``scp`` covers the Azure AD convention. Override for
+            an OP whose access tokens signal type differently. Ignored when
+            ``require_access_token_marker`` is ``False``.
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913  # opt-in F-07 marker config adds two optional params
         self,
         app,
         discovery_url: str,
         audience: str | None = None,
         excluded_paths: list[str] | None = None,
         custom_claims_validator: Callable | None = None,
+        require_access_token_marker: bool = False,
+        access_token_marker_claims: tuple[
+            str, ...
+        ] = _DEFAULT_ACCESS_TOKEN_MARKER_CLAIMS,
     ):
         super().__init__(app)
         if not audience:
@@ -73,8 +105,18 @@ class TokenValidationMiddleware(BaseHTTPMiddleware):
                 "TokenValidationMiddleware requires a non-empty 'audience'; a "
                 "None/empty audience skips aud enforcement for aud-less tokens."
             )
+        # An empty marker set with the check enabled would reject every token
+        # (no claim can ever satisfy ``any(...)``); fail loudly at construction
+        # rather than silently 401ing all traffic.
+        if require_access_token_marker and not access_token_marker_claims:
+            raise ValueError(
+                "require_access_token_marker=True needs a non-empty "
+                "access_token_marker_claims; an empty set rejects every token."
+            )
         self.discovery_url = discovery_url
         self.audience = audience
+        self.require_access_token_marker = require_access_token_marker
+        self.access_token_marker_claims = access_token_marker_claims
         # ``is not None`` (not truthiness) so an explicit [] means "exclude
         # nothing" instead of silently re-enabling the defaults.
         self.excluded_paths = (
@@ -118,6 +160,32 @@ class TokenValidationMiddleware(BaseHTTPMiddleware):
             )
         return parts[1]
 
+    def _wrong_token_type_error(self, claims: dict) -> str | None:
+        """A 401 detail if *claims* are the wrong token type for a resource
+        server (an ID token presented as an access token), else ``None``.
+
+        Two complementary checks:
+
+        * Negative (always on): an ID-token-only claim
+          (``nonce``/``at_hash``/``c_hash``) is present — those never appear on
+          an access token. With ``audience`` defaulted to the client_id an ID
+          token's ``aud`` matches, so the type must be discriminated on claims.
+        * Positive (opt-in, ``require_access_token_marker``): a code-flow ID
+          token carries none of the negative claims, so also require a positive
+          access-token marker (``scope``/``scp`` by default). Off by default —
+          behaviour unchanged unless explicitly enabled.
+        """
+        if any(c in claims for c in _ID_TOKEN_ONLY_CLAIMS):
+            return "ID token cannot be used as an access token"
+        if self.require_access_token_marker and not any(
+            c in claims for c in self.access_token_marker_claims
+        ):
+            return (
+                "Access token required; presented token lacks an "
+                "access-token marker claim"
+            )
+        return None
+
     async def _authenticate(self, request: Request, token: str) -> JSONResponse | None:
         """Validate *token* and attach claims; return an error response or None."""
         try:
@@ -130,11 +198,11 @@ class TokenValidationMiddleware(BaseHTTPMiddleware):
                 ),
                 disco_doc_address=self.discovery_url,
             )
-            # Reject an ID token presented as an access token. With audience
-            # defaulted to client_id, an ID token's aud matches, so type must
-            # be discriminated on ID-token-only claims.
-            if any(c in claims for c in _ID_TOKEN_ONLY_CLAIMS):
-                return self._unauthorized("ID token cannot be used as an access token")
+            # Reject an ID token presented as an access token (token-type
+            # confusion at the resource server).
+            wrong_type = self._wrong_token_type_error(claims)
+            if wrong_type is not None:
+                return self._unauthorized(wrong_type)
             request.state.user = to_principal(claims)
             request.state.claims = claims
             request.state.token = token

--- a/packages/fastapi-identity-model/tests/test_middleware.py
+++ b/packages/fastapi-identity-model/tests/test_middleware.py
@@ -152,3 +152,26 @@ def test_root_excluded_path_is_not_a_catch_all():
     assert mw_obj._is_excluded("/api/me") is False
     assert mw_obj._is_excluded("/docs") is True
     assert mw_obj._is_excluded("/docs/oauth2-redirect") is True
+
+
+def test_access_token_marker_defaults_off():
+    # The F-07 defence is opt-in: default construction leaves it disabled with
+    # the scope/scp marker set, so existing deployments are unaffected.
+    mw_obj = TokenValidationMiddleware(
+        FastAPI(), discovery_url=DISCOVERY_URL, audience="cid"
+    )
+    assert mw_obj.require_access_token_marker is False
+    assert mw_obj.access_token_marker_claims == ("scope", "scp")
+
+
+def test_require_access_token_marker_with_empty_claims_raises():
+    # Enabling the requirement with no marker claims would 401 every token;
+    # reject it at construction rather than silently blocking all traffic.
+    with pytest.raises(ValueError, match="access_token_marker_claims"):
+        TokenValidationMiddleware(
+            FastAPI(),
+            discovery_url=DISCOVERY_URL,
+            audience="cid",
+            require_access_token_marker=True,
+            access_token_marker_claims=(),
+        )

--- a/packages/fastapi-identity-model/tests/test_security_id_token_substitution.py
+++ b/packages/fastapi-identity-model/tests/test_security_id_token_substitution.py
@@ -1,22 +1,23 @@
-"""Adversarial ID-token-substitution test for the middleware (F-07).
+"""ID-token-substitution behaviour for the middleware (F-07).
 
-``TokenValidationMiddleware`` discriminates ID tokens from access tokens ONLY
+``TokenValidationMiddleware`` discriminated ID tokens from access tokens ONLY
 by the presence of ``_ID_TOKEN_ONLY_CLAIMS = ("nonce", "at_hash", "c_hash")``.
 All three are OPTIONAL for the authorization-code flow, so a code-flow ID token
 routinely carries none of them. With ``audience`` defaulted to the client_id,
-such an ID token's ``aud`` matches, it passes ``validate_token`` (valid
-signature/issuer/audience), and the guard's ``any(...)`` is False — so an
-OP-authenticated user can replay their own ID token as ``Authorization:
-Bearer`` and reach every protected route without a client-authorized access
-token.
+such an ID token's ``aud`` matches, it passes ``validate_token``, and the
+negative guard's ``any(...)`` is False — so an OP-authenticated user could
+replay their own ID token as ``Authorization: Bearer`` and reach every protected
+route without a client-authorized access token.
 
-The existing ``test_id_token_rejected_as_access_token`` only covers the
-nonce-PRESENT case; this exercises the real gap. ``validate_token`` is mocked
-to return the claims a genuine code-flow ID token would yield after passing
-signature/iss/aud validation — isolating the middleware's type-confusion guard,
-matching the existing harness. It asserts 401 and XFAILs (today: 200) until a
-positive access-token marker (e.g. ``typ:at+jwt`` or a distinct RS audience)
-is required.
+The fix adds an OPT-IN positive-marker requirement
+(``require_access_token_marker``): when enabled, a validated token must carry a
+positive access-token marker (default ``scope``/``scp``) or it is rejected. It
+is opt-in and default-off so it never breaks an integration whose access tokens
+legitimately omit those claims.
+
+``validate_token`` is mocked to return the claims a genuine token would yield
+after passing signature/iss/aud validation — isolating the middleware's
+type-confusion guard, matching the existing harness.
 """
 
 from unittest.mock import AsyncMock
@@ -33,8 +34,17 @@ pytestmark = pytest.mark.unit
 
 DISCOVERY_URL = "https://op/.well-known/openid-configuration"
 
+# A valid code-flow ID token: correct iss/sig/aud, but NONE of the ID-token-only
+# marker claims the negative guard keys on, and no access-token marker either.
+CODEFLOW_ID_TOKEN_CLAIMS = {
+    "sub": "user-1",
+    "aud": "cid",
+    "iss": "https://op",
+    "exp": 9999999999,
+}
 
-def _app(monkeypatch, validate) -> FastAPI:
+
+def _app(monkeypatch, validate, **mw_kwargs) -> FastAPI:
     monkeypatch.setattr(mw, "validate_token", validate)
     app = FastAPI()
     app.add_middleware(
@@ -42,6 +52,7 @@ def _app(monkeypatch, validate) -> FastAPI:
         discovery_url=DISCOVERY_URL,
         audience="cid",
         excluded_paths=["/health"],
+        **mw_kwargs,
     )
 
     @app.get("/me")
@@ -57,22 +68,84 @@ def _client(app: FastAPI) -> httpx.AsyncClient:
     )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="F-07: a code-flow ID token (no nonce/at_hash/c_hash, aud=client_id) "
-    "is accepted as a bearer access token",
-)
-async def test_codeflow_id_token_without_hash_claims_is_rejected(monkeypatch):
-    # A valid code-flow ID token: correct iss/sig/aud, but NONE of the
-    # ID-token-only marker claims the guard keys on.
-    id_token_claims = {
-        "sub": "user-1",
-        "aud": "cid",
-        "iss": "https://op",
-        "exp": 9999999999,
-    }
-    async with _client(
-        _app(monkeypatch, AsyncMock(return_value=id_token_claims))
-    ) as client:
-        resp = await client.get("/me", headers={"Authorization": "Bearer idtok"})
+async def _get_me(app: FastAPI) -> httpx.Response:
+    async with _client(app) as client:
+        return await client.get("/me", headers={"Authorization": "Bearer tok"})
+
+
+async def test_codeflow_id_token_rejected_when_marker_required(monkeypatch):
+    """F-07 fix: with the opt-in on, a code-flow ID token (no hash claims, no
+    ``scope``) is rejected 401 — it lacks a positive access-token marker."""
+    app = _app(
+        monkeypatch,
+        AsyncMock(return_value=CODEFLOW_ID_TOKEN_CLAIMS),
+        require_access_token_marker=True,
+    )
+    resp = await _get_me(app)
     assert resp.status_code == 401
+    assert "access-token marker" in resp.json()["detail"]
+
+
+async def test_codeflow_id_token_accepted_when_marker_not_required(monkeypatch):
+    """Backward-compat: with the opt-in OFF (default), the identical token still
+    authenticates (200) — the control changes nothing unless explicitly enabled."""
+    app = _app(monkeypatch, AsyncMock(return_value=CODEFLOW_ID_TOKEN_CLAIMS))
+    resp = await _get_me(app)
+    assert resp.status_code == 200
+    assert resp.json()["sub"] == "user-1"
+
+
+async def test_access_token_with_scope_accepted_when_marker_required(monkeypatch):
+    """No false positive: a real access token carrying ``scope`` is accepted even
+    with the marker requirement enabled."""
+    claims = {**CODEFLOW_ID_TOKEN_CLAIMS, "scope": "openid profile email"}
+    app = _app(
+        monkeypatch, AsyncMock(return_value=claims), require_access_token_marker=True
+    )
+    resp = await _get_me(app)
+    assert resp.status_code == 200
+    assert resp.json()["scope"] == "openid profile email"
+
+
+async def test_access_token_with_scp_accepted_when_marker_required(monkeypatch):
+    """Azure AD convention: an access token carrying scopes under ``scp`` is
+    accepted (``scp`` is a default marker claim)."""
+    claims = {**CODEFLOW_ID_TOKEN_CLAIMS, "scp": "api.read"}
+    app = _app(
+        monkeypatch, AsyncMock(return_value=claims), require_access_token_marker=True
+    )
+    resp = await _get_me(app)
+    assert resp.status_code == 200
+
+
+async def test_custom_marker_claim_is_honoured(monkeypatch):
+    """An OP that signals access-token type with a non-default claim can be
+    accommodated by overriding ``access_token_marker_claims`` — a token with the
+    configured marker is accepted, one without (only ``scope``) is rejected."""
+    with_marker = {**CODEFLOW_ID_TOKEN_CLAIMS, "token_use": "access"}
+    app = _app(
+        monkeypatch,
+        AsyncMock(return_value=with_marker),
+        require_access_token_marker=True,
+        access_token_marker_claims=("token_use",),
+    )
+    assert (await _get_me(app)).status_code == 200
+
+    only_scope = {**CODEFLOW_ID_TOKEN_CLAIMS, "scope": "openid"}
+    app = _app(
+        monkeypatch,
+        AsyncMock(return_value=only_scope),
+        require_access_token_marker=True,
+        access_token_marker_claims=("token_use",),
+    )
+    assert (await _get_me(app)).status_code == 401
+
+
+async def test_id_token_with_nonce_rejected_regardless_of_marker(monkeypatch):
+    """The pre-existing negative guard still fires: an ID token carrying a
+    hash/nonce claim is rejected even with the marker requirement off."""
+    claims = {**CODEFLOW_ID_TOKEN_CLAIMS, "nonce": "n-123"}
+    app = _app(monkeypatch, AsyncMock(return_value=claims))
+    resp = await _get_me(app)
+    assert resp.status_code == 401
+    assert "ID token" in resp.json()["detail"]

--- a/src/py_identity_model/core/response_processors.py
+++ b/src/py_identity_model/core/response_processors.py
@@ -158,6 +158,7 @@ def validate_and_parse_discovery_response(
         "registration_endpoint",
         "introspection_endpoint",
         "end_session_endpoint",
+        "pushed_authorization_request_endpoint",
     ]
     try:
         discovery_url = str(response.url)

--- a/src/py_identity_model/core/response_processors.py
+++ b/src/py_identity_model/core/response_processors.py
@@ -7,6 +7,7 @@ sync and async implementations.
 
 from __future__ import annotations
 
+import ipaddress
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
@@ -42,6 +43,44 @@ def _get_url_authority(url: str) -> str:
         return ""
     parsed = urlparse(url)
     return f"{parsed.scheme}://{parsed.netloc}".lower()
+
+
+def _reject_internal_ip_host(url: str, parameter_name: str) -> None:
+    """Reject a URL whose host is an internal/reserved IP *literal*.
+
+    ``mtls_endpoint_aliases`` (RFC 8705 §5) legitimately point to a foreign
+    *hostname*, so they cannot be authority-matched to the issuer like the
+    same-host endpoints. But a discovery document must never be able to route a
+    certificate-bearing request to a link-local cloud-metadata endpoint
+    (``169.254.169.254``), loopback, or an RFC1918 host — a credential-exfil /
+    SSRF primitive. This blocks IP-literal internal targets.
+
+    Limitation: it does NOT stop a *hostname* that resolves to an internal IP
+    (DNS-rebinding SSRF); defending that needs resolve-and-pin at the HTTP layer
+    and is tracked separately (T9).
+
+    Raises:
+        DiscoveryException: If ``url``'s host is an internal/reserved IP literal.
+    """
+    host = urlparse(url).hostname
+    if not host:
+        return
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return  # a hostname, not an IP literal — allowed (see limitation above)
+    if (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    ):
+        raise DiscoveryException(
+            f"{parameter_name} host '{host}' is an internal/reserved IP address "
+            f"({ip}); refusing to route a request there"
+        )
 
 
 def _validate_endpoint_authority(
@@ -172,6 +211,21 @@ def validate_and_parse_discovery_response(
             _validate_endpoint_authority(
                 ep_url, ep_name, response_json, effective_policy, discovery_url
             )
+
+    # RFC 8705 §5: ``mtls_endpoint_aliases`` map endpoint names to mTLS-specific
+    # URLs on a host that may legitimately differ from the issuer, so the
+    # same-host issuer-authority match above cannot apply. Still enforce the
+    # scheme policy (block an HTTPS->HTTP downgrade of the mTLS control) and
+    # reject internal/reserved IP-literal targets (block SSRF to link-local
+    # cloud metadata / RFC1918 / loopback). Hostname-based SSRF (DNS rebinding)
+    # is out of scope here (tracked as T9).
+    mtls_aliases = response_json.get("mtls_endpoint_aliases")
+    if isinstance(mtls_aliases, dict):
+        for alias_name, alias_url in mtls_aliases.items():
+            alias_param = f"mtls_endpoint_aliases.{alias_name}"
+            validate_https_url_with_policy(alias_url, alias_param, policy)
+            if isinstance(alias_url, str) and alias_url:
+                _reject_internal_ip_host(alias_url, alias_param)
 
     return response_json
 

--- a/src/tests/integration/test_id_token_substitution.py
+++ b/src/tests/integration/test_id_token_substitution.py
@@ -1,0 +1,89 @@
+"""Real-OP validation of the F-07 ID-token-substitution discriminator.
+
+The FastAPI ``TokenValidationMiddleware`` gained an opt-in defence
+(``require_access_token_marker``) that rejects a validated token carrying no
+*positive* access-token marker claim — closing the gap where a code-flow ID
+token (no nonce/at_hash/c_hash, ``aud == client_id``) is replayed as a bearer
+access token. Its default marker set is ``("scope", "scp")``.
+
+That defence is only safe if, for a real provider, the marker set actually
+separates a genuine ID token from a genuine access token: the ID token must NOT
+carry it (else the fix would be a no-op) and the access token MUST carry it
+(else the fix would falsely reject real access tokens). The middleware logic
+itself is deterministic and unit-tested against mocked claims; this test proves
+the premise on REAL tokens minted against whatever provider ``--env-file``
+selects, across the CI provider matrix.
+
+Lives in the core integration suite (``src/tests -m integration``) because that
+is where the real-token fixtures and the running OP fixtures are — the fastapi
+package is not synced into this environment, so the middleware is not imported;
+its decision predicate is mirrored locally and kept in lockstep by this test.
+"""
+
+import jwt as pyjwt
+import pytest
+
+
+pytestmark = pytest.mark.integration
+
+# Mirrors ``_DEFAULT_ACCESS_TOKEN_MARKER_CLAIMS`` in the fastapi package's
+# ``middleware.py``. Kept in sync deliberately: this suite cannot import the
+# fastapi package (not synced here), so if the middleware default changes, this
+# constant must change with it — the assertions below are what would catch a
+# drift that makes the default unsafe for a real provider.
+_ACCESS_TOKEN_MARKER_CLAIMS = ("scope", "scp")
+
+# A JWT is three non-empty dot-separated segments.
+_JWT_SEPARATOR_COUNT = 2
+
+
+def _looks_like_jwt(token: str) -> bool:
+    return token.count(".") == _JWT_SEPARATOR_COUNT and all(token.split("."))
+
+
+def _claims(token: str) -> dict:
+    """Decode a JWT WITHOUT signature verification (only to read claim names)."""
+    return pyjwt.decode(token, options={"verify_signature": False})
+
+
+def _has_access_token_marker(claims: dict) -> bool:
+    """The exact predicate the middleware applies when the defence is enabled."""
+    return any(c in claims for c in _ACCESS_TOKEN_MARKER_CLAIMS)
+
+
+@pytest.mark.integration
+class TestIdTokenSubstitutionDiscriminator:
+    """The default marker set must separate a real ID token from a real access
+    token for the provider under test."""
+
+    def test_marker_set_separates_id_and_access_tokens(self, auth_code_result):
+        token = auth_code_result["token_response"].token or {}
+        id_token = token.get("id_token")
+        access_token = token.get("access_token")
+
+        if not id_token:
+            pytest.skip("Auth-code response carried no id_token — nothing to separate")
+        assert _looks_like_jwt(id_token), "ID token is not a JWT — cannot inspect"
+        assert access_token, "Auth-code flow returned no access_token"
+
+        id_claims = _claims(id_token)
+        # The ID token must NOT satisfy the access-token marker predicate,
+        # otherwise the F-07 defence would let this provider's ID token through.
+        assert not _has_access_token_marker(id_claims), (
+            "real ID token carries an access-token marker claim "
+            f"({[c for c in _ACCESS_TOKEN_MARKER_CLAIMS if c in id_claims]}); "
+            "the default marker set does not separate ID from access tokens for "
+            "this provider — the F-07 defence would be a no-op here"
+        )
+
+        # A JWT access token MUST satisfy the predicate, otherwise the defence
+        # would falsely reject this provider's real access tokens.
+        if not _looks_like_jwt(access_token):
+            pytest.skip("Provider issued an opaque access token — marker check N/A")
+        access_claims = _claims(access_token)
+        assert _has_access_token_marker(access_claims), (
+            "real access token carries none of the default marker claims "
+            f"{_ACCESS_TOKEN_MARKER_CLAIMS}; enabling require_access_token_marker "
+            "would falsely reject this provider's access tokens — the default "
+            "marker set is unsafe for this OP"
+        )

--- a/src/tests/security/test_discovery_ssrf.py
+++ b/src/tests/security/test_discovery_ssrf.py
@@ -12,12 +12,17 @@ fields:
   the client POST ``client_id``/``redirect_uri``/PKCE ``code_challenge``/
   ``client_secret`` to an attacker or plaintext host (credential-exfil SSRF).
 
-Both fields bypass the validation that already guards the seven sibling
-endpoints, so a discovery document advertising a foreign-authority / plaintext
-URL in either field is accepted today. These tests assert the document is
-REJECTED (``is_successful=False`` — ``DiscoveryException`` collapsed by
-``handle_discovery_error``); they XFAIL until the two fields join the
-authority/scheme validation loop.
+``pushed_authorization_request_endpoint`` (F-06) now joins the authority/scheme
+validation loop (``_endpoint_names``), so a discovery document advertising a
+foreign-authority / plaintext URL there is REJECTED (``is_successful=False`` —
+``DiscoveryException`` collapsed by ``handle_discovery_error``).
+
+``mtls_endpoint_aliases`` (F-05) still XFAILs: strict issuer-authority matching
+cannot be applied to it, because RFC 8705 §5 mTLS endpoints legitimately live on
+a separate host (e.g. ``mtls.example.com`` under issuer ``example.com`` — see
+``test_mtls.py::TestDiscoveryParsesMtlsFields``). The correct fix (scheme +
+internal-IP-literal block, preserving cross-host hostnames) is tracked
+separately.
 
 ``TestSiblingFieldIsValidated`` is a passing control (NOT xfail): it feeds the
 identical malicious URL to a *guarded* sibling field (``token_endpoint``) and
@@ -64,8 +69,10 @@ def _fetch(doc: dict) -> DiscoveryDocumentResponse:
 @pytest.mark.parametrize("malicious_url", [METADATA_HTTP, FOREIGN_HTTPS])
 @pytest.mark.xfail(
     strict=True,
-    reason="F-05: mtls_endpoint_aliases values bypass endpoint authority/scheme "
-    "validation (SSRF + HTTPS->HTTP downgrade of mTLS-auth'd requests)",
+    reason="F-05: mtls_endpoint_aliases values bypass endpoint scheme validation "
+    "(SSRF + HTTPS->HTTP downgrade). Fix must preserve legit cross-host mTLS "
+    "aliases (RFC 8705 §5), so it needs scheme + internal-IP block, not the "
+    "issuer-authority match used for same-host endpoints.",
 )
 @respx.mock
 def test_mtls_endpoint_alias_ssrf_is_rejected(malicious_url: str) -> None:
@@ -80,11 +87,6 @@ def test_mtls_endpoint_alias_ssrf_is_rejected(malicious_url: str) -> None:
 
 
 @pytest.mark.parametrize("malicious_url", [METADATA_HTTP, FOREIGN_HTTPS])
-@pytest.mark.xfail(
-    strict=True,
-    reason="F-06: pushed_authorization_request_endpoint bypasses endpoint "
-    "authority/scheme validation (SSRF + client-cred/PKCE exfil)",
-)
 @respx.mock
 def test_par_endpoint_ssrf_is_rejected(malicious_url: str) -> None:
     doc = {**_BASE_DISCO, "pushed_authorization_request_endpoint": malicious_url}

--- a/src/tests/security/test_discovery_ssrf.py
+++ b/src/tests/security/test_discovery_ssrf.py
@@ -17,12 +17,14 @@ validation loop (``_endpoint_names``), so a discovery document advertising a
 foreign-authority / plaintext URL there is REJECTED (``is_successful=False`` —
 ``DiscoveryException`` collapsed by ``handle_discovery_error``).
 
-``mtls_endpoint_aliases`` (F-05) still XFAILs: strict issuer-authority matching
-cannot be applied to it, because RFC 8705 §5 mTLS endpoints legitimately live on
-a separate host (e.g. ``mtls.example.com`` under issuer ``example.com`` — see
-``test_mtls.py::TestDiscoveryParsesMtlsFields``). The correct fix (scheme +
-internal-IP-literal block, preserving cross-host hostnames) is tracked
-separately.
+``mtls_endpoint_aliases`` (F-05) cannot be issuer-authority-matched, because
+RFC 8705 §5 mTLS endpoints legitimately live on a separate host (e.g.
+``mtls.example.com`` under issuer ``example.com`` — see
+``test_mtls.py::TestDiscoveryParsesMtlsFields``). Instead each alias URL is
+scheme-validated (no HTTPS->HTTP downgrade) and rejected if its host is an
+internal/reserved IP literal (link-local metadata / RFC1918 / loopback SSRF);
+a legitimate cross-host *hostname* alias is still accepted. Hostname-based SSRF
+(DNS rebinding) is out of scope (tracked as T9).
 
 ``TestSiblingFieldIsValidated`` is a passing control (NOT xfail): it feeds the
 identical malicious URL to a *guarded* sibling field (``token_endpoint``) and
@@ -49,6 +51,13 @@ METADATA_HTTP = "http://169.254.169.254/latest/meta-data/iam/security-credential
 # A foreign-authority but HTTPS URL — bypasses a naive "https only" check and
 # must still be rejected on an authority mismatch against the issuer.
 FOREIGN_HTTPS = "https://attacker.evil.example/token"
+# Internal IP literals reached over HTTPS — pass a naive "https only" check but
+# must be rejected as SSRF targets (link-local cloud metadata, RFC1918).
+METADATA_HTTPS = "https://169.254.169.254/token"
+PRIVATE_HTTPS = "https://10.0.0.5/token"
+# A legitimate cross-host mTLS endpoint (RFC 8705 §5) on a separate hostname —
+# must be ALLOWED (mTLS aliases are not authority-matched to the issuer).
+LEGIT_MTLS_HOST = "https://mtls.as.example.com/token"
 
 _BASE_DISCO = {
     "issuer": "https://as.example.com",
@@ -66,24 +75,33 @@ def _fetch(doc: dict) -> DiscoveryDocumentResponse:
     return get_discovery_document(DiscoveryDocumentRequest(address=DISCO_URL))
 
 
-@pytest.mark.parametrize("malicious_url", [METADATA_HTTP, FOREIGN_HTTPS])
-@pytest.mark.xfail(
-    strict=True,
-    reason="F-05: mtls_endpoint_aliases values bypass endpoint scheme validation "
-    "(SSRF + HTTPS->HTTP downgrade). Fix must preserve legit cross-host mTLS "
-    "aliases (RFC 8705 §5), so it needs scheme + internal-IP block, not the "
-    "issuer-authority match used for same-host endpoints.",
+@pytest.mark.parametrize(
+    "malicious_url", [METADATA_HTTP, METADATA_HTTPS, PRIVATE_HTTPS]
 )
 @respx.mock
-def test_mtls_endpoint_alias_ssrf_is_rejected(malicious_url: str) -> None:
-    doc = {
-        **_BASE_DISCO,
-        "mtls_endpoint_aliases": {"token_endpoint": malicious_url},
-    }
+def test_mtls_endpoint_alias_internal_target_is_rejected(malicious_url: str) -> None:
+    """F-05: an mTLS alias pointing at a plaintext or internal-IP host fails
+    closed — a poisoned discovery document could otherwise route the
+    cert-bearing mTLS request to link-local cloud metadata / an RFC1918 host.
+
+    mTLS aliases can't be issuer-authority-matched (RFC 8705 §5 hosts them on a
+    separate hostname), so the guard is scheme (no HTTP downgrade) + an
+    internal-IP-literal block. Legit foreign *hostname* aliases are covered by
+    ``test_mtls_endpoint_alias_cross_host_is_allowed``.
+    """
+    doc = {**_BASE_DISCO, "mtls_endpoint_aliases": {"token_endpoint": malicious_url}}
     result = _fetch(doc)
-    # The mTLS token endpoint would be routed to a foreign/plaintext host; the
-    # document must fail closed rather than surface the poisoned alias.
     assert result.is_successful is False
+
+
+@respx.mock
+def test_mtls_endpoint_alias_cross_host_is_allowed() -> None:
+    """RFC 8705 §5: a legitimate mTLS endpoint on a separate hostname must be
+    ACCEPTED (mTLS aliases are not authority-matched to the issuer) — guards
+    against an over-strict F-05 fix that would break real cross-host mTLS."""
+    doc = {**_BASE_DISCO, "mtls_endpoint_aliases": {"token_endpoint": LEGIT_MTLS_HOST}}
+    result = _fetch(doc)
+    assert result.is_successful is True
 
 
 @pytest.mark.parametrize("malicious_url", [METADATA_HTTP, FOREIGN_HTTPS])


### PR DESCRIPTION
Opt-in access-token-marker enforcement (F-07) plus the SSRF hardening from #497 (F-05/F-06), folded in after the squash-merge of #496 auto-closed #497.

Carries three conventional commits (merge-committed so semantic-release sees each):
- `fix(discovery)`: validate `pushed_authorization_request_endpoint` (F-06)
- `fix(discovery)`: reject internal-IP `mtls_endpoint_aliases` (F-05)
- `feat(fastapi)`: opt-in access-token-marker enforcement (F-07)

**Verified locally before merge** (not CI-only): `src/tests/security/test_discovery_ssrf.py` 8/8 pass; `make test-fastapi` 72 passed / 95.7% cov incl. the F-07 marker tests. Remaining red/blue findings (F-01/02/04/09/10/18, R.10/11) stay tracked as `xfail` in the adversarial suite (#496) — future hardening.