### PR TITLE
feat(cache): per-process cache observability counters + benchmark + doc fix (T299)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,8 +100,9 @@ src/py_identity_model/
    - Core functions are pure (no I/O) and return result objects or raise exceptions
 
 3. **Caching Strategy**
-   - Discovery documents: Cached per-process with `functools.lru_cache` (sync) and `async_lru.alru_cache` (async)
-   - JWKS keys: Cached to avoid repeated fetches during token validation
+   - Discovery documents and JWKS are cached per-process with an explicit **TTL + LRU** cache (an `OrderedDict` bounded to `DEFAULT_MAX_CACHE_ENTRIES` = 64), **not** `functools.lru_cache`/`async_lru.alru_cache`. Cache *policy* lives in `core/jwks_cache.py`; the sync/async cache stacks live in `sync/token_validation.py` and `aio/token_validation.py`.
+   - Entries expire on a TTL resolved from `Cache-Control: max-age` → env override (`DISCO_CACHE_TTL` / `JWKS_CACHE_TTL`) → built-in default, clamped to `[60s, 86400s]`. Concurrent misses are coalesced into a single upstream fetch via per-URI striped locks.
+   - Per-process cache hit/miss/refresh counters are exposed via `core/cache_metrics.py` (`get_cache_counters()`, re-exported at the top level); the async cache paths are instrumented. Clear caches with `clear_discovery_cache()` / `clear_jwks_cache()` (async variants must be `await`ed).
    - All caches are per-process, not shared across processes
 
 4. **Error Handling**

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -10,112 +10,108 @@ py-identity-model is designed for high performance with built-in caching and sup
 
 ### Discovery Document Caching
 
-Discovery documents are cached automatically to avoid repeated HTTP requests:
+Discovery documents and JWKS are cached in-process to keep the steady-state
+request path off the network. The cache is **not** `functools.lru_cache` /
+`async_lru.alru_cache` — those were replaced (v3.0.0) with an explicit
+**TTL + LRU** cache so entries expire on a schedule, key rotation is handled
+automatically, and concurrent misses are coalesced into a single upstream
+fetch. The cache *policy* lives in `core/jwks_cache.py`; the sync and async
+cache stacks live in `sync/token_validation.py` and `aio/token_validation.py`.
 
-**Sync Implementation:**
-```python
-from functools import lru_cache
+### What is cached
 
-@lru_cache(maxsize=128)
-def _get_disco_response(disco_doc_address: str) -> DiscoveryDocumentResponse:
-    """Cached discovery document fetching"""
-    request = DiscoveryDocumentRequest(address=disco_doc_address)
-    return get_discovery_document(request)
-```
+| Cache | Cache key | Backing store | Default TTL | Env override |
+|-------|-----------|---------------|-------------|--------------|
+| Discovery document | `(address, require_https)` | `OrderedDict` | 3600s (1 hour) | `DISCO_CACHE_TTL` |
+| JWKS | `jwks_uri` | `OrderedDict` | 86400s (24 hours) | `JWKS_CACHE_TTL` |
 
-**Async Implementation:**
-```python
-from async_lru import alru_cache
+Both caches share the same policy machinery:
 
-@alru_cache(maxsize=128)
-async def _get_disco_response(disco_doc_address: str) -> DiscoveryDocumentResponse:
-    """Cached async discovery document fetching"""
-    request = DiscoveryDocumentRequest(address=disco_doc_address)
-    return await get_discovery_document(request)
-```
+- **LRU eviction, 64 entries** (`DEFAULT_MAX_CACHE_ENTRIES`). The store is an
+  `OrderedDict`, not a plain dict, so a *read hit* refreshes recency
+  (`touch_cache_entry`) and eviction targets the least-recently-**used** entry.
+- **TTL resolution order.** For each entry the TTL is the first available of:
+  (1) the response's `Cache-Control: max-age`, (2) the environment override,
+  (3) the built-in default. The resolved value is clamped to
+  **[60s, 86400s]** (`MIN_CACHE_TTL_SECONDS` … `MAX_CACHE_TTL_SECONDS`); a bad
+  or out-of-range env value is clamped and logged, never crashes the request.
+- **Single-flight fetch.** Per-URI striped locks (32 stripes) ensure a cache
+  miss issues exactly one upstream fetch; concurrent requests for the same URI
+  wait on the stripe and then read the freshly-cached entry (a
+  *double-checked* hit) rather than each hitting the network.
+- **Kid-miss cooldown.** If a JWT's `kid` is absent from the cached JWKS the
+  cache is treated as stale and a refresh is forced (OP key rotation). This is
+  rate-limited per-URI — default 5s (`DEFAULT_KID_MISS_REFRESH_COOLDOWN_SECONDS`,
+  override `KID_MISS_REFRESH_COOLDOWN`) — so an attacker forging tokens with
+  random unknown kids cannot amplify inbound traffic into upstream JWKS fetches.
+- **Per-event-loop locks (async).** The async write/fetch locks are keyed on
+  the running event loop via `WeakKeyDictionary` (#399), so a test runner or
+  embed that creates a new loop per scope does not hit
+  `RuntimeError: <Lock> is bound to a different event loop`.
 
-### JWKS Caching
-
-JSON Web Key Sets are also cached:
-
-- **Cache Size**: 128 entries (both sync and async)
-- **Cache Key**: JWKS URL (from discovery document)
-- **Cache Duration**: Lifetime of the process
-- **Thread Safety**: Both implementations are thread-safe
-
-### Cache Behavior Differences
-
-| Aspect | Synchronous | Asynchronous |
-|--------|-------------|--------------|
-| Library | `functools.lru_cache` | `async_lru.alru_cache` |
-| Max Entries | 128 | 128 |
-| Thread Safety | ✅ Yes | ✅ Yes |
-| Cache Sharing | Sync calls only | Async calls only |
-| Cache Clearing | `function.cache_clear()` | `function.cache_clear()` |
-| Performance | Fast | Fast |
-
-**Important:** Sync and async caches are **separate**. They do not share cached data.
-
-#### Example: Cache Separation
-
-```python
-from py_identity_model import get_discovery_document as sync_disco
-from py_identity_model.aio import get_discovery_document as async_disco
-from py_identity_model import DiscoveryDocumentRequest
-
-# First call - fetches from network (sync cache)
-disco = sync_disco(DiscoveryDocumentRequest(address="https://..."))
-
-# Second call - uses sync cache (fast)
-disco = sync_disco(DiscoveryDocumentRequest(address="https://..."))
-
-# Async call - fetches from network again (separate cache!)
-disco = await async_disco(DiscoveryDocumentRequest(address="https://..."))
-
-# Second async call - uses async cache (fast)
-disco = await async_disco(DiscoveryDocumentRequest(address="https://..."))
-```
+**Important:** the sync and async caches are **separate** process-global
+`OrderedDict`s. They do not share cached data.
 
 ### Clearing Caches
 
-You can manually clear caches if needed:
+Use the public cache-clear helpers. **Breaking change (v3.0.0):** the async
+helpers are now `async def` — they acquire the cache write lock before
+clearing so a fetch in flight can't write its result back into a "cleared"
+cache — so callers must `await` them.
 
 ```python
-from py_identity_model.sync.token_validation import _get_disco_response, _get_jwks_response
+# Sync
+from py_identity_model import clear_discovery_cache, clear_jwks_cache
 
-# Clear discovery document cache
-_get_disco_response.cache_clear()
-
-# Clear JWKS cache
-_get_jwks_response.cache_clear()
+clear_discovery_cache()
+clear_jwks_cache()
 ```
-
-For async:
-```python
-from py_identity_model.aio.token_validation import _get_disco_response, _get_jwks_response
-
-# Clear async discovery document cache
-_get_disco_response.cache_clear()
-
-# Clear async JWKS cache
-_get_jwks_response.cache_clear()
-```
-
-### Cache Statistics
-
-You can inspect cache performance:
 
 ```python
-from py_identity_model.sync.token_validation import _get_disco_response
+# Async — must be awaited
+from py_identity_model.aio import clear_discovery_cache, clear_jwks_cache
 
-# Get cache statistics
-info = _get_disco_response.cache_info()
-print(f"Hits: {info.hits}")
-print(f"Misses: {info.misses}")
-print(f"Size: {info.currsize}")
-print(f"Max Size: {info.maxsize}")
-print(f"Hit Rate: {info.hits / (info.hits + info.misses) * 100:.2f}%")
+await clear_discovery_cache()
+await clear_jwks_cache()
 ```
+
+There is no `_get_disco_response.cache_clear()` / `.cache_info()` — those are
+`functools.lru_cache` APIs and the cache no longer uses `lru_cache`.
+
+### Observing Cache Hit Rate
+
+The cache exposes lightweight per-process counters via
+`core/cache_metrics.py`, re-exported at the top level. Read a `snapshot()` and
+compute whatever rate you need:
+
+```python
+from py_identity_model import get_cache_counters
+
+snap = get_cache_counters().snapshot()
+# {'disco_hits': ..., 'disco_misses': ..., 'jwks_hits': ...,
+#  'jwks_misses': ..., 'jwks_refreshes': ...}
+
+jwks_total = snap["jwks_hits"] + snap["jwks_misses"]
+jwks_hit_rate = snap["jwks_hits"] / jwks_total if jwks_total else 0.0
+```
+
+Semantics:
+
+- **hit** — request served from a fresh cached entry (no upstream call);
+  **miss** — request that had to fetch from upstream;
+  **refresh** — a *forced* upstream JWKS re-fetch (kid-miss or
+  signature-failure key-rotation recovery). A refresh that coalesces onto
+  another coroutine's in-flight fetch does no upstream work and is not counted.
+- Counters currently cover the **async** cache paths
+  (`_get_disco_response` / `_get_cached_jwks` / `_refresh_jwks`). The sync
+  stack uses the same TTL/LRU structure but is not yet instrumented.
+- Counters are **per-process**. Under `uvicorn --workers N` each worker keeps
+  its own tally — aggregate snapshots across workers for a fleet-wide rate.
+- The injected-`http_client` path bypasses the caches entirely and is
+  deliberately **not** counted (it performs no caching, so a hit rate over it
+  would be meaningless).
+- `get_cache_counters().reset()` zeros every counter — useful for per-run
+  baselines and tests.
 
 ## Performance Benchmarks
 
@@ -518,25 +514,28 @@ Monitor cache performance in production:
 
 ```python
 import logging
-from py_identity_model.sync.token_validation import _get_disco_response
+from py_identity_model import get_cache_counters
 
 logger = logging.getLogger(__name__)
 
 def log_cache_stats():
     """Log cache statistics periodically."""
-    disco_info = _get_disco_response.cache_info()
+    snap = get_cache_counters().snapshot()
 
-    total = disco_info.hits + disco_info.misses
-    hit_rate = (disco_info.hits / total * 100) if total > 0 else 0
+    disco_total = snap["disco_hits"] + snap["disco_misses"]
+    disco_rate = (snap["disco_hits"] / disco_total * 100) if disco_total else 0
+    jwks_total = snap["jwks_hits"] + snap["jwks_misses"]
+    jwks_rate = (snap["jwks_hits"] / jwks_total * 100) if jwks_total else 0
 
     logger.info(
-        f"Discovery cache: {disco_info.hits} hits, "
-        f"{disco_info.misses} misses, "
-        f"{hit_rate:.1f}% hit rate, "
-        f"{disco_info.currsize}/{disco_info.maxsize} entries"
+        f"Discovery cache: {snap['disco_hits']} hits, "
+        f"{snap['disco_misses']} misses, {disco_rate:.1f}% hit rate | "
+        f"JWKS cache: {snap['jwks_hits']} hits, {snap['jwks_misses']} misses, "
+        f"{snap['jwks_refreshes']} refreshes, {jwks_rate:.1f}% hit rate"
     )
 
-# Log every 1000 requests or periodically
+# Log every 1000 requests or periodically. Counters are per-process — aggregate
+# across workers for a fleet-wide rate.
 ```
 
 ### Performance Metrics

--- a/src/py_identity_model/__init__.py
+++ b/src/py_identity_model/__init__.py
@@ -5,6 +5,7 @@ Provides both synchronous and asynchronous APIs for OpenID Connect operations.
 
 # Initialize SSL compatibility for backward compatibility with requests library
 from . import ssl_config  # noqa: F401
+from .core.cache_metrics import CacheCounters, get_cache_counters
 
 # Backward compatible sync exports (default)
 from .exceptions import (
@@ -150,6 +151,7 @@ __all__ = [
     # Base Classes
     "BaseRequest",
     "BaseResponse",
+    "CacheCounters",
     # mTLS (RFC 8705)
     "CertificateBindingError",
     # Identity models
@@ -245,6 +247,7 @@ __all__ = [
     "generate_code_verifier",
     "generate_dpop_key",
     "generate_pkce_pair",
+    "get_cache_counters",
     # Sync API (default)
     "get_discovery_document",
     "get_jwks",

--- a/src/py_identity_model/aio/token_validation.py
+++ b/src/py_identity_model/aio/token_validation.py
@@ -11,6 +11,7 @@ import threading
 import time
 from weakref import WeakKeyDictionary
 
+from ..core.cache_metrics import get_cache_counters
 from ..core.discovery_policy import DiscoveryPolicy
 from ..core.jwks_cache import (
     DiscoCacheEntry,
@@ -134,16 +135,23 @@ async def _get_disco_response(
         # against an eviction on another loop sharing this module-global cache;
         # the process-wide lock inside touch_cache_entry does (#397).
         touch_cache_entry(_disco_cache, cache_key)
+        get_cache_counters().record_disco_hit()
         return entry.response
 
     fetch_lock = _get_disco_fetch_lock(cache_key)
     async with fetch_lock:
         entry = _disco_cache.get(cache_key)
         if entry is not None and not is_cache_expired(entry):
+            # Double-checked hit: another coroutine populated the entry while we
+            # waited on the fetch lock. This is a genuine cache hit, not a miss —
+            # counting it as a miss would inflate the miss rate under concurrent
+            # warmup.
             touch_cache_entry(_disco_cache, cache_key)
+            get_cache_counters().record_disco_hit()
             return entry.response
 
         policy = DiscoveryPolicy(require_https=require_https)
+        get_cache_counters().record_disco_miss()
         response = await get_discovery_document(
             DiscoveryDocumentRequest(address=disco_doc_address, policy=policy),
         )
@@ -219,19 +227,24 @@ async def _get_cached_jwks(jwks_uri: str, require_https: bool = True) -> JwksRes
         # Refresh LRU recency (see _get_disco_response) — self-serializing via
         # the process-wide structure lock, no per-loop write lock needed.
         touch_cache_entry(_jwks_cache, jwks_uri)
+        get_cache_counters().record_jwks_hit()
         return entry.response
 
     fetch_lock = _get_jwks_fetch_lock(jwks_uri)
     async with fetch_lock:
         entry = _jwks_cache.get(jwks_uri)
         if entry is not None and not is_cache_expired(entry):
+            # Double-checked hit populated by a concurrent fetch (see
+            # _get_disco_response) — count as a hit, not a miss.
             touch_cache_entry(_jwks_cache, jwks_uri)
+            get_cache_counters().record_jwks_hit()
             return entry.response
 
         # The jwks_uri was already vetted against this policy when the
         # discovery document was processed; thread it through so the
         # pre-flight scheme check inside get_jwks() does not double-reject.
         policy = DiscoveryPolicy(require_https=require_https)
+        get_cache_counters().record_jwks_miss()
         response = await get_jwks(JwksRequest(address=jwks_uri, policy=policy))
         async with _get_jwks_cache_write_lock():
             apply_jwks_cache_outcome(
@@ -272,6 +285,10 @@ async def _refresh_jwks(
             return entry.response, False
 
         logger.info("Forcing JWKS refresh for %s (possible key rotation)", jwks_uri)
+        # Count only the branch that issues the upstream GET. The coalesced
+        # early return above returns another coroutine's just-fetched result
+        # and does no upstream work, so it is not a refresh fetch.
+        get_cache_counters().record_jwks_refresh()
         policy = DiscoveryPolicy(require_https=require_https)
         response = await get_jwks(JwksRequest(address=jwks_uri, policy=policy))
         async with _get_jwks_cache_write_lock():

--- a/src/py_identity_model/aio/token_validation.py
+++ b/src/py_identity_model/aio/token_validation.py
@@ -151,10 +151,17 @@ async def _get_disco_response(
             return entry.response
 
         policy = DiscoveryPolicy(require_https=require_https)
-        get_cache_counters().record_disco_miss()
         response = await get_discovery_document(
             DiscoveryDocumentRequest(address=disco_doc_address, policy=policy),
         )
+        # Count the miss only when an upstream fetch actually succeeded.
+        # get_discovery_document runs a pre-flight scheme check that returns an
+        # unsuccessful response *before any network I/O* for a disallowed URI;
+        # such a request does zero upstream work and must not inflate the
+        # miss/fetch-volume counter (else forged non-https addresses skew the
+        # very hit-rate this counter exists to report).
+        if response.is_successful:
+            get_cache_counters().record_disco_miss()
         async with _get_disco_cache_write_lock():
             apply_disco_cache_outcome(
                 _disco_cache, cache_key, response, time.monotonic()
@@ -244,8 +251,14 @@ async def _get_cached_jwks(jwks_uri: str, require_https: bool = True) -> JwksRes
         # discovery document was processed; thread it through so the
         # pre-flight scheme check inside get_jwks() does not double-reject.
         policy = DiscoveryPolicy(require_https=require_https)
-        get_cache_counters().record_jwks_miss()
         response = await get_jwks(JwksRequest(address=jwks_uri, policy=policy))
+        # Count the miss only when an upstream fetch actually succeeded. get_jwks
+        # returns an unsuccessful response for a disallowed scheme (e.g. plaintext
+        # http://) via a pre-flight check *before any network I/O*; a rejected
+        # request does zero upstream work and must not inflate the
+        # miss/fetch-volume counter.
+        if response.is_successful:
+            get_cache_counters().record_jwks_miss()
         async with _get_jwks_cache_write_lock():
             apply_jwks_cache_outcome(
                 _jwks_cache,
@@ -285,12 +298,15 @@ async def _refresh_jwks(
             return entry.response, False
 
         logger.info("Forcing JWKS refresh for %s (possible key rotation)", jwks_uri)
-        # Count only the branch that issues the upstream GET. The coalesced
-        # early return above returns another coroutine's just-fetched result
-        # and does no upstream work, so it is not a refresh fetch.
-        get_cache_counters().record_jwks_refresh()
         policy = DiscoveryPolicy(require_https=require_https)
         response = await get_jwks(JwksRequest(address=jwks_uri, policy=policy))
+        # Count only the branch that issues the upstream GET, and only when it
+        # actually succeeded. The coalesced early return above returns another
+        # coroutine's just-fetched result and does no upstream work; a scheme-
+        # rejected refresh returns an unsuccessful response before any network
+        # I/O. Neither is an upstream re-fetch, so neither is counted.
+        if response.is_successful:
+            get_cache_counters().record_jwks_refresh()
         async with _get_jwks_cache_write_lock():
             apply_jwks_cache_outcome(
                 _jwks_cache,

--- a/src/py_identity_model/core/cache_metrics.py
+++ b/src/py_identity_model/core/cache_metrics.py
@@ -33,11 +33,18 @@ class CacheCounters:
     """Thread-safe hit/miss/refresh tallies for the discovery and JWKS caches.
 
     A *hit* is a request served from a fresh cached entry (no upstream call).
-    A *miss* is a request that had to fetch the document/keys from upstream.
-    A *refresh* is a forced upstream JWKS re-fetch triggered by a kid miss or
-    a signature-verification failure (key-rotation recovery); a refresh that
-    coalesces onto another coroutine's in-flight fetch does no upstream work
-    and is not counted.
+    A *miss* is a request that fetched the document/keys from upstream and
+    succeeded. A *refresh* is a forced upstream JWKS re-fetch triggered by a
+    kid miss or a signature-verification failure (key-rotation recovery) that
+    succeeded.
+
+    Only upstream fetches that actually reached the network and returned a
+    successful response are counted. A request rejected by the pre-flight URL
+    scheme check (e.g. a plaintext ``http://`` address under the default
+    HTTPS-required policy) does zero upstream work and is *not* counted — so a
+    forged non-https discovery/JWKS URI cannot inflate the miss/fetch-volume
+    tally. Likewise a refresh that coalesces onto another coroutine's in-flight
+    fetch does no upstream work and is not counted.
     """
 
     disco_hits: int = 0

--- a/src/py_identity_model/core/cache_metrics.py
+++ b/src/py_identity_model/core/cache_metrics.py
@@ -1,0 +1,116 @@
+"""Per-process cache observability counters.
+
+Lightweight, dependency-free hit/miss/refresh counters for the discovery
+and JWKS caches. These make the cache-hit rate and upstream-fetch volume
+observable without pulling in a metrics runtime (Prometheus, statsd, …);
+a caller that wants those can read :func:`get_cache_counters` snapshots and
+export them however it likes.
+
+**Scope:** counters are *per-process*. Each worker (uvicorn ``--workers N``,
+gunicorn fork, …) keeps its own :data:`CACHE_COUNTERS`; aggregate across
+workers externally when a fleet-wide rate is needed (the load/soak harness
+sums per-worker snapshots).
+
+**Cost:** every ``record_*`` is an O(1) integer increment under a dedicated
+leaf :class:`threading.Lock`. The lock guards only the counter fields — it
+never wraps I/O or a cache-structure critical section, so instrumenting the
+cache fast path adds no contention against the cache itself.
+
+**What is counted:** only the module-level singleton cache paths in
+:mod:`py_identity_model.aio.token_validation`
+(``_get_disco_response`` / ``_get_cached_jwks`` / ``_refresh_jwks``). The
+injected-``http_client`` path bypasses those caches entirely and is
+deliberately *not* counted — it performs no caching, so a "hit rate" over it
+would be meaningless.
+"""
+
+from dataclasses import dataclass, field
+import threading
+
+
+@dataclass
+class CacheCounters:
+    """Thread-safe hit/miss/refresh tallies for the discovery and JWKS caches.
+
+    A *hit* is a request served from a fresh cached entry (no upstream call).
+    A *miss* is a request that had to fetch the document/keys from upstream.
+    A *refresh* is a forced upstream JWKS re-fetch triggered by a kid miss or
+    a signature-verification failure (key-rotation recovery); a refresh that
+    coalesces onto another coroutine's in-flight fetch does no upstream work
+    and is not counted.
+    """
+
+    disco_hits: int = 0
+    disco_misses: int = 0
+    jwks_hits: int = 0
+    jwks_misses: int = 0
+    jwks_refreshes: int = 0
+    _lock: threading.Lock = field(
+        default_factory=threading.Lock, repr=False, compare=False
+    )
+
+    def record_disco_hit(self) -> None:
+        """Count a discovery request served from a fresh cache entry."""
+        with self._lock:
+            self.disco_hits += 1
+
+    def record_disco_miss(self) -> None:
+        """Count a discovery request that fetched from upstream."""
+        with self._lock:
+            self.disco_misses += 1
+
+    def record_jwks_hit(self) -> None:
+        """Count a JWKS request served from a fresh cache entry."""
+        with self._lock:
+            self.jwks_hits += 1
+
+    def record_jwks_miss(self) -> None:
+        """Count a JWKS request that fetched from upstream."""
+        with self._lock:
+            self.jwks_misses += 1
+
+    def record_jwks_refresh(self) -> None:
+        """Count a forced upstream JWKS re-fetch (key-rotation recovery)."""
+        with self._lock:
+            self.jwks_refreshes += 1
+
+    def snapshot(self) -> dict[str, int]:
+        """Return a point-in-time copy of every counter.
+
+        The returned dict is a detached copy — mutating it does not affect the
+        live counters, and the counters can advance freely afterwards.
+        """
+        with self._lock:
+            return {
+                "disco_hits": self.disco_hits,
+                "disco_misses": self.disco_misses,
+                "jwks_hits": self.jwks_hits,
+                "jwks_misses": self.jwks_misses,
+                "jwks_refreshes": self.jwks_refreshes,
+            }
+
+    def reset(self) -> None:
+        """Zero every counter. Primarily for tests and per-run baselines."""
+        with self._lock:
+            self.disco_hits = 0
+            self.disco_misses = 0
+            self.jwks_hits = 0
+            self.jwks_misses = 0
+            self.jwks_refreshes = 0
+
+
+# Process-wide singleton. The async cache paths increment this directly; a
+# caller reads it via ``get_cache_counters().snapshot()``.
+CACHE_COUNTERS = CacheCounters()
+
+
+def get_cache_counters() -> CacheCounters:
+    """Return the process-wide :data:`CACHE_COUNTERS` singleton."""
+    return CACHE_COUNTERS
+
+
+__all__ = [
+    "CACHE_COUNTERS",
+    "CacheCounters",
+    "get_cache_counters",
+]

--- a/src/tests/benchmarks/test_benchmarks.py
+++ b/src/tests/benchmarks/test_benchmarks.py
@@ -3,12 +3,25 @@
 Run with: make test-benchmark
 """
 
+import asyncio
+import base64
+import time
+
+import httpx
 import jwt as pyjwt
 import pytest
+import respx
 
 from py_identity_model import (
     validate_fapi_authorization_request,
     validate_fapi_client_config,
+)
+from py_identity_model.aio.token_validation import (
+    clear_discovery_cache,
+    clear_jwks_cache,
+)
+from py_identity_model.aio.token_validation import (
+    validate_token as aio_validate_token,
 )
 from py_identity_model.core.discovery_policy import (
     DiscoveryPolicy,
@@ -20,6 +33,7 @@ from py_identity_model.core.dpop import (
     generate_dpop_key,
 )
 from py_identity_model.core.jar import create_request_object
+from py_identity_model.core.models import TokenValidationConfig
 from py_identity_model.core.parsers import jwks_from_dict
 from py_identity_model.core.pkce import (
     generate_code_challenge,
@@ -200,3 +214,98 @@ def test_bench_pyjwt_decode_baseline(benchmark, sample_signed_jwt, ec_public_pem
 
     result = benchmark(decode_jwt)
     assert result is not None
+
+
+# ============================================================================
+# End-to-end validate_token warm-path Benchmark
+# ============================================================================
+#
+# The raw ``pyjwt.decode`` baseline above measures only the crypto verify. The
+# function that actually runs on every resource-server request is
+# ``aio.validate_token`` — discovery lookup, JWKS lookup, key resolution, decode
+# and claim validation. On the warm path (disco + JWKS both cached) every
+# upstream fetch is skipped, so this micro measures the per-request overhead the
+# cache is meant to eliminate. Upstream is respx-mocked and the caches are
+# pre-warmed once, so the benched runs never touch the network.
+
+_BENCH_ISSUER = "https://bench.example.com"
+_BENCH_DISCO_URL = f"{_BENCH_ISSUER}/.well-known/openid-configuration"
+_BENCH_JWKS_URL = f"{_BENCH_ISSUER}/jwks"
+_BENCH_AUDIENCE = "bench-api"
+
+
+def _rsa_public_jwk(public_key, kid: str) -> dict:
+    """Build an RS256 JWK dict from a cryptography RSA public key."""
+    numbers = public_key.public_numbers()
+
+    def _b64u(value: int, length: int) -> str:
+        return (
+            base64.urlsafe_b64encode(value.to_bytes(length, "big"))
+            .rstrip(b"=")
+            .decode()
+        )
+
+    return {
+        "kty": "RSA",
+        "kid": kid,
+        "n": _b64u(numbers.n, 256),
+        "e": _b64u(numbers.e, 3),
+        "alg": "RS256",
+        "use": "sig",
+    }
+
+
+@pytest.mark.benchmark(group="validation")
+def test_bench_validate_token_warm_path(benchmark, rsa_private_key, rsa_private_pem):
+    """Benchmark the async ``validate_token`` warm path (disco + JWKS cached)."""
+    kid = "bench-validate-key"
+    jwk = _rsa_public_jwk(rsa_private_key.public_key(), kid)
+    disco_doc = {
+        "issuer": _BENCH_ISSUER,
+        "authorization_endpoint": f"{_BENCH_ISSUER}/authorize",
+        "token_endpoint": f"{_BENCH_ISSUER}/token",
+        "jwks_uri": _BENCH_JWKS_URL,
+        "response_types_supported": ["code"],
+        "subject_types_supported": ["public"],
+        "id_token_signing_alg_values_supported": ["RS256"],
+    }
+    now = int(time.time())
+    token = pyjwt.encode(
+        {
+            "iss": _BENCH_ISSUER,
+            "sub": "bench-user",
+            "aud": _BENCH_AUDIENCE,
+            "exp": now + 86400,
+            "iat": now,
+            "nbf": now,
+        },
+        rsa_private_pem,
+        algorithm="RS256",
+        headers={"kid": kid},
+    )
+    config = TokenValidationConfig(perform_disco=True, audience=_BENCH_AUDIENCE)
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(clear_discovery_cache())
+        loop.run_until_complete(clear_jwks_cache())
+        with respx.mock:
+            respx.get(_BENCH_DISCO_URL).mock(
+                return_value=httpx.Response(200, json=disco_doc)
+            )
+            respx.get(_BENCH_JWKS_URL).mock(
+                return_value=httpx.Response(200, json={"keys": [jwk]})
+            )
+            # Warm both caches once so the benched runs are pure cache-hit path.
+            loop.run_until_complete(aio_validate_token(token, config, _BENCH_DISCO_URL))
+            result = benchmark(
+                lambda: loop.run_until_complete(
+                    aio_validate_token(token, config, _BENCH_DISCO_URL)
+                )
+            )
+        assert result is not None
+        assert result["sub"] == "bench-user"
+    finally:
+        loop.run_until_complete(clear_discovery_cache())
+        loop.run_until_complete(clear_jwks_cache())
+        loop.close()

--- a/src/tests/security/test_aio_cache_fetch_controls.py
+++ b/src/tests/security/test_aio_cache_fetch_controls.py
@@ -1,0 +1,393 @@
+"""Fail-closed controls for the async cache fetch paths (T299).
+
+T299 instrumented the three module-level singleton cache functions in
+``py_identity_model.aio.token_validation`` with observability counters:
+``_get_disco_response``, ``_get_cached_jwks`` and ``_refresh_jwks``. These are
+security-gated (``tools/mutation_security.py``). This module pins the
+security-relevant behaviour of those functions so a regression cannot silently:
+
+* drop the HTTPS scheme enforcement (policy default flip / ``policy=None`` /
+  dropped ``policy`` kwarg) — an SSRF / HTTPS->HTTP downgrade,
+* stop threading the caller's ``require_https`` through to ``get_jwks`` — a
+  legitimate ``require_https=False`` fetch would break,
+* drop the ``cooldown`` sidecar cleanup on eviction — an unbounded-growth
+  memory leak keyed by attacker-controlled URIs,
+* lose the double-checked-lock cache hit / LRU-recency refresh — cache-stampede
+  and hot-entry-eviction regressions (#397),
+* break the empty-keys retained-cache fallback (``and``->``or``) or the
+  refresh coalescing guard (``>=``->``>``).
+
+The double-checked-hit branch is normally only reachable under concurrency
+(one coroutine populates the entry while another waits on the fetch lock). We
+reach it deterministically instead by stubbing ``is_cache_expired`` to report
+the pre-seeded entry as *expired* on the lock-free fast-path check and *fresh*
+on the under-lock re-check — exactly the state a concurrent populate produces.
+"""
+
+import time
+from unittest.mock import Mock
+
+import httpx
+import pytest
+import respx
+
+from py_identity_model import get_cache_counters
+from py_identity_model.aio import token_validation as aio_tv
+from py_identity_model.aio.token_validation import (
+    _get_cached_jwks,
+    _get_disco_response,
+    _refresh_jwks,
+    clear_discovery_cache,
+    clear_jwks_cache,
+)
+from py_identity_model.core.jwks_cache import (
+    DiscoCacheEntry,
+    JwksCacheEntry,
+    _reset_env_for_testing,
+)
+from py_identity_model.core.models import (
+    DiscoveryDocumentResponse,
+    JwksResponse,
+)
+from py_identity_model.core.parsers import jwks_from_dict
+from py_identity_model.exceptions import ConfigurationException
+
+from ..unit.token_validation_helpers import generate_rsa_keypair
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+async def _clean_state():
+    """Reset all shared module-global cache state + counters between tests."""
+    await clear_discovery_cache()
+    await clear_jwks_cache()
+    aio_tv._kid_miss_last_attempt.clear()
+    get_cache_counters().reset()
+    _reset_env_for_testing()
+    yield
+    await clear_discovery_cache()
+    await clear_jwks_cache()
+    aio_tv._kid_miss_last_attempt.clear()
+    get_cache_counters().reset()
+    _reset_env_for_testing()
+
+
+# Generate ONE RSA keypair for the whole module. These tests exercise cache /
+# counter / single-flight behaviour and never verify a signature, so the key
+# content is irrelevant — any valid JWK works. Generating per-test would add
+# ~15 RSA-2048 keygens of CPU contention under ``-n auto``, which is enough to
+# slow the wall-clock-sensitive kid-miss-cooldown tests past their 5s window.
+_KEY_DICT, _ = generate_rsa_keypair()
+
+
+def _jwk():
+    return jwks_from_dict(_KEY_DICT)
+
+
+def _jwks_resp(keys):
+    return JwksResponse(is_successful=True, keys=keys)
+
+
+def _disco_resp(issuer="https://opx.example"):
+    return DiscoveryDocumentResponse(is_successful=True, issuer=issuer)
+
+
+# ---------------------------------------------------------------------------
+# Scheme enforcement (SSRF / HTTPS->HTTP downgrade)
+# ---------------------------------------------------------------------------
+
+
+class TestSchemeEnforcement:
+    """A plaintext ``http://`` JWKS endpoint must be rejected under the default
+    (``require_https`` omitted) policy, and only fetched when the caller
+    explicitly relaxes the policy — pinning the ``require_https`` default and
+    the policy thread-through against flip / ``None`` / dropped-kwarg mutants."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_cached_jwks_default_rejects_plaintext_http(self):
+        route = respx.get("http://op.example/jwks").mock(
+            return_value=httpx.Response(
+                200,
+                json={"keys": [_KEY_DICT]},
+                headers={"Cache-Control": "max-age=3600"},
+            )
+        )
+        # Default require_https=True -> plaintext non-loopback HTTP is rejected
+        # by the pre-flight scheme check inside get_jwks BEFORE any network I/O.
+        result = await _get_cached_jwks("http://op.example/jwks")
+        assert result.is_successful is False
+        assert route.call_count == 0
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_refresh_default_rejects_plaintext_http(self):
+        route = respx.get("http://op.example/jwks").mock(
+            return_value=httpx.Response(
+                200,
+                json={"keys": [_KEY_DICT]},
+                headers={"Cache-Control": "max-age=3600"},
+            )
+        )
+        response, from_retained = await _refresh_jwks("http://op.example/jwks")
+        assert response.is_successful is False
+        assert from_retained is False
+        assert route.call_count == 0
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_refresh_threads_require_https_false_allows_http(self):
+        key = _KEY_DICT
+        route = respx.get("http://op.example/jwks").mock(
+            return_value=httpx.Response(
+                200,
+                json={"keys": [key]},
+                headers={"Cache-Control": "max-age=3600"},
+            )
+        )
+        # Caller explicitly opts out of HTTPS; the policy MUST be threaded
+        # through to get_jwks (not dropped/None, which would re-impose the
+        # strict default and reject this legitimate fetch).
+        response, _ = await _refresh_jwks("http://op.example/jwks", require_https=False)
+        assert response.is_successful is True
+        assert response.keys
+        assert route.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Cooldown sidecar eviction (unbounded-growth / memory leak)
+# ---------------------------------------------------------------------------
+
+
+class TestCooldownSidecarEviction:
+    """When the JWKS cache evicts an entry, its ``_kid_miss_last_attempt``
+    cooldown sidecar entry must be evicted too. Dropping the ``cooldown`` kwarg
+    (or passing ``None``) leaks the sidecar unboundedly under attacker-driven
+    distinct-URI churn even though the cache itself is bounded."""
+
+    def _seed(self, monkeypatch, old_uri):
+        monkeypatch.setenv("JWKS_CACHE_MAX_ENTRIES", "1")
+        _reset_env_for_testing()
+        aio_tv._jwks_cache[old_uri] = JwksCacheEntry(
+            response=_jwks_resp([_jwk()]),
+            cached_at=time.monotonic(),
+            ttl=1e9,
+        )
+        aio_tv._kid_miss_last_attempt[old_uri] = 123.0
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_cached_jwks_eviction_clears_cooldown(self, monkeypatch):
+        old_uri = "https://old.example/jwks"
+        new_uri = "https://new.example/jwks"
+        self._seed(monkeypatch, old_uri)
+        respx.get(new_uri).mock(
+            return_value=httpx.Response(
+                200,
+                json={"keys": [_KEY_DICT]},
+                headers={"Cache-Control": "max-age=3600"},
+            )
+        )
+        await _get_cached_jwks(new_uri)
+        # old_uri was evicted (max=1); its cooldown sidecar entry must be gone.
+        assert old_uri not in aio_tv._jwks_cache
+        assert old_uri not in aio_tv._kid_miss_last_attempt
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_refresh_eviction_clears_cooldown(self, monkeypatch):
+        old_uri = "https://old.example/jwks"
+        new_uri = "https://new.example/jwks"
+        self._seed(monkeypatch, old_uri)
+        respx.get(new_uri).mock(
+            return_value=httpx.Response(
+                200,
+                json={"keys": [_KEY_DICT]},
+                headers={"Cache-Control": "max-age=3600"},
+            )
+        )
+        await _refresh_jwks(new_uri)
+        assert old_uri not in aio_tv._jwks_cache
+        assert old_uri not in aio_tv._kid_miss_last_attempt
+
+
+# ---------------------------------------------------------------------------
+# _refresh_jwks empty-keys fallback + coalescing guard
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshSemantics:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_empty_refresh_does_not_falsely_fall_back(self):
+        """``and``->``or`` guard: a retained entry with EMPTY keys must NOT be
+        surfaced as a fallback. Only a retained entry with real keys does.
+
+        Original: ``retained is not None and retained.response.keys`` -> the
+        empty retained entry is falsy -> no fallback -> returns the empty
+        upstream response with ``from_retained=False``. The mutated ``or`` would
+        fall back and mislabel it ``from_retained=True``.
+        """
+        uri = "https://op.example/jwks"
+        aio_tv._jwks_cache[uri] = JwksCacheEntry(
+            response=_jwks_resp([]),  # retained but EMPTY
+            cached_at=time.monotonic() - 1000.0,  # old -> not coalesced
+            ttl=1e9,
+        )
+        respx.get(uri).mock(return_value=httpx.Response(200, json={"keys": []}))
+
+        response, from_retained = await _refresh_jwks(uri)
+        assert from_retained is False
+        assert (response.keys or []) == []
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_refresh_coalesces_on_equal_timestamp(self, monkeypatch):
+        """``>=``->``>`` guard: when a concurrent refresh already wrote an entry
+        whose ``cached_at`` equals this refresh's ``request_time`` (captured
+        inside the lock), this call must coalesce and return WITHOUT issuing an
+        upstream fetch. Forcing ``time.monotonic()`` to the entry's exact
+        ``cached_at`` exercises the boundary the ``>=`` protects."""
+        uri = "https://op.example/jwks"
+        seeded = _jwks_resp([_jwk()])
+        fixed_t = 5000.0
+        aio_tv._jwks_cache[uri] = JwksCacheEntry(
+            response=seeded, cached_at=fixed_t, ttl=1e9
+        )
+        route = respx.get(uri).mock(
+            return_value=httpx.Response(
+                200,
+                json={"keys": [_KEY_DICT]},
+                headers={"Cache-Control": "max-age=3600"},
+            )
+        )
+        monkeypatch.setattr(aio_tv.time, "monotonic", lambda: fixed_t)
+
+        response, from_retained = await _refresh_jwks(uri)
+        assert response is seeded
+        assert from_retained is False
+        assert route.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Discovery required-address error message
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoRequiredAddress:
+    @pytest.mark.asyncio
+    async def test_none_address_raises_with_actionable_message(self):
+        with pytest.raises(ConfigurationException) as exc:
+            await _get_disco_response(None)
+        assert (
+            str(exc.value) == "disco_doc_address is required when perform_disco is True"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Double-checked-lock hit + LRU recency (cache stampede / hot-entry eviction)
+# ---------------------------------------------------------------------------
+
+
+def _expired_then_fresh():
+    """is_cache_expired stub: True on the fast-path check (entry looks stale),
+    False on the under-lock re-check (entry is fresh) — the exact state a
+    concurrent populate leaves for the second coroutine."""
+    return Mock(side_effect=[True, False])
+
+
+class TestDoubleCheckedLockAndLru:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_disco_double_checked_hit_refreshes_recency(self, monkeypatch):
+        """The under-lock double-checked hit returns the cached response with NO
+        upstream fetch and refreshes LRU recency (moves the key to MRU).
+
+        Kills: under-lock ``entry=None`` / ``get(None)`` (would re-fetch),
+        ``touch_cache_entry`` arg mutations that raise, and the no-op
+        ``touch(cache, None)`` (recency would not move).
+        """
+        addr_x = "https://opx.example/.well-known/openid-configuration"
+        addr_y = "https://opy.example/.well-known/openid-configuration"
+        key_x = (addr_x, True)
+        key_y = (addr_y, True)
+        resp_x = _disco_resp("https://opx.example")
+        # Seed order: x (oldest) then y (newest).
+        aio_tv._disco_cache[key_x] = DiscoCacheEntry(
+            response=resp_x, cached_at=time.monotonic(), ttl=1e9
+        )
+        aio_tv._disco_cache[key_y] = DiscoCacheEntry(
+            response=_disco_resp("https://opy.example"),
+            cached_at=time.monotonic(),
+            ttl=1e9,
+        )
+        route = respx.get(addr_x).mock(
+            return_value=httpx.Response(200, json={"issuer": "https://opx.example"})
+        )
+        monkeypatch.setattr(aio_tv, "is_cache_expired", _expired_then_fresh())
+
+        result = await _get_disco_response(addr_x)
+
+        assert result is resp_x  # served from cache, exact object
+        assert route.call_count == 0  # no upstream fetch
+        # x moved to MRU (end); y is now the LRU-first entry.
+        assert list(aio_tv._disco_cache.keys()) == [key_y, key_x]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_disco_fast_path_hit_refreshes_recency(self, monkeypatch):
+        """The lock-free fast-path hit refreshes LRU recency. Kills the
+        fast-path ``touch(cache, None)`` no-op (hot entry would not move and
+        an attacker reading distinct addresses could evict it)."""
+        addr_x = "https://opx.example/.well-known/openid-configuration"
+        addr_y = "https://opy.example/.well-known/openid-configuration"
+        key_x = (addr_x, True)
+        key_y = (addr_y, True)
+        resp_x = _disco_resp("https://opx.example")
+        aio_tv._disco_cache[key_x] = DiscoCacheEntry(
+            response=resp_x, cached_at=time.monotonic(), ttl=1e9
+        )
+        aio_tv._disco_cache[key_y] = DiscoCacheEntry(
+            response=_disco_resp("https://opy.example"),
+            cached_at=time.monotonic(),
+            ttl=1e9,
+        )
+        route = respx.get(addr_x).mock(
+            return_value=httpx.Response(200, json={"issuer": "https://opx.example"})
+        )
+        # Fresh on the fast path -> fast-path hit taken.
+        monkeypatch.setattr(aio_tv, "is_cache_expired", Mock(side_effect=[False]))
+
+        result = await _get_disco_response(addr_x)
+
+        assert result is resp_x
+        assert route.call_count == 0
+        assert list(aio_tv._disco_cache.keys()) == [key_y, key_x]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_jwks_double_checked_hit_refreshes_recency(self, monkeypatch):
+        """Async twin of the disco double-checked-hit test for
+        ``_get_cached_jwks`` — kills the no-op ``touch(cache, None)`` on the
+        under-lock double-checked-hit branch."""
+        uri_x = "https://opx.example/jwks"
+        uri_y = "https://opy.example/jwks"
+        resp_x = _jwks_resp([_jwk()])
+        aio_tv._jwks_cache[uri_x] = JwksCacheEntry(
+            response=resp_x, cached_at=time.monotonic(), ttl=1e9
+        )
+        aio_tv._jwks_cache[uri_y] = JwksCacheEntry(
+            response=_jwks_resp([_jwk()]), cached_at=time.monotonic(), ttl=1e9
+        )
+        route = respx.get(uri_x).mock(
+            return_value=httpx.Response(200, json={"keys": []})
+        )
+        monkeypatch.setattr(aio_tv, "is_cache_expired", _expired_then_fresh())
+
+        result = await _get_cached_jwks(uri_x)
+
+        assert result is resp_x
+        assert route.call_count == 0
+        assert list(aio_tv._jwks_cache.keys()) == [uri_y, uri_x]

--- a/src/tests/security/test_aio_cache_fetch_controls.py
+++ b/src/tests/security/test_aio_cache_fetch_controls.py
@@ -120,6 +120,10 @@ class TestSchemeEnforcement:
         result = await _get_cached_jwks("http://op.example/jwks")
         assert result.is_successful is False
         assert route.call_count == 0
+        # Fail-closed observability: a scheme-rejected request issues zero
+        # upstream work, so it MUST NOT bump the upstream-fetch miss counter
+        # (else an attacker inflates the miss rate with forged http:// URIs).
+        assert get_cache_counters().snapshot()["jwks_misses"] == 0
 
     @respx.mock
     @pytest.mark.asyncio
@@ -135,6 +139,26 @@ class TestSchemeEnforcement:
         assert response.is_successful is False
         assert from_retained is False
         assert route.call_count == 0
+        # Fail-closed: a scheme-rejected refresh does zero upstream work, so the
+        # refresh (upstream re-fetch) counter MUST NOT increment.
+        assert get_cache_counters().snapshot()["jwks_refreshes"] == 0
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_disco_default_rejects_plaintext_http(self):
+        route = respx.get("http://op.example/.well-known/openid-configuration").mock(
+            return_value=httpx.Response(200, json={"issuer": "http://op.example"})
+        )
+        # Default require_https=True -> plaintext non-loopback HTTP disco is
+        # rejected by the pre-flight scheme check BEFORE any network I/O.
+        result = await _get_disco_response(
+            "http://op.example/.well-known/openid-configuration"
+        )
+        assert result.is_successful is False
+        assert route.call_count == 0
+        # Fail-closed: a scheme-rejected disco request does zero upstream work,
+        # so the disco miss (upstream-fetch) counter MUST NOT increment.
+        assert get_cache_counters().snapshot()["disco_misses"] == 0
 
     @respx.mock
     @pytest.mark.asyncio
@@ -154,6 +178,8 @@ class TestSchemeEnforcement:
         assert response.is_successful is True
         assert response.keys
         assert route.call_count == 1
+        # An upstream fetch WAS issued, so the refresh counter increments.
+        assert get_cache_counters().snapshot()["jwks_refreshes"] == 1
 
 
 # ---------------------------------------------------------------------------

--- a/src/tests/unit/test_cache_metrics.py
+++ b/src/tests/unit/test_cache_metrics.py
@@ -1,0 +1,230 @@
+# ruff: noqa: PLR2004
+"""Unit tests for the per-process cache observability counters.
+
+Covers :class:`CacheCounters` in isolation (every ``record_*`` method,
+``snapshot`` detachment, ``reset``, thread-safety smoke) and its integration
+with the async discovery/JWKS cache paths, asserting exact hit/miss/refresh
+transitions across warm/cold/refresh scenarios.
+"""
+
+import threading
+
+import httpx
+import pytest
+import respx
+
+from py_identity_model import CacheCounters, get_cache_counters
+from py_identity_model.aio.token_validation import (
+    _get_cached_jwks,
+    _get_disco_response,
+    _refresh_jwks,
+    clear_discovery_cache,
+    clear_jwks_cache,
+)
+from py_identity_model.core.cache_metrics import CACHE_COUNTERS
+
+from .token_validation_helpers import (
+    DISCO_RESPONSE_WITH_JWKS,
+    generate_rsa_keypair,
+)
+
+
+# ============================================================================
+# CacheCounters in isolation
+# ============================================================================
+
+
+class TestCacheCountersUnit:
+    """Exercise every CacheCounters method without any cache I/O."""
+
+    def test_starts_at_zero(self):
+        counters = CacheCounters()
+        assert counters.snapshot() == {
+            "disco_hits": 0,
+            "disco_misses": 0,
+            "jwks_hits": 0,
+            "jwks_misses": 0,
+            "jwks_refreshes": 0,
+        }
+
+    def test_record_disco_hit(self):
+        counters = CacheCounters()
+        counters.record_disco_hit()
+        counters.record_disco_hit()
+        assert counters.snapshot()["disco_hits"] == 2
+
+    def test_record_disco_miss(self):
+        counters = CacheCounters()
+        counters.record_disco_miss()
+        assert counters.snapshot()["disco_misses"] == 1
+
+    def test_record_jwks_hit(self):
+        counters = CacheCounters()
+        counters.record_jwks_hit()
+        counters.record_jwks_hit()
+        counters.record_jwks_hit()
+        assert counters.snapshot()["jwks_hits"] == 3
+
+    def test_record_jwks_miss(self):
+        counters = CacheCounters()
+        counters.record_jwks_miss()
+        assert counters.snapshot()["jwks_misses"] == 1
+
+    def test_record_jwks_refresh(self):
+        counters = CacheCounters()
+        counters.record_jwks_refresh()
+        counters.record_jwks_refresh()
+        assert counters.snapshot()["jwks_refreshes"] == 2
+
+    def test_each_counter_is_independent(self):
+        counters = CacheCounters()
+        counters.record_disco_hit()
+        counters.record_disco_miss()
+        counters.record_jwks_hit()
+        counters.record_jwks_miss()
+        counters.record_jwks_refresh()
+        assert counters.snapshot() == {
+            "disco_hits": 1,
+            "disco_misses": 1,
+            "jwks_hits": 1,
+            "jwks_misses": 1,
+            "jwks_refreshes": 1,
+        }
+
+    def test_snapshot_is_detached_copy(self):
+        counters = CacheCounters()
+        counters.record_disco_hit()
+        snap = counters.snapshot()
+        # Mutating the snapshot must not touch the live counters...
+        snap["disco_hits"] = 999
+        assert counters.snapshot()["disco_hits"] == 1
+        # ...and the live counters advancing must not touch an old snapshot.
+        counters.record_disco_hit()
+        assert snap["disco_hits"] == 999
+
+    def test_reset_zeros_every_counter(self):
+        counters = CacheCounters()
+        counters.record_disco_hit()
+        counters.record_disco_miss()
+        counters.record_jwks_hit()
+        counters.record_jwks_miss()
+        counters.record_jwks_refresh()
+        counters.reset()
+        assert counters.snapshot() == {
+            "disco_hits": 0,
+            "disco_misses": 0,
+            "jwks_hits": 0,
+            "jwks_misses": 0,
+            "jwks_refreshes": 0,
+        }
+
+    def test_concurrent_increments_are_not_lost(self):
+        """Thread-safety smoke: N threads each incrementing must total N*loops."""
+        counters = CacheCounters()
+        threads_count = 8
+        per_thread = 1000
+
+        def worker():
+            for _ in range(per_thread):
+                counters.record_jwks_hit()
+
+        threads = [threading.Thread(target=worker) for _ in range(threads_count)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert counters.snapshot()["jwks_hits"] == threads_count * per_thread
+
+
+class TestCacheCountersSingleton:
+    """The module singleton is shared and reachable from the public surface."""
+
+    def test_get_cache_counters_returns_singleton(self):
+        assert get_cache_counters() is CACHE_COUNTERS
+        assert get_cache_counters() is get_cache_counters()
+
+    def test_singleton_is_a_cache_counters(self):
+        assert isinstance(get_cache_counters(), CacheCounters)
+
+
+# ============================================================================
+# Integration with the async cache paths
+# ============================================================================
+
+DISCO_URL = "https://example.com/.well-known/openid-configuration"
+JWKS_URL = "https://example.com/jwks"
+
+
+@pytest.fixture
+async def _clean_cache_state():
+    """Reset caches and counters around each async integration test."""
+    await clear_discovery_cache()
+    await clear_jwks_cache()
+    get_cache_counters().reset()
+    yield
+    await clear_discovery_cache()
+    await clear_jwks_cache()
+    get_cache_counters().reset()
+
+
+@pytest.mark.usefixtures("_clean_cache_state")
+class TestCacheCountersIntegration:
+    """Drive the real async cache functions and assert exact counter moves."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_disco_miss_then_hit(self):
+        route = respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+
+        # First call: cold cache → upstream fetch → one miss, no hits.
+        await _get_disco_response(DISCO_URL)
+        snap = get_cache_counters().snapshot()
+        assert snap["disco_misses"] == 1
+        assert snap["disco_hits"] == 0
+
+        # Second call: fresh entry → hit, no additional upstream fetch.
+        await _get_disco_response(DISCO_URL)
+        snap = get_cache_counters().snapshot()
+        assert snap["disco_misses"] == 1
+        assert snap["disco_hits"] == 1
+        assert route.call_count == 1  # the hit did NOT hit the network
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_jwks_miss_then_hit(self):
+        key_dict, _pem = generate_rsa_keypair()
+        route = respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(200, json={"keys": [key_dict]})
+        )
+
+        await _get_cached_jwks(JWKS_URL)
+        snap = get_cache_counters().snapshot()
+        assert snap["jwks_misses"] == 1
+        assert snap["jwks_hits"] == 0
+
+        await _get_cached_jwks(JWKS_URL)
+        snap = get_cache_counters().snapshot()
+        assert snap["jwks_misses"] == 1
+        assert snap["jwks_hits"] == 1
+        assert route.call_count == 1
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_refresh_counts_upstream_fetch(self):
+        key_dict, _pem = generate_rsa_keypair()
+        respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(200, json={"keys": [key_dict]})
+        )
+
+        # Prime the cache (miss), then force a refresh (key rotation).
+        await _get_cached_jwks(JWKS_URL)
+        assert get_cache_counters().snapshot()["jwks_refreshes"] == 0
+
+        await _refresh_jwks(JWKS_URL)
+        snap = get_cache_counters().snapshot()
+        assert snap["jwks_refreshes"] == 1
+        # A refresh is an upstream re-fetch, not a hit.
+        assert snap["jwks_hits"] == 0

--- a/src/tests/unit/test_kid_miss_cooldown.py
+++ b/src/tests/unit/test_kid_miss_cooldown.py
@@ -42,6 +42,7 @@ from py_identity_model.aio.token_validation import (
 )
 from py_identity_model.core.jwks_cache import (
     DEFAULT_KID_MISS_REFRESH_COOLDOWN_SECONDS,
+    MAX_KID_MISS_COOLDOWN_SECONDS,
     JwksCacheEntry,
     _reset_env_for_testing,
     apply_jwks_cache_outcome,
@@ -107,6 +108,26 @@ def _sign_unknown_kid_token(kid: str) -> str:
         {"sub": "attacker", "iss": "https://example.com"},
         headers={"kid": kid},
     )
+
+
+def _pin_cooldown_high(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the kid-miss cooldown to the maximum so ``EXPECTED_FETCH_COUNT``
+    assertions are independent of wall-clock time.
+
+    The cooldown is measured against real ``time.monotonic()``. The
+    amplification/isolation tests below fire a 25-request attacker loop and
+    assert exactly one prime + one forced refresh — which only holds if the
+    whole loop completes inside the cooldown window. With the 5s default and
+    a per-request RSA keygen, under ``pytest -n auto`` CPU contention the loop
+    can outlast 5s and a second refresh fires, flaking the count. Pinning to
+    the max (well above any loop duration) removes the timing dependency
+    without weakening what the test proves (that the cooldown coalesces a
+    burst into a single refresh). ``_reset_env_for_testing`` clears the memo
+    so the new value is read; ``monkeypatch`` reverts the env at teardown and
+    the autouse fixture resets the memo again.
+    """
+    monkeypatch.setenv("KID_MISS_REFRESH_COOLDOWN", str(MAX_KID_MISS_COOLDOWN_SECONDS))
+    _reset_env_for_testing()
 
 
 # ============================================================================
@@ -176,7 +197,8 @@ EXPECTED_FETCH_COUNT = 2  # 1 prime + 1 refresh inside cooldown window
 
 class TestKidMissCooldownBoundsAmplification:
     @respx.mock
-    def test_sync_cooldown_caps_fetches_under_attack(self):
+    def test_sync_cooldown_caps_fetches_under_attack(self, monkeypatch):
+        _pin_cooldown_high(monkeypatch)
         defender_key_dict, _defender_pem = generate_rsa_keypair()
         defender_key_dict["kid"] = "defender-kid"
 
@@ -213,7 +235,8 @@ class TestKidMissCooldownBoundsAmplification:
 
     @pytest.mark.asyncio
     @respx.mock
-    async def test_async_cooldown_caps_fetches_under_attack(self):
+    async def test_async_cooldown_caps_fetches_under_attack(self, monkeypatch):
+        _pin_cooldown_high(monkeypatch)
         defender_key_dict, _defender_pem = generate_rsa_keypair()
         defender_key_dict["kid"] = "defender-kid"
 
@@ -365,7 +388,8 @@ class TestCooldownDoesNotBlockLegitimateTraffic:
 
 class TestCooldownIsolationAcrossIssuers:
     @respx.mock
-    def test_per_issuer_cooldown_does_not_cross_contaminate(self):
+    def test_per_issuer_cooldown_does_not_cross_contaminate(self, monkeypatch):
+        _pin_cooldown_high(monkeypatch)
         other_disco_url = "https://other.example/.well-known/openid-configuration"
         other_jwks_url = "https://other.example/jwks"
         other_disco_response = {

--- a/tools/mutation_security_allowlist.txt
+++ b/tools/mutation_security_allowlist.txt
@@ -22,3 +22,37 @@
 # below is never reached. No input that reaches the else branch can observe []
 # vs None: semantically equivalent, unkillable.
 py_identity_model.core.token_validation_logic.x__enforce_allowed_issuers__mutmut_6
+
+# ── T299 cache-observability counters (aio.token_validation) ──────────────────
+#
+# Lock-stripe distribution (class 2): ``_get_*_fetch_lock(None)`` makes
+# ``hash(None) % STRIPES`` pick one fixed valid stripe instead of hashing the
+# URI/key. Single-flight correctness is unaffected — same-URI fetches still
+# serialise on the same lock object — only which of the 32 stripes is selected
+# changes, which is not observable.
+py_identity_model.aio.token_validation.x__get_disco_response__mutmut_19
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_3
+
+# Log-only (class 1): message-text / logger-arg mutations of the "Forcing JWKS
+# refresh" info line (11-17) and the empty-keys retained-cache fallback info
+# line (42-52). These are human-readable log strings, not security controls;
+# they change no control flow, return value, or counter. Asserting exact log
+# text is brittle and out of scope.
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_11
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_12
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_13
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_14
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_15
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_16
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_17
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_42
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_43
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_44
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_45
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_46
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_47
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_48
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_49
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_50
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_51
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_52


### PR DESCRIPTION
## Summary
Foundation fixups for the E2E Token-Blaster harness (design §8 P0 — unblocks T311's cache-hit-rate metric). Three deliverables:

- **Per-process cache observability counters** (`core/cache_metrics.py`): dependency-free, thread-safe `CacheCounters` singleton tracking disco/JWKS hit/miss and JWKS refresh. `get_cache_counters().snapshot()` surface; increments are O(1) under a leaf lock and never wrap I/O.
- **Instrumented the async cache path** (`aio/token_validation.py`): `_get_disco_response`, `_get_cached_jwks`, `_refresh_jwks` now record hit/miss/refresh. Miss/refresh counted **only on a successful upstream fetch** — scheme-rejected (zero-I/O) requests do not inflate the tally (fail-closed).
- **Warm-path micro-benchmark** (`src/tests/benchmarks/`): `test_bench_validate_token_warm_path` benches the true warm request path (disco hit + JWKS hit + decode), not just raw `pyjwt.decode`.
- **Corrected `docs/performance.md`**: the caching section documented `functools.lru_cache`/`async_lru.alru_cache(maxsize=128)` + `cache_info()`/`cache_clear()` APIs that no longer exist. Rewritten to the real TTL-`OrderedDict` LRU stack (64-entry LRU, 32-stripe single-flight, per-URI kid-miss cooldown, per-loop `WeakKeyDictionary` locks, `async clear_*_cache()`) plus the new counters surface.

Refs epic #462 (TH-1 foundation, design §8 P0).

## Review Findings Addressed
Reviewers: Blind + Edge + Acceptance + Sentinel + Viper.
- **P0: 0**
- **P1: 3** (Blind ×3 / Edge ×2, same root cause) — miss/refresh counters were incremented *before* the upstream fetch, so a scheme-rejected zero-I/O request inflated the miss/upstream-fetch tally. **Fixed** (commit 003724c): gate the increments on `response.is_successful`; docstring aligned; 3 fail-closed tests added (scheme-rejected disco/JWKS/refresh assert counter stays 0; positive control asserts refresh==1).
- **P2: 2** NITPICK (annotation-position `threading.Lock`; dataclass eq-by-value on a singleton) — skipped per triage (pyrefly passes; cosmetic on a process singleton).
- Acceptance: 4/4 AC PASS · Sentinel: 0 BLOCK/0 WARN (20 mutation waivers independently verified benign) · Viper: 0 findings.
- Mechanical `make security-gate`: **PASSED** — 140 mutants in changed functions all killed or waived-equivalent.

## Test plan
- [x] Unit tests pass (`test_cache_metrics.py` drives the real async cache funcs via respx; 27 targeted passed)
- [x] Security fail-closed suite passes (`test_aio_cache_fetch_controls.py`)
- [x] `[skip-integration-tests: per-process observability library fix; no real-IdP behavior to prove E2E — design note mandates "test = unit + the new micro-bench"]`
- [x] Warm-path micro-benchmark added
- [x] Lint passes (`make lint`: ruff/format/pyrefly/coverage green)
- [x] Mechanical security-gate passes (mutation testing on changed security modules)
- [x] Independent review agents passed (5 reviewers, 1 fix iteration)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)