### PR TITLE
feat(security): opt-in multi-tenant issuer pinning via allowed_issuers (R.9)

### DIFF
--- a/docs/security/control-matrix.md
+++ b/docs/security/control-matrix.md
@@ -28,8 +28,8 @@ to `shipped` and links its proving test as it lands.
 | Control | Module | RFC / spec | Attack (audit ref) | Proving test | Status |
 | ------- | ------ | ---------- | ------------------ | ------------ | ------ |
 | Basic-auth credential form-urlencoding | `core/client_auth.py` | RFC 6749 §2.3.1 / App. B | Reserved chars in `client_id`/secret mangled or `:` splits credential (R.5, #482) | `security/test_basic_auth_encoding.py` | shipped |
-| Reject alg downgrade / confusion (honor caller allowlist; never trust token header) | `core/token_validation_logic.py`, `core/jwt_helpers.py` | RFC 7515 §4.1.1, RFC 8725 §2.1 | HS/`none` alg-confusion & downgrade forgery (R.1) | _pending SC1_ | pending |
-| Issuer allowlist pinning before trusting discovery | `core/token_validation_logic.py` | OIDC Core §2, RFC 9207 | Multi-tenant issuer spoofing (R.9) | _pending SC2_ | pending |
+| Reject alg downgrade / confusion (honor caller allowlist; never trust token header) | `core/parsers.py`, `core/token_validation_logic.py`, `core/jwt_helpers.py` | RFC 7515 §4.1.1, RFC 8725 §2.1 | HS/`none` alg-confusion & downgrade forgery (R.1) | `security/test_alg_confusion_contract.py` | shipped |
+| Issuer allowlist pinning before trusting discovery | `core/token_validation_logic.py`, `core/models.py` | OIDC Core §2, RFC 9207 | Multi-tenant issuer spoofing (R.9) | `security/test_issuer_pinning.py` | shipped |
 | Sender-constrained tokens (`cnf.x5t#S256` / `cnf.jkt`) + strict audience | `core/mtls.py`, `core/dpop.py`, `core/token_validation_logic.py` | RFC 8705 §3, RFC 9449 §7 | Stolen-token replay against a bearer RS (R.2) | _pending SC3_ | pending |
 | Enforce `verify_aud` / `verify_iss` / `require exp` | `core/jwt_helpers.py`, `core/token_validation_logic.py` | RFC 7519 §4.1, RFC 8725 §3.x | Audience/issuer/expiry checks silently disabled (R.3) | _pending SC4_ | pending |
 | Require `sub` claim on ID tokens | `core/token_validation_logic.py` | OIDC Core §2 | ID token accepted without a subject (R.10) | _pending SC5_ | pending |

--- a/src/py_identity_model/core/models.py
+++ b/src/py_identity_model/core/models.py
@@ -1316,6 +1316,15 @@ class TokenValidationConfig:
         leeway: Clock skew tolerance in seconds for ``exp`` and ``nbf``
             claims.  Useful when clocks between the issuer and this
             server are not perfectly synchronized.
+        allowed_issuers: Optional allowlist of approved issuer identifiers.
+            **Purely opt-in.** When ``None`` (the default) discovery is assumed
+            authoritative and its issuer is used as-is — default behaviour is
+            unchanged. When set, the issuer used to validate the token (the
+            discovery document's issuer in discovery mode, otherwise ``issuer``)
+            MUST be a member, checked *before* the discovery result is trusted.
+            Set it only for multi-tenant callers that resolve discovery from an
+            untrusted token's ``iss`` — without it an attacker who stands up their
+            own tenant and mints a validly-signed token would pass validation.
 
     Examples:
         >>> # Multi-tenant with clock skew tolerance
@@ -1350,6 +1359,7 @@ class TokenValidationConfig:
     claims_validator: Callable | None = None
     require_https: bool = True
     leeway: float | None = None
+    allowed_issuers: list[str] | None = None
 
 
 __all__ = [

--- a/src/py_identity_model/core/token_validation_logic.py
+++ b/src/py_identity_model/core/token_validation_logic.py
@@ -13,7 +13,11 @@ from ..core.models import (
     JwksResponse,
     TokenValidationConfig,
 )
-from ..exceptions import ConfigurationException, TokenValidationException
+from ..exceptions import (
+    ConfigurationException,
+    InvalidIssuerException,
+    TokenValidationException,
+)
 from ..logging_config import logger
 from ..logging_utils import redact_token
 
@@ -98,6 +102,46 @@ def validate_config_for_manual_validation(
         )
 
 
+def _enforce_allowed_issuers(
+    effective_issuer: str | list[str] | None,
+    allowed_issuers: list[str],
+) -> None:
+    """Fail closed unless every issuer used to validate the token is approved.
+
+    Multi-tenant spoofing defence (Epic 16 R.9 / audit RT-SPOOF-F1). In discovery
+    mode the ``effective_issuer`` is whatever discovery document the caller pointed
+    at, so the idiomatic middleware pattern (read ``iss`` from the untrusted token,
+    build ``disco_doc_address`` from it, validate) lets an attacker stand up their
+    own tenant, mint a validly-signed token, and pass — only the app's own
+    ``iss``->authz mapping would stop it. Pinning an approved issuer set rejects
+    the discovery result *before* it is trusted. Configured but unresolvable ->
+    fail closed rather than skip the check.
+
+    Raises:
+        InvalidIssuerException: If the effective issuer is not in ``allowed_issuers``
+            (or no issuer could be resolved to check).
+    """
+    allowed = set(allowed_issuers)
+    if isinstance(effective_issuer, str):
+        candidates = [effective_issuer]
+    elif effective_issuer:
+        candidates = list(effective_issuer)
+    else:
+        candidates = []
+    if not candidates:
+        raise InvalidIssuerException(
+            "allowed_issuers is configured but no issuer was resolved to check "
+            "against; refusing to validate without a pinned issuer",
+            details={"allowed_issuers": sorted(allowed)},
+        )
+    for iss in candidates:
+        if iss not in allowed:
+            raise InvalidIssuerException(
+                f"Issuer '{iss}' is not in the configured allowed_issuers",
+                details={"issuer": iss, "allowed_issuers": sorted(allowed)},
+            )
+
+
 def decode_with_config(
     jwt: str,
     token_validation_config: TokenValidationConfig,
@@ -128,6 +172,21 @@ def decode_with_config(
         logger.warning(
             "Discovery issuer overrides configured multi-issuer list; "
             "multi-issuer is not supported in discovery mode"
+        )
+
+    # Multi-tenant issuer pinning (OPT-IN): only when the caller sets
+    # allowed_issuers. When it is None (the default) this is skipped entirely and
+    # discovery stays authoritative — default behaviour is unchanged. When set,
+    # the issuer used to validate the token (the discovery issuer in disco mode,
+    # else the configured issuer) MUST be in the approved set, checked before
+    # decode so an attacker's own tenant is rejected before the discovery result
+    # is trusted (audit RT-SPOOF-F1).
+    if token_validation_config.allowed_issuers is not None:
+        effective_issuer = (
+            issuer if issuer is not None else token_validation_config.issuer
+        )
+        _enforce_allowed_issuers(
+            effective_issuer, token_validation_config.allowed_issuers
         )
 
     return decode_and_validate_jwt(
@@ -229,6 +288,9 @@ def build_resolved_config(
         claims_validator=original_config.claims_validator,
         require_https=original_config.require_https,
         leeway=original_config.leeway,
+        # Propagate the issuer allowlist so the disco/retry paths (which validate
+        # via this resolved config) still enforce issuer pinning.
+        allowed_issuers=original_config.allowed_issuers,
     )
 
 

--- a/src/tests/security/test_issuer_pinning.py
+++ b/src/tests/security/test_issuer_pinning.py
@@ -1,0 +1,103 @@
+"""Fail-closed tests for multi-tenant issuer pinning (SC2 / Epic 16 R.9).
+
+Audit RT-SPOOF-F1: the library validated the token's ``iss`` against whatever
+discovery document the caller pointed at, with no approved-issuer allowlist. A
+caller that resolves discovery from the untrusted token's ``iss`` (the idiomatic
+multi-tenant pattern) would therefore accept a validly-signed token from an
+attacker's own tenant. ``allowed_issuers`` pins the approved set and is enforced
+before the discovery result is trusted.
+
+Each test fails if the control is reverted:
+* ``decode_with_config`` (the shared chokepoint for every path) rejects an
+  effective issuer outside the allowlist;
+* ``build_resolved_config`` propagates ``allowed_issuers`` — without this the
+  discovery/retry paths (which validate via the resolved config) would silently
+  skip the check;
+* the ``_enforce_allowed_issuers`` logic fails closed on the edge cases.
+"""
+
+from __future__ import annotations
+
+import jwt as pyjwt
+import pytest
+
+from py_identity_model.core.models import TokenValidationConfig
+from py_identity_model.core.token_validation_logic import (
+    _enforce_allowed_issuers,
+    build_resolved_config,
+    decode_with_config,
+)
+from py_identity_model.exceptions import InvalidIssuerException
+
+
+_LEGIT = "https://api.descope.com/v1/apps/LEGIT"
+_ATTACKER = "https://api.descope.com/v1/apps/ATTACKER"
+
+
+class TestChokepointRejectsUnapprovedIssuer:
+    def test_attacker_tenant_issuer_rejected_before_decode(self):
+        # The exact multi-tenant attack: discovery resolved to the attacker's own
+        # tenant issuer. Even with a well-formed key/alg, pinning rejects it
+        # before the token is decoded/trusted.
+        cfg = TokenValidationConfig(
+            perform_disco=True,
+            key={"kty": "RSA"},
+            algorithms=["RS256"],
+            allowed_issuers=[_LEGIT],
+        )
+        with pytest.raises(
+            InvalidIssuerException, match="not in the configured allowed_issuers"
+        ):
+            decode_with_config("a.b.c", cfg, issuer=_ATTACKER)
+
+    def test_default_no_allowlist_does_not_pin(self):
+        # OPT-IN: with allowed_issuers unset (the default), discovery stays
+        # authoritative — no pinning. Decode proceeds past the (absent) issuer
+        # check and fails downstream on the dummy token/key for an unrelated
+        # reason — never with InvalidIssuerException. Locks in that this control
+        # does not change default behaviour.
+        cfg = TokenValidationConfig(
+            perform_disco=True, key={"kty": "RSA"}, algorithms=["RS256"]
+        )
+        # The flow reaches decode (past the skipped pin) and fails there building
+        # PyJWK from the dummy key — a jwt InvalidKeyError, NOT the
+        # InvalidIssuerException pinning would raise. If pinning were not opt-in,
+        # InvalidIssuerException would be raised first and this would fail.
+        with pytest.raises(pyjwt.InvalidKeyError):
+            decode_with_config("a.b.c", cfg, issuer=_ATTACKER)
+
+
+class TestResolvedConfigPropagatesAllowlist:
+    def test_build_resolved_config_carries_allowed_issuers(self):
+        # Without propagation the disco/retry paths validate via a resolved config
+        # whose allowed_issuers is None -> the pin is silently skipped on the main
+        # attack path. This test locks the propagation in.
+        cfg = TokenValidationConfig(perform_disco=True, allowed_issuers=[_LEGIT])
+        resolved = build_resolved_config(cfg, {"kty": "RSA"}, "RS256")
+        assert resolved.allowed_issuers == [_LEGIT]
+
+
+class TestEnforceAllowedIssuers:
+    def test_allowed_single_issuer_passes(self):
+        _enforce_allowed_issuers(_LEGIT, [_LEGIT])  # no raise
+
+    def test_disallowed_single_issuer_rejected(self):
+        with pytest.raises(
+            InvalidIssuerException, match="not in the configured allowed_issuers"
+        ):
+            _enforce_allowed_issuers(_ATTACKER, [_LEGIT])
+
+    def test_list_all_allowed_passes(self):
+        _enforce_allowed_issuers(
+            [_LEGIT, "https://other/LEGIT2"], [_LEGIT, "https://other/LEGIT2"]
+        )
+
+    def test_list_with_one_disallowed_rejected(self):
+        with pytest.raises(InvalidIssuerException):
+            _enforce_allowed_issuers([_LEGIT, _ATTACKER], [_LEGIT])
+
+    def test_unresolvable_issuer_fails_closed(self):
+        # allowed_issuers configured but nothing resolved to check -> reject,
+        # never skip the check.
+        with pytest.raises(InvalidIssuerException, match="no issuer was resolved"):
+            _enforce_allowed_issuers(None, [_LEGIT])

--- a/src/tests/security/test_issuer_pinning.py
+++ b/src/tests/security/test_issuer_pinning.py
@@ -21,17 +21,22 @@ from __future__ import annotations
 import jwt as pyjwt
 import pytest
 
+from py_identity_model.core import token_validation_logic
 from py_identity_model.core.models import TokenValidationConfig
 from py_identity_model.core.token_validation_logic import (
     _enforce_allowed_issuers,
     build_resolved_config,
     decode_with_config,
 )
-from py_identity_model.exceptions import InvalidIssuerException
+from py_identity_model.exceptions import (
+    ConfigurationException,
+    InvalidIssuerException,
+)
 
 
 _LEGIT = "https://api.descope.com/v1/apps/LEGIT"
 _ATTACKER = "https://api.descope.com/v1/apps/ATTACKER"
+_LEEWAY_SENTINEL = 42.0
 
 
 class TestChokepointRejectsUnapprovedIssuer:
@@ -67,37 +72,213 @@ class TestChokepointRejectsUnapprovedIssuer:
             decode_with_config("a.b.c", cfg, issuer=_ATTACKER)
 
 
-class TestResolvedConfigPropagatesAllowlist:
-    def test_build_resolved_config_carries_allowed_issuers(self):
-        # Without propagation the disco/retry paths validate via a resolved config
-        # whose allowed_issuers is None -> the pin is silently skipped on the main
-        # attack path. This test locks the propagation in.
-        cfg = TokenValidationConfig(perform_disco=True, allowed_issuers=[_LEGIT])
-        resolved = build_resolved_config(cfg, {"kty": "RSA"}, "RS256")
+class TestBuildResolvedConfigCopiesAllFields:
+    """``build_resolved_config`` sets key/algorithms from the resolved JWK and
+    copies every other field from the original. A dropped/altered field would let
+    the disco/retry paths validate under the wrong config — most dangerously a
+    silently-lost ``allowed_issuers`` (pin skipped). Pins each field explicitly."""
+
+    def test_all_fields_propagated(self):
+        def _cv(_claims: dict) -> bool:
+            return True
+
+        original = TokenValidationConfig(
+            perform_disco=True,
+            key={"orig": "unused"},
+            audience="aud-sentinel",
+            algorithms=["RS512"],  # must be replaced by [alg]
+            issuer="iss-sentinel",
+            subject="sub-sentinel",
+            options={"verify_aud": False},
+            claims_validator=_cv,
+            require_https=False,
+            leeway=_LEEWAY_SENTINEL,
+            allowed_issuers=[_LEGIT],
+        )
+        resolved = build_resolved_config(original, {"resolved": "key"}, "ES256")
+        # From the resolver arguments:
+        assert resolved.key == {"resolved": "key"}
+        assert resolved.algorithms == ["ES256"]
+        # Copied from the original (distinct sentinels catch a field swap/drop):
+        assert resolved.perform_disco is True
+        assert resolved.audience == "aud-sentinel"
+        assert resolved.issuer == "iss-sentinel"
+        assert resolved.subject == "sub-sentinel"
+        assert resolved.options == {"verify_aud": False}
+        assert resolved.claims_validator is _cv
+        assert resolved.require_https is False
+        assert resolved.leeway == _LEEWAY_SENTINEL
         assert resolved.allowed_issuers == [_LEGIT]
 
 
 class TestEnforceAllowedIssuers:
     def test_allowed_single_issuer_passes(self):
-        _enforce_allowed_issuers(_LEGIT, [_LEGIT])  # no raise
+        assert _enforce_allowed_issuers(_LEGIT, [_LEGIT]) is None
 
-    def test_disallowed_single_issuer_rejected(self):
-        with pytest.raises(
-            InvalidIssuerException, match="not in the configured allowed_issuers"
-        ):
+    def test_all_of_a_list_allowed_passes(self):
+        other = "https://api.descope.com/v1/apps/LEGIT2"
+        assert _enforce_allowed_issuers([_LEGIT, other], [_LEGIT, other]) is None
+
+    def test_disallowed_single_issuer_rejected_full_contract(self):
+        with pytest.raises(InvalidIssuerException) as exc_info:
             _enforce_allowed_issuers(_ATTACKER, [_LEGIT])
+        exc = exc_info.value
+        assert exc.message == (
+            f"Issuer '{_ATTACKER}' is not in the configured allowed_issuers"
+        )
+        assert exc.details == {"issuer": _ATTACKER, "allowed_issuers": [_LEGIT]}
 
-    def test_list_all_allowed_passes(self):
-        _enforce_allowed_issuers(
-            [_LEGIT, "https://other/LEGIT2"], [_LEGIT, "https://other/LEGIT2"]
+    def test_list_with_one_disallowed_names_the_bad_issuer(self):
+        with pytest.raises(InvalidIssuerException) as exc_info:
+            _enforce_allowed_issuers([_LEGIT, _ATTACKER], [_LEGIT])
+        exc = exc_info.value
+        assert exc.message == (
+            f"Issuer '{_ATTACKER}' is not in the configured allowed_issuers"
+        )
+        assert exc.details == {"issuer": _ATTACKER, "allowed_issuers": [_LEGIT]}
+
+    @pytest.mark.parametrize("unresolvable", [None, []])
+    def test_unresolvable_issuer_fails_closed_full_contract(self, unresolvable):
+        # allowed_issuers configured but nothing resolved to check -> reject.
+        with pytest.raises(InvalidIssuerException) as exc_info:
+            _enforce_allowed_issuers(unresolvable, [_LEGIT])
+        exc = exc_info.value
+        assert exc.message == (
+            "allowed_issuers is configured but no issuer was resolved to check "
+            "against; refusing to validate without a pinned issuer"
+        )
+        assert exc.details == {"allowed_issuers": [_LEGIT]}
+
+    def test_empty_string_issuer_is_treated_as_disallowed_not_unresolved(self):
+        # "" is a resolved-but-bogus issuer, not an absent one: it must be
+        # rejected as disallowed (pins the isinstance-str branch).
+        with pytest.raises(InvalidIssuerException) as exc_info:
+            _enforce_allowed_issuers("", [_LEGIT])
+        assert exc_info.value.details == {"issuer": "", "allowed_issuers": [_LEGIT]}
+
+    def test_details_allowed_issuers_is_sorted(self):
+        with pytest.raises(InvalidIssuerException) as exc_info:
+            _enforce_allowed_issuers(_ATTACKER, ["z-iss", "a-iss"])
+        assert exc_info.value.details["allowed_issuers"] == ["a-iss", "z-iss"]
+
+
+class TestDecodeWithConfigChokepoint:
+    """Pins the decode chokepoint that SC2 modified: the key/algorithms guard, the
+    opt-in pin (effective-issuer selection), and the pass-through to
+    ``decode_and_validate_jwt``."""
+
+    def test_missing_key_raises_typed_configuration_exception(self):
+        cfg = TokenValidationConfig(
+            perform_disco=True, algorithms=["RS256"]
+        )  # key unset
+        with pytest.raises(ConfigurationException) as exc_info:
+            decode_with_config("a.b.c", cfg)
+        assert exc_info.value.message == (
+            "Token validation configuration must have key and algorithms set"
         )
 
-    def test_list_with_one_disallowed_rejected(self):
-        with pytest.raises(InvalidIssuerException):
-            _enforce_allowed_issuers([_LEGIT, _ATTACKER], [_LEGIT])
+    def test_missing_algorithms_raises_typed_configuration_exception(self):
+        cfg = TokenValidationConfig(
+            perform_disco=True, key={"kty": "oct", "k": "AA"}
+        )  # algorithms unset
+        with pytest.raises(ConfigurationException):
+            decode_with_config("a.b.c", cfg)
 
-    def test_unresolvable_issuer_fails_closed(self):
-        # allowed_issuers configured but nothing resolved to check -> reject,
-        # never skip the check.
-        with pytest.raises(InvalidIssuerException, match="no issuer was resolved"):
-            _enforce_allowed_issuers(None, [_LEGIT])
+    def test_pin_uses_config_issuer_when_no_discovery_override(self, monkeypatch):
+        # issuer arg None -> the effective issuer for the pin is config.issuer; a
+        # disallowed config.issuer must be rejected *before* decode runs.
+        cfg = TokenValidationConfig(
+            perform_disco=True,
+            key={"kty": "oct", "k": "AA"},
+            algorithms=["HS256"],
+            issuer=_ATTACKER,
+            allowed_issuers=[_LEGIT],
+        )
+        calls: list = []
+        monkeypatch.setattr(
+            token_validation_logic,
+            "decode_and_validate_jwt",
+            lambda **kwargs: calls.append(kwargs) or {},
+        )
+        with pytest.raises(InvalidIssuerException):
+            decode_with_config("a.b.c", cfg, issuer=None)
+        assert calls == []  # rejected before decode
+
+    def test_decode_receives_every_field_and_discovery_issuer_wins(self, monkeypatch):
+        override = "https://disco/OVERRIDE"
+        cfg = TokenValidationConfig(
+            perform_disco=True,
+            key={"kty": "oct", "k": "AA"},
+            algorithms=["HS256"],
+            audience="aud-sentinel",
+            issuer=_LEGIT,
+            subject="sub-sentinel",
+            options={"verify_aud": False},
+            leeway=17.0,
+            allowed_issuers=[_LEGIT, override],
+        )
+        captured: dict = {}
+        monkeypatch.setattr(
+            token_validation_logic,
+            "decode_and_validate_jwt",
+            lambda **kwargs: captured.update(kwargs) or {"ok": True},
+        )
+        result = decode_with_config("a.b.c", cfg, issuer=override)
+        assert result == {"ok": True}
+        assert captured == {
+            "jwt": "a.b.c",
+            "key": {"kty": "oct", "k": "AA"},
+            "algorithms": ["HS256"],
+            "audience": "aud-sentinel",
+            "issuer": override,  # discovery override wins over config.issuer
+            "options": {"verify_aud": False},
+            "leeway": 17.0,
+            "subject": "sub-sentinel",
+        }
+
+    def test_multi_issuer_list_with_discovery_override_warns(self, monkeypatch):
+        cfg = TokenValidationConfig(
+            perform_disco=True,
+            key={"kty": "oct", "k": "AA"},
+            algorithms=["HS256"],
+            issuer=["iss-a", "iss-b"],  # a configured multi-issuer list
+        )
+        warnings: list = []
+        monkeypatch.setattr(
+            token_validation_logic,
+            "decode_and_validate_jwt",
+            lambda **_kwargs: {},
+        )
+        monkeypatch.setattr(
+            token_validation_logic.logger,
+            "warning",
+            lambda msg, *_args: warnings.append(msg),
+        )
+        decode_with_config("a.b.c", cfg, issuer="https://disco/OVERRIDE")
+        assert warnings == [
+            "Discovery issuer overrides configured multi-issuer list; "
+            "multi-issuer is not supported in discovery mode"
+        ]
+
+    def test_no_warning_without_discovery_override(self, monkeypatch):
+        # No discovery override (issuer arg None) -> the multi-issuer warning must
+        # not fire even with a configured list (pins the `issuer is not None` half).
+        cfg = TokenValidationConfig(
+            perform_disco=True,
+            key={"kty": "oct", "k": "AA"},
+            algorithms=["HS256"],
+            issuer=["iss-a", "iss-b"],
+        )
+        warnings: list = []
+        monkeypatch.setattr(
+            token_validation_logic,
+            "decode_and_validate_jwt",
+            lambda **_kwargs: {},
+        )
+        monkeypatch.setattr(
+            token_validation_logic.logger,
+            "warning",
+            lambda msg, *_args: warnings.append(msg),
+        )
+        decode_with_config("a.b.c", cfg, issuer=None)
+        assert warnings == []

--- a/tools/mutation_security_allowlist.txt
+++ b/tools/mutation_security_allowlist.txt
@@ -14,3 +14,11 @@
 #
 # SC0 seeds this file empty: SC0 changes no security module, so its gate run is
 # a no-op. Each remediation task (SC1–SC10) adds its own justified waivers.
+
+# R.9 issuer pinning (_enforce_allowed_issuers): the `else` branch sets
+# `candidates = []`; mutant _6 sets it to `None`. Both fall straight into
+# `if not candidates:` — `not []` and `not None` are both True — so both raise
+# the identical "no issuer was resolved" InvalidIssuerException and the for-loop
+# below is never reached. No input that reaches the else branch can observe []
+# vs None: semantically equivalent, unkillable.
+py_identity_model.core.token_validation_logic.x__enforce_allowed_issuers__mutmut_6


### PR DESCRIPTION
Re-cut clean onto current main from the stale SC-stack branch (#489). Closes the R.9 / RT-SPOOF-F1 finding.

## Problem
A multi-tenant caller that resolves discovery from an untrusted token's `iss` (the idiomatic pattern) accepts a validly-signed token minted by an **attacker's own tenant** — the library trusts whatever discovery document it's pointed at, with no approved-issuer allowlist.

## Fix (opt-in, default-off, backward-compatible)
- New `TokenValidationConfig.allowed_issuers: list[str] | None = None`. Default `None` → behaviour unchanged.
- When set, the issuer used to validate (discovery issuer in disco mode, else the configured issuer) MUST be a member — enforced in `decode_with_config` **before** the discovery result is trusted, and propagated through `build_resolved_config` so the disco/retry paths enforce it too.
- Configured-but-unresolvable → fail **closed** (`InvalidIssuerException`), never skip.

## Gate
`token_validation_logic.py` is mutation-gated. The three changed functions have **89 in-scope mutants; all killed or waived** (one provably-equivalent mutant — `candidates = [] → None` in a branch that immediately raises on `not candidates` — waived by exact name with justification). Full-contract tests in `test_issuer_pinning.py` (message + details + sorted set, field-copy sentinels, decode pass-through, multi-issuer warning).

## Supersedes #489
#489's other commits already landed on main via other PRs: alg-confusion (SC1) via #507, the gate foundation, and cert-binding. Only this feature remained; #489 will be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)