### PR TITLE
fix(ci): anchor version sed so it can't corrupt the cryptography>=50 pin

### DIFF
--- a/.github/workflows/publish-dist.yml
+++ b/.github/workflows/publish-dist.yml
@@ -27,7 +27,11 @@ jobs:
       - name: Build distribution 📦
         run: |
           echo ${{ steps.vars.outputs.tag }}
-          sed -i -e "s/0.0.0/${{ steps.vars.outputs.tag }}/" pyproject.toml
+          # Anchor to the project.version line: an unanchored `s/0.0.0/<ver>/`
+          # also matches the `0.0.0` inside dependency pins (e.g.
+          # `cryptography>=50.0.0`), rewriting it to `cryptography>=5<ver>` and
+          # breaking the build (this froze every cryptography>=50 release).
+          sed -i -e "s/^version = \"0.0.0\"/version = \"${{ steps.vars.outputs.tag }}\"/" pyproject.toml
           make build-dist
       - name: Publish distribution 📦 to PyPI
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,11 @@ jobs:
           echo "Building version ${{ steps.release.outputs.version }}"
           # Ensure version is set in pyproject.toml (semantic-release should have done this,
           # but we verify/set it explicitly to be safe)
-          sed -i -e "s/0.0.0/${{ steps.release.outputs.version }}/" pyproject.toml
+          # Anchor to the project.version line: an unanchored `s/0.0.0/<ver>/`
+          # also matches the `0.0.0` inside dependency pins (e.g.
+          # `cryptography>=50.0.0`), rewriting it to `cryptography>=5<ver>` and
+          # breaking the build (this froze every cryptography>=50 release).
+          sed -i -e "s/^version = \"0.0.0\"/version = \"${{ steps.release.outputs.version }}\"/" pyproject.toml
           make build-dist
 
       - name: Upload to GitHub Release Assets

--- a/Makefile
+++ b/Makefile
@@ -125,13 +125,7 @@ generate-token: ## Generate a sample JWT token
 ci-setup: ## CI environment setup
 	python -m pip install --upgrade pip
 	pip install pipx
-	# Pin uv: newer uv (0.12.x+) synthesizes a phantom `cryptography>=53.8.3`
-	# constraint on the python_full_version>='3.14' resolution split, making
-	# `cryptography>=50,<51` unsatisfiable and breaking `make build-dist` in the
-	# PyPI publish (3.8.1/3.8.2/3.8.3 all failed to publish for this reason).
-	# 0.11.29 resolves cryptography>=50 across all supported Pythons (incl. 3.14)
-	# correctly. Revisit once the uv resolver bug is fixed upstream.
-	pipx install uv==0.11.29
+	pipx install uv
 	uv venv
 	uv sync --all-packages
 


### PR DESCRIPTION
## Real root cause (supersedes #504)

The PyPI publish has failed for **every** release since `cryptography>=50.0.0` (3.8.1, 3.8.2, 3.8.3, 3.8.4) — PyPI is frozen at **3.8.0** (`cryptography<49`).

The build step ran:
```
sed -i -e "s/0.0.0/${version}/" pyproject.toml
```
to fill a version placeholder. But the unanchored pattern **also matched the `0.0.0` inside `cryptography>=50.0.0`**, rewriting it to `cryptography>=5${version}`:

| release | corrupted pin | result |
|---------|---------------|--------|
| 3.8.3 | `cryptography>=53.8.3` | build fails (no such version) |
| 3.8.4 | `cryptography>=53.8.4` | build fails |

The phantom version tracking the release number was the tell. Releases before the 50.0.0 bump were fine because `cryptography<49` / `45.0.2` contain no `0.0.0`.

(#504's uv pin was a misdiagnosis — uv was never the cause. This PR reverts it.)

## Fix

Anchor the substitution to `^version = "0.0.0"` in `release.yml` + `publish-dist.yml` — mirrors the fix already present in `publish-prerelease.yml`. Since semantic-release sets the version via `version_toml`, this is a safety no-op that can no longer touch dependency pins. Verified: `sed … | grep cryptography` → `cryptography>=50.0.0,<51` (intact).

## Impact

Unblocks publishing `cryptography>=50` to PyPI — the only way downstreams (identity-stack) can reach the fixes for **PYSEC-2026-3552 / 3553 / 3554** without ignoring them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)