### PR TITLE
fix(security): reject HS*/none against an asymmetric key with a typed error (F-01)

### DIFF
--- a/src/py_identity_model/core/parsers.py
+++ b/src/py_identity_model/core/parsers.py
@@ -28,6 +28,14 @@ _ALG_TO_KTY: dict[str, str] = {
     "EdDSA": "OKP",
     "Ed25519": "OKP",
     "Ed448": "OKP",
+    # Symmetric algorithms map to the "oct" key type. Listing them lets the
+    # consistency check reject an HS* header presented against an asymmetric
+    # (RSA/EC/OKP) JWK — the classic algorithm-confusion vector (RFC 8725
+    # §2.1/§3.1) — while still allowing a legitimate HS256 token signed with a
+    # shared-secret "oct" key (OIDC id_token_signed_response_alg=HS256).
+    "HS256": "oct",
+    "HS384": "oct",
+    "HS512": "oct",
 }
 
 
@@ -46,6 +54,17 @@ def _validate_key_alg_consistency(
     """
     if not jwt_alg:
         return
+
+    # RFC 8725 §3.2: never verify a signed token with the "none" algorithm on a
+    # key-based path. Reject with a typed exception before PyJWK is constructed —
+    # otherwise the no-kid branch hands "none" to PyJWK and raises an untyped
+    # NotImplementedError, breaking the PyIdentityModelException contract (F-01).
+    if jwt_alg.lower() == "none":
+        raise TokenValidationException(
+            "Algorithm 'none' is not permitted for signed-token validation",
+            token_part="header",
+            details={"kid": key.kid, "alg": jwt_alg},
+        )
 
     expected_kty = _ALG_TO_KTY.get(jwt_alg)
     if expected_kty and key.kty != expected_kty:

--- a/src/tests/security/test_alg_confusion_contract.py
+++ b/src/tests/security/test_alg_confusion_contract.py
@@ -30,7 +30,7 @@ import jwt as pyjwt
 import pytest
 import respx
 
-from py_identity_model.core.models import TokenValidationConfig
+from py_identity_model.core.models import JsonWebKey, TokenValidationConfig
 from py_identity_model.core.parsers import (
     _validate_key_alg_consistency,
     find_key_by_kid,
@@ -142,3 +142,87 @@ def test_hs256_against_symmetric_oct_key_is_allowed() -> None:
     oct_key = jwks_from_dict({"kty": "oct", "k": "A" * 43, "kid": "hs"})
     # Must not raise — HS256 is consistent with an oct key.
     _validate_key_alg_consistency(oct_key, "HS256")
+
+
+def _key(kty: str = "RSA", *, kid: str = "k1", alg: str | None = None) -> JsonWebKey:
+    """Minimal spec-valid JWK for the given key type. Only ``kty``/``kid``/``alg``
+    are read by the guard; the material is placeholder-but-present so
+    ``JsonWebKey.__post_init__`` validation passes."""
+    if kty == "RSA":
+        return JsonWebKey(kty="RSA", kid=kid, alg=alg, n="AQAB", e="AQAB")
+    if kty == "oct":
+        return JsonWebKey(kty="oct", kid=kid, alg=alg, k="AQAB")
+    raise ValueError(f"unsupported test kty: {kty}")
+
+
+class TestValidateKeyAlgConsistencyContract:
+    """Full exception-contract pins for ``_validate_key_alg_consistency`` — the
+    alg-confusion guard F-01 hardens. Each raising branch asserts type, message,
+    ``token_part`` and ``details``; each accepting branch asserts a clean no-op.
+    Together these kill the guard's mutants (mutation-security gate)."""
+
+    @pytest.mark.parametrize("empty_alg", [None, ""])
+    def test_falsy_alg_is_a_noop(self, empty_alg: str | None) -> None:
+        # No JWT alg -> nothing to check. Also pins that None never reaches
+        # ``.lower()`` (which would AttributeError if the early return were dropped).
+        assert _validate_key_alg_consistency(_key("RSA"), empty_alg) is None
+
+    @pytest.mark.parametrize("none_alg", ["none", "NONE", "None"])
+    def test_none_alg_is_rejected_case_insensitively(self, none_alg: str) -> None:
+        with pytest.raises(TokenValidationException) as exc_info:
+            _validate_key_alg_consistency(_key("RSA", kid="rsa-1"), none_alg)
+        exc = exc_info.value
+        assert exc.message == (
+            "Algorithm 'none' is not permitted for signed-token validation"
+        )
+        assert exc.token_part == "header"
+        assert exc.details == {"kid": "rsa-1", "alg": none_alg}
+
+    def test_symmetric_alg_against_asymmetric_key_is_rejected(self) -> None:
+        # The alg-confusion attack: an HS* header verified against an RSA key.
+        with pytest.raises(TokenValidationException) as exc_info:
+            _validate_key_alg_consistency(_key("RSA", kid="rsa-2"), "HS256")
+        exc = exc_info.value
+        assert exc.message == (
+            "Key type 'RSA' is incompatible with algorithm 'HS256' "
+            "(expected key type 'oct')"
+        )
+        assert exc.token_part == "header"
+        assert exc.details == {"kid": "rsa-2", "kty": "RSA", "alg": "HS256"}
+
+    def test_asymmetric_alg_against_symmetric_key_is_rejected(self) -> None:
+        with pytest.raises(TokenValidationException) as exc_info:
+            _validate_key_alg_consistency(_key("oct", kid="oct-1"), "RS256")
+        exc = exc_info.value
+        assert exc.message == (
+            "Key type 'oct' is incompatible with algorithm 'RS256' "
+            "(expected key type 'RSA')"
+        )
+        assert exc.token_part == "header"
+        assert exc.details == {"kid": "oct-1", "kty": "oct", "alg": "RS256"}
+
+    def test_consistent_kty_and_no_declared_alg_is_a_noop(self) -> None:
+        # RS256 against an RSA key that omits its optional ``alg`` — consistent.
+        assert _validate_key_alg_consistency(_key("RSA"), "RS256") is None
+
+    def test_alg_absent_from_map_is_not_kty_gated(self) -> None:
+        # An alg with no entry in ``_ALG_TO_KTY`` has no expected kty, so the kty
+        # branch must NOT fire (pins the ``expected_kty and ...`` short-circuit).
+        assert _validate_key_alg_consistency(_key("oct"), "PS999") is None
+
+    def test_declared_key_alg_mismatch_is_rejected(self) -> None:
+        # kty is consistent (RSA/RS256) but the key's own ``alg`` disagrees.
+        with pytest.raises(TokenValidationException) as exc_info:
+            _validate_key_alg_consistency(
+                _key("RSA", kid="rsa-3", alg="RS384"), "RS256"
+            )
+        exc = exc_info.value
+        assert exc.message == (
+            "Key algorithm 'RS384' does not match JWT algorithm 'RS256'"
+        )
+        assert exc.token_part == "header"
+        assert exc.details == {"kid": "rsa-3", "key_alg": "RS384", "jwt_alg": "RS256"}
+
+    def test_declared_key_alg_match_is_a_noop(self) -> None:
+        # key.alg == jwt_alg and kty consistent — must pass (pins the ``!=`` check).
+        assert _validate_key_alg_consistency(_key("RSA", alg="RS256"), "RS256") is None

--- a/src/tests/security/test_alg_confusion_contract.py
+++ b/src/tests/security/test_alg_confusion_contract.py
@@ -31,7 +31,11 @@ import pytest
 import respx
 
 from py_identity_model.core.models import TokenValidationConfig
-from py_identity_model.core.parsers import find_key_by_kid, jwks_from_dict
+from py_identity_model.core.parsers import (
+    _validate_key_alg_consistency,
+    find_key_by_kid,
+    jwks_from_dict,
+)
 from py_identity_model.exceptions import (
     PyIdentityModelException,
     TokenValidationException,
@@ -77,11 +81,6 @@ def _alg_less_rsa_jwk() -> dict:
 
 
 @pytest.mark.parametrize("attacker_alg", ["HS256", "none"])
-@pytest.mark.xfail(
-    strict=True,
-    reason="F-01: _validate_key_alg_consistency no-ops for HS*/none, so a "
-    "no-kid symmetric/none alg against a single alg-less RSA JWK is not rejected",
-)
 def test_find_key_by_kid_rejects_symmetric_alg_against_rsa_key(
     attacker_alg: str,
 ) -> None:
@@ -92,11 +91,6 @@ def test_find_key_by_kid_rejects_symmetric_alg_against_rsa_key(
         find_key_by_kid(None, [key], jwt_alg=attacker_alg)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="F-01: HS256 no-kid token vs single alg-less RSA JWK escapes as an "
-    "untyped jwt.InvalidKeyError, violating the PyIdentityModelException contract",
-)
 @respx.mock
 def test_validate_token_hs256_no_kid_raises_typed_exception() -> None:
     jwk = _alg_less_rsa_jwk()
@@ -120,11 +114,6 @@ def test_validate_token_hs256_no_kid_raises_typed_exception() -> None:
         )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="F-01: alg=none no-kid token vs single alg-less RSA JWK escapes as an "
-    "untyped NotImplementedError, violating the PyIdentityModelException contract",
-)
 @respx.mock
 def test_validate_token_none_alg_no_kid_raises_typed_exception() -> None:
     jwk = _alg_less_rsa_jwk()
@@ -140,3 +129,16 @@ def test_validate_token_none_alg_no_kid_raises_typed_exception() -> None:
             token_validation_config=config,
             disco_doc_address=DISCO_URL,
         )
+
+
+def test_hs256_against_symmetric_oct_key_is_allowed() -> None:
+    """Positive control: HS* against a symmetric ``oct`` key is a LEGITIMATE
+    OIDC configuration — a confidential client with
+    ``id_token_signed_response_alg=HS256`` verifies the ID token with its client
+    secret (an ``oct`` JWK). Only HS*/``none`` against an *asymmetric* key is the
+    alg-confusion attack, so the guard must NOT reject this. Pins the kty-gated
+    fix against over-rejecting the spec-permitted symmetric case.
+    """
+    oct_key = jwks_from_dict({"kty": "oct", "k": "A" * 43, "kid": "hs"})
+    # Must not raise — HS256 is consistent with an oct key.
+    _validate_key_alg_consistency(oct_key, "HS256")


### PR DESCRIPTION
Second trust-rebuild PR. Test-first; the 4 F-01 cases **failed as strict-xfail on `main` and pass with the fix**, plus a new positive control.

## What was wrong
`_validate_key_alg_consistency` no-op'd for exactly the attacker's algorithms — `HS256/384/512` and `none` weren't in `_ALG_TO_KTY`, so `expected_kty` was `None` and the check was skipped. A no-kid `alg=HS256`/`none` token against a single alg-less RSA JWK then reached `PyJWK(rsa_key, …)` → **untyped `jwt.InvalidKeyError`/`NotImplementedError`** → escapes the `PyIdentityModelException` contract → 500/traceback (DoS-shaped info leak). Not a forgery (PyJWT's `kty` check blocks that), but #488/SC1 left this edge open — its own strict-xfail proved it.

## Fix (spec-grounded)
- RFC 8725 §3.1 ("each key MUST be used with exactly one algorithm … MUST be checked"), §3.2 (`none` SHOULD NOT be consumed), RFC 7515 §4.1.1.
- Map `HS256/384/512 → "oct"` so the existing kty check rejects HS* against an asymmetric key; reject `alg=none` on the key-based path with a typed exception before `PyJWK`.

## No over-rejection (the trap avoided)
Gated on JWK `kty`: a legitimate **HS256 ID token signed with a client-secret `oct` key** (OIDC `id_token_signed_response_alg=HS256`) still validates — proven by `test_hs256_against_symmetric_oct_key_is_allowed`. A blanket HS* ban would have broken that.

## Tests
4 strict-xfail → passing (HS256/none via `find_key_by_kid` and via `validate_token`), + the positive control. Full unit+security suite **1533 passed / 13 xfailed**, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)