### PR TITLE
fix(fastapi): uniform 401 body across validation failures (F-18, CWE-209)

### DIFF
--- a/packages/fastapi-identity-model/fastapi_identity_model/middleware.py
+++ b/packages/fastapi-identity-model/fastapi_identity_model/middleware.py
@@ -50,6 +50,12 @@ _ID_TOKEN_ONLY_CLAIMS = ("nonce", "at_hash", "c_hash")
 # a client_credentials token minted with no scopes) legitimately carry neither.
 _DEFAULT_ACCESS_TOKEN_MARKER_CLAIMS = ("scope", "scp")
 
+# F-18 (CWE-209): every token-validation failure returns this single generic 401
+# body so the response cannot be used as an oracle to distinguish the rejection
+# cause (invalid signature vs wrong audience vs expired). The specific cause is
+# logged server-side for operators, never returned to the caller.
+_GENERIC_401_DETAIL = "Invalid or unauthorized token"
+
 
 class TokenValidationMiddleware(BaseHTTPMiddleware):
     """
@@ -217,11 +223,18 @@ class TokenValidationMiddleware(BaseHTTPMiddleware):
                 content={"detail": "Authentication temporarily unavailable"},
             )
         except PyIdentityModelException as e:
-            return self._unauthorized(f"Token validation failed: {e!s}")
+            # Uniform 401 body — do NOT echo the stage-specific cause
+            # (signature/audience/expiry), which would form a CWE-209 oracle
+            # (F-18). Log the real cause server-side for operators.
+            logger.info("Token rejected during validation: %s", e)
+            return self._unauthorized(_GENERIC_401_DETAIL)
         except InvalidTokenError as e:
             # A malformed/undecodable token (e.g. raw pyjwt DecodeError from
-            # header parsing during key lookup) is a client error, not a 500.
-            return self._unauthorized(f"Invalid token: {e!s}")
+            # header parsing during key lookup) is a client error, not a 500 —
+            # and returns the same generic body as any other rejection so the
+            # response can't distinguish "malformed" from "invalid".
+            logger.info("Malformed token rejected: %s", e)
+            return self._unauthorized(_GENERIC_401_DETAIL)
         except Exception:
             # A genuinely unexpected (non-library) failure is a server fault,
             # not an auth decision. Surface a 500 without leaking internals.

--- a/packages/fastapi-identity-model/tests/test_middleware.py
+++ b/packages/fastapi-identity-model/tests/test_middleware.py
@@ -74,7 +74,8 @@ async def test_invalid_token_returns_401(monkeypatch):
     async with _client(_app(monkeypatch, validate)) as client:
         resp = await client.get("/me", headers={"Authorization": "Bearer bad"})
     assert resp.status_code == 401
-    assert "Token validation failed" in resp.json()["detail"]
+    # F-18: uniform, non-oracular 401 body (does not echo the validation cause).
+    assert resp.json()["detail"] == mw._GENERIC_401_DETAIL
 
 
 async def test_unexpected_error_returns_500(monkeypatch):
@@ -100,7 +101,8 @@ async def test_malformed_token_returns_401_not_500(monkeypatch):
     async with _client(_app(monkeypatch, validate)) as client:
         resp = await client.get("/me", headers={"Authorization": "Bearer invalid"})
     assert resp.status_code == 401
-    assert "Invalid token" in resp.json()["detail"]
+    # F-18: malformed tokens return the same uniform body as any other rejection.
+    assert resp.json()["detail"] == mw._GENERIC_401_DETAIL
 
 
 async def test_id_token_rejected_as_access_token(monkeypatch):

--- a/packages/fastapi-identity-model/tests/test_security_error_oracle.py
+++ b/packages/fastapi-identity-model/tests/test_security_error_oracle.py
@@ -54,11 +54,6 @@ def _client(app: FastAPI) -> httpx.AsyncClient:
     )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="F-18: 401 body echoes the stage-specific validation error, forming a "
-    "token-validation oracle (CWE-209)",
-)
 async def test_401_body_is_uniform_across_failure_stages(monkeypatch):
     # Three different validation failures, each a PyIdentityModelException.
     failures = [


### PR DESCRIPTION
Test-first; the F-18 strict-xfail (three distinct validation failures must yield identical 401 bodies) **failed on `main` and passes with the fix**.

## What was wrong
`_authenticate` returned `f"Token validation failed: {e!s}"` — echoing the stage-specific cause (`Invalid signature` / `Invalid audience` / `Token has expired`). A holder of a validly-signed but out-of-scope token can distinguish *why* it was rejected — a **CWE-209** oracle useful for token-reuse / forgery probing.

## Fix
- All `PyIdentityModelException` and malformed-token (`InvalidTokenError`) rejections return one generic body: `_GENERIC_401_DETAIL = "Invalid or unauthorized token"`.
- The specific cause is **logged server-side** for operators, never returned.
- The wrong-token-type response (F-07) stays distinct on purpose — it reports token *type*, not a validation-stage cause (and isn't a signature/aud/expiry oracle).

## Tests
- Flips the strict-xfail `test_401_body_is_uniform_across_failure_stages`.
- Updates `test_invalid_token_returns_401` and `test_malformed_token_returns_401_not_500` — they asserted the old leaky strings; now they positively assert the uniform body.
- `make test-fastapi`: **73 passed / 1 xfailed**, 95.75% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)