### PR TITLE
docs: surface 12 orphaned API reference pages in mkdocs nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,12 +90,24 @@ nav:
   - API Reference:
       - Overview: api/index.md
       - Discovery: api/discovery.md
+      - Discovery Policy: api/discovery-policy.md
       - JWKS: api/jwks.md
       - Token Client: api/token-client.md
       - Token Validation: api/token-validation.md
+      - Authorization Code + PKCE: api/auth-code-pkce.md
+      - Refresh Token: api/refresh-token.md
+      - Device Authorization: api/device-auth.md
+      - Token Introspection: api/introspection.md
+      - Token Revocation: api/revocation.md
+      - Token Exchange: api/token-exchange.md
+      - DPoP: api/dpop.md
+      - Pushed Authorization Requests: api/par.md
+      - JWT-Secured Authorization Request: api/jar.md
+      - FAPI 2.0: api/fapi.md
       - UserInfo: api/userinfo.md
       - Authorize Callback: api/authorize-callback.md
       - Identity & Claims: api/identity.md
+      - HTTP Client: api/http-client.md
       - Exceptions: api/exceptions.md
   - Roadmap: py_identity_model_roadmap.md
   - Examples:


### PR DESCRIPTION
## What
`docs/api/` contains **21** reference pages, but the mkdocs `nav` listed only **9** — so 12 pages were built into the site yet unreachable from the navigation sidebar.

## Orphaned pages now added
`discovery-policy`, `auth-code-pkce`, `refresh-token`, `device-auth`, `introspection`, `revocation`, `token-exchange`, `dpop`, `par`, `jar`, `fapi`, `http-client`.

They're inserted into the **API Reference** section ordered to match the README's protocol-feature flow (discovery → tokens → grants → advanced protocols → userinfo/identity → infra).

## Validation
- Confirmed every `api/*.md` referenced in `nav` exists on disk.
- Confirmed **no** `api/*.md` file remains orphaned from the nav.
- `nav`-only change; no page content touched.

## Noted for follow-up (not in this PR)
- `docs/certification.md` OIDF submission-format section is stale (portal now wants 3 certification-package zips).
- `token_characterization_node-oidc.md` is a working artifact tracked at repo root — candidate to relocate under `docs/` or remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)