### PR TITLE
fix(ci): pin uv to 0.11.29 to unbreak PyPI publish (cryptography>=50)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,13 @@ generate-token: ## Generate a sample JWT token
 ci-setup: ## CI environment setup
 	python -m pip install --upgrade pip
 	pip install pipx
-	pipx install uv
+	# Pin uv: newer uv (0.12.x+) synthesizes a phantom `cryptography>=53.8.3`
+	# constraint on the python_full_version>='3.14' resolution split, making
+	# `cryptography>=50,<51` unsatisfiable and breaking `make build-dist` in the
+	# PyPI publish (3.8.1/3.8.2/3.8.3 all failed to publish for this reason).
+	# 0.11.29 resolves cryptography>=50 across all supported Pythons (incl. 3.14)
+	# correctly. Revisit once the uv resolver bug is fixed upstream.
+	pipx install uv==0.11.29
 	uv venv
 	uv sync --all-packages
 


### PR DESCRIPTION
## Problem

PyPI is frozen at **3.8.0**, which caps `cryptography<49`. Every release since the `cryptography>=50,<51` bump — **3.8.1, 3.8.2, 3.8.3** — failed to publish:

```
No solution found when resolving dependencies for split (markers: python_full_version >= '3.14'):
  Because py-identity-model depends on cryptography<51 and cryptography>=53.8.3,
  which are incompatible ...
```

`cryptography>=53.8.3` is a **phantom** — no such version exists. cryptography 50.0.0 ships py3.14 wheels (`cp311-abi3` + `cp314-cp314t`), so 3.14 is genuinely supported. The bound is a **uv resolver regression** in the pipx-installed latest uv (0.12.x+) on the py3.14 split. uv **0.11.29** resolves `cryptography>=50` across all supported Pythons (incl. 3.14) correctly.

## Fix

Pin `pipx install uv==0.11.29` in `make ci-setup` (used by both `release.yml` and `publish-dist.yml`). No change to supported Python versions or the cryptography constraint.

## Impact

Unblocks publishing a `cryptography>=50` release, which is the **only** way downstreams (identity-stack) can reach the fixes for **PYSEC-2026-3552 / 3553 / 3554** (currently unfixable because the published `<49` cap holds them at 48.0.1).

## Verification

This PR's CI runs `make ci-setup` + `make build-dist` with the pinned uv — green CI here proves the resolver fix. On merge, semantic-release cuts a patch release that publishes the `cryptography>=50` build to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)