### PR TITLE
docs: add AI-assisted contribution policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Summary
+
+<!-- What does this change and why? -->
+
+## AI provenance
+
+<!--
+If any part of this PR was AI-assisted, check the box and fill in the harness and
+model lines. See CONTRIBUTING.md -> AI-Assisted Contributions.
+-->
+- [ ] This PR was AI-assisted
+- Harness/agent:
+- Model(s):
+- [ ] A human has reviewed this change and is accountable for it
+
+## Checklist
+
+- [ ] CI is green
+- [ ] Tests added/updated where appropriate
+- [ ] Docs updated if behavior changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -367,3 +367,20 @@ Contributors will be recognized in the project documentation and release notes. 
 ## License
 
 By contributing to py-identity-model, you agree that your contributions will be licensed under the Apache License 2.0.
+
+## AI-Assisted Contributions
+
+Contributions that use AI tools (GitHub Copilot, Claude Code, ChatGPT, Cursor, the Ralph loop, `pi`, etc.) are welcome. We apply the same quality standards to all contributions regardless of how they were authored.
+
+### Requirements for AI-assisted PRs
+
+- **All CI checks must pass** — lint, tests, security scans. No exceptions.
+- **Audit disclosure is required.** Every AI-assisted PR must record, in the PR description's **AI provenance** block, the **harness/agent(s)** and the **model(s)** used to produce the change (for example: harness `Claude Code`, model `claude-opus-4-8`; or harness `ralph-orchestrator + pi`, model `z-ai/glm-5.2`).
+- **A human is accountable.** A named human must review the change and attest to it. The submitter is responsible for the correctness, security, and quality of the code regardless of whether it was AI-generated.
+- **Advisory-only AI.** AI output — including automated review — is advisory until a human attests. A green check is not sign-off.
+
+### What we look for
+
+- No hallucinated APIs, invented SDK methods, or fabricated citations.
+- Tests actually run and cover the new functionality.
+- Documentation is accurate and complete.


### PR DESCRIPTION
## Summary

Adds an AI-assisted contribution policy: a CONTRIBUTING "AI-Assisted Contributions" section requiring AI-generated PRs to disclose the harness and model(s) used and to name an accountable human, plus a PR template carrying the AI-provenance block. Standardizes the policy across the jamescrowley321 repos.

## AI provenance

- [x] This PR was AI-assisted
- Harness/agent: Claude Code (Anthropic)
- Model(s): claude-opus-4-8
- [x] A human has reviewed this change and is accountable for it (James Crowley)

## Checklist

- [x] CI is green (docs-only change)
- [ ] Tests added/updated where appropriate (N/A - docs)
- [x] Docs updated if behavior changed
