### PR TITLE
test(harness): unified multi-provider TokenSource minter + mock OP + forged corpus (TH-1.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,10 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "src/tests/**/*.py" = ["S101"]   # 1858 assert violations — all test assertions, 0 in production code
+"src/tests/harness/**/*.py" = [
+    "S101",    # pytest assertions
+    "PLR0913", # minter / mock-OP APIs are intentionally parameter-rich (mint, sign, mint_access_token)
+]
 "examples/**/*.py" = ["S101"]    # 73 assert violations in example integration tests
 "packages/**/tests/**/*.py" = [
     "S101",    # pytest assertions

--- a/src/tests/harness/__init__.py
+++ b/src/tests/harness/__init__.py
@@ -1,0 +1,51 @@
+"""Token-blaster harness shared infrastructure (epic #462, TH-1.1..TH-1.5).
+
+A single home for the pieces T300/T301/T311 share:
+
+* :class:`TokenSource` — the unified multi-provider minter (``mint``) plus the
+  pre-minted :class:`ReplayPool`.
+* :class:`MockOP` — a controllable, framework-free ASGI OpenID Provider holding
+  a known signing key (valid tokens, forged corpus, T311 failure injection).
+* :func:`build_corpus` — the forged / negative token corpus.
+"""
+
+from __future__ import annotations
+
+from .corpus import CORPUS_AUDIENCE, ForgedToken, build_corpus
+from .mock_op import MockOP, MockOPControls, SigningKey
+from .token_source import (
+    Grant,
+    HarnessCapabilityError,
+    HarnessCredentialError,
+    HarnessError,
+    Malform,
+    MintedToken,
+    MintSpec,
+    Provider,
+    ProviderConfig,
+    ReplayPool,
+    TokenSource,
+    prime_pool,
+)
+
+
+__all__ = [
+    "CORPUS_AUDIENCE",
+    "ForgedToken",
+    "Grant",
+    "HarnessCapabilityError",
+    "HarnessCredentialError",
+    "HarnessError",
+    "Malform",
+    "MintSpec",
+    "MintedToken",
+    "MockOP",
+    "MockOPControls",
+    "Provider",
+    "ProviderConfig",
+    "ReplayPool",
+    "SigningKey",
+    "TokenSource",
+    "build_corpus",
+    "prime_pool",
+]

--- a/src/tests/harness/corpus.py
+++ b/src/tests/harness/corpus.py
@@ -1,0 +1,194 @@
+"""Forged / negative token corpus for the token-blaster harness (TH-1.1).
+
+Real OPs will not emit invalid tokens and node-oidc's keys are ephemeral and
+not exported, so the negative corpus is forged off the *known* signing key of
+the controllable :class:`~mock_op.MockOP` (design §3).
+
+Each :class:`ForgedToken` records ``library_rejects`` — whether
+:func:`py_identity_model.aio.validate_token` (signature + ``iss``/``aud``/``exp``
+checks) rejects it. Note the distinction from *resource-server* policy, which
+is T302's concern:
+
+* ``id_as_access`` and ``cnf_bound`` are *validly signed JWTs for the audience*
+  — the library ACCEPTS them; only the RS access-token marker / ``require_scope``
+  layer (F-07 / F-02) distinguishes them. They therefore carry
+  ``library_rejects=False`` here.
+* ``oversized`` / ``multi_aud_untrusted`` are likewise valid to the library.
+
+Real-issuer negatives that cannot be forged (a real OP signing an expired token
+with its real key) reuse the committed expired tokens + cross-provider
+``kid``-mismatch already in the integration suite.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import time
+from typing import TYPE_CHECKING, Any
+
+import jwt
+
+
+if TYPE_CHECKING:
+    from .mock_op import MockOP
+
+
+CORPUS_AUDIENCE = "mock-api"
+
+
+@dataclass(frozen=True)
+class ForgedToken:
+    """A single corpus entry.
+
+    Attributes:
+        name: Stable class name (matches a :class:`~token_source.Malform` value).
+        jwt: The compact-serialized token.
+        description: What makes it invalid (or, for accepted classes, why the
+            library accepts it despite RS-layer policy rejecting it).
+        library_rejects: Whether ``aio.validate_token`` rejects it outright.
+    """
+
+    name: str
+    jwt: str
+    description: str
+    library_rejects: bool
+
+
+def _base_claims(mock_op: MockOP, now: int, *, audience: Any = CORPUS_AUDIENCE) -> dict:
+    return {
+        "iss": mock_op.issuer,
+        "sub": "mock-subject",
+        "aud": audience,
+        "iat": now,
+        "nbf": now,
+        "exp": now + 300,
+        "client_id": "mock-client",
+        "scope": "read",
+    }
+
+
+def _tamper_signature(token: str) -> str:
+    """Flip the *first* character of the signature segment (invalid signature).
+
+    The first base64url character carries fully-significant bits, so flipping it
+    always changes the decoded signature bytes. (The *last* character of an
+    RSA-2048 signature encodes only 2 significant bits plus 4 discard bits, so
+    flipping it can decode to identical bytes and leave the signature valid.)
+    """
+    header, payload, signature = token.split(".")
+    flipped = "B" if signature[0] != "B" else "C"
+    return f"{header}.{payload}.{flipped}{signature[1:]}"
+
+
+def build_corpus(mock_op: MockOP) -> dict[str, ForgedToken]:
+    """Build the full forged corpus keyed to *mock_op*'s known signing key."""
+    now = int(time.time())
+    entries: list[ForgedToken] = []
+
+    def add(name: str, token: str, description: str, *, rejects: bool) -> None:
+        entries.append(ForgedToken(name, token, description, rejects))
+
+    # -- Accepted by the library (signature + iss + aud + exp all valid) -----
+    add(
+        "valid",
+        mock_op.sign(_base_claims(mock_op, now)),
+        "well-formed token signed by a published key",
+        rejects=False,
+    )
+    id_claims = _base_claims(mock_op, now)
+    id_claims.pop("scope")
+    id_claims.pop("client_id")
+    id_claims["nonce"] = "n-abc"
+    add(
+        "id_as_access",
+        mock_op.sign(id_claims),
+        "ID-token-shaped (no scope/client_id) presented as a bearer access "
+        "token — library accepts; RS marker (F-07) must reject",
+        rejects=False,
+    )
+    cnf_claims = _base_claims(mock_op, now)
+    cnf_claims["cnf"] = {"jkt": "0ZcOCORZNYy-DWpqq30jZyJGHTN0d2HglBV3uiguA4I"}
+    add(
+        "cnf_bound",
+        mock_op.sign(cnf_claims),
+        "DPoP/mTLS cnf-bound token presented as a plain bearer — library "
+        "accepts (F-02 accepted-today contract; do not assume rejection)",
+        rejects=False,
+    )
+    big_claims = _base_claims(mock_op, now)
+    for i in range(200):
+        big_claims[f"pad_{i}"] = "x" * 64
+    add(
+        "oversized",
+        mock_op.sign(big_claims),
+        "valid token bloated with 200 padding claims (resource-exhaustion probe)",
+        rejects=False,
+    )
+    multi_aud = _base_claims(mock_op, now, audience=[CORPUS_AUDIENCE, "urn:untrusted"])
+    add(
+        "multi_aud_untrusted",
+        mock_op.sign(multi_aud),
+        "multi-aud token whose secondary audience is untrusted — library "
+        "accepts because the trusted audience is present",
+        rejects=False,
+    )
+
+    # -- Rejected by the library --------------------------------------------
+    expired = _base_claims(mock_op, now)
+    expired["iat"] = expired["nbf"] = now - 600
+    expired["exp"] = now - 300
+    add("expired", mock_op.sign(expired), "exp in the past", rejects=True)
+
+    nbf_future = _base_claims(mock_op, now)
+    nbf_future["nbf"] = now + 3600
+    add("nbf_future", mock_op.sign(nbf_future), "nbf in the future", rejects=True)
+
+    wrong_iss = _base_claims(mock_op, now)
+    wrong_iss["iss"] = "https://evil.example.com"
+    add(
+        "wrong_iss",
+        mock_op.sign(wrong_iss),
+        "iss does not match discovery",
+        rejects=True,
+    )
+
+    wrong_aud = _base_claims(mock_op, now, audience="urn:some-other-api")
+    add(
+        "wrong_aud",
+        mock_op.sign(wrong_aud),
+        "aud does not match expected",
+        rejects=True,
+    )
+
+    add(
+        "tampered_sig",
+        _tamper_signature(mock_op.sign(_base_claims(mock_op, now))),
+        "byte-flipped signature",
+        rejects=True,
+    )
+    add(
+        "unknown_kid",
+        mock_op.sign(_base_claims(mock_op, now), key=mock_op.unpublished_key),
+        "signed by a key whose kid is absent from JWKS",
+        rejects=True,
+    )
+    add(
+        "wrong_alg",
+        jwt.encode(
+            _base_claims(mock_op, now),
+            # >= 32 bytes to avoid PyJWT's InsecureKeyLengthWarning; the exact
+            # secret is irrelevant — the point is HS256 against an RSA kid.
+            "harness-hmac-confusion-secret-key-32b",
+            algorithm="HS256",
+            headers={"kid": mock_op.primary_key.kid},
+        ),
+        "HS256 signed while claiming an RSA kid (alg-confusion)",
+        rejects=True,
+    )
+    add(
+        "alg_none",
+        jwt.encode(_base_claims(mock_op, now), "", algorithm="none"),
+        "unsigned token with alg:none",
+        rejects=True,
+    )
+    return {entry.name: entry for entry in entries}

--- a/src/tests/harness/mock_op.py
+++ b/src/tests/harness/mock_op.py
@@ -27,7 +27,7 @@ from collections.abc import Awaitable, Callable, MutableMapping
 from dataclasses import dataclass
 import json
 import time
-from typing import Any
+from typing import Any, get_args, get_type_hints
 from urllib.parse import parse_qs
 
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
@@ -110,6 +110,43 @@ class MockOPControls:
     jwks_cache_control: str | None = None
     serve_empty_jwks: bool = False
     oversized_jwks_padding: int = 0
+
+
+def _resolve_control_types() -> dict[str, tuple[type, ...]]:
+    """Resolved ``{field_name: accepted_types}`` for :class:`MockOPControls`."""
+    mapping: dict[str, tuple[type, ...]] = {}
+    for name, anno in get_type_hints(MockOPControls).items():
+        args = get_args(anno)
+        mapping[name] = tuple(a for a in (args or (anno,)) if isinstance(a, type))
+    return mapping
+
+
+# Field -> accepted types, resolved once (the dataclass is immutable in shape).
+_CONTROL_TYPES: dict[str, tuple[type, ...]] = _resolve_control_types()
+
+
+def _set_control(controls: MockOPControls, name: str, value: Any) -> bool:
+    """Type-checked control mutation; returns True if the value was applied.
+
+    A stray ``{"jwks_status": "boom"}`` or ``{"retry_after": 3}`` (JSON number,
+    not string) would otherwise poison a *later* request — an ``int`` handed to
+    an ASGI ``status`` field, or a ``.encode()`` on a non-string. Reject the
+    mismatch at the control call so the failure is local and obvious.
+    """
+    types = _CONTROL_TYPES.get(name)
+    if not types:
+        return False
+    # ``bool`` is a subclass of ``int``: accept it only for genuine bool knobs,
+    # and never let it (or a JSON int) masquerade as a status/int field's value.
+    if isinstance(value, bool):
+        accepted = bool in types
+    elif isinstance(value, int) and float in types:
+        accepted = True  # JSON ints are fine for float knobs (latency_seconds)
+    else:
+        accepted = isinstance(value, types)
+    if accepted:
+        setattr(controls, name, value)
+    return accepted
 
 
 # ASGI scope/messages are MutableMapping (matching httpx.ASGITransport's spec).
@@ -300,7 +337,12 @@ class MockOP:
         except jwt.PyJWTError:
             return {"active": False}
         now = int(time.time())
-        active = int(claims.get("exp", 0)) > now
+        try:
+            active = int(claims.get("exp", 0)) > now
+        except (TypeError, ValueError):
+            # A malformed ``exp`` (exactly the kind of token this harness feeds)
+            # must report inactive, not 500 the endpoint.
+            active = False
         return {"active": active, **claims}
 
     # -- ASGI application ---------------------------------------------------
@@ -380,7 +422,13 @@ class MockOP:
         """Out-of-process control endpoint for the uvicorn-booted case (T311).
 
         Accepts a JSON body: ``{"rotate": true, "publish": false}`` and/or any
-        subset of :class:`MockOPControls` field names to set.
+        subset of :class:`MockOPControls` field names to set. Field values are
+        type-checked against the dataclass; mismatches are reported back in the
+        ``rejected`` list rather than poisoning a later request.
+
+        Security: this route performs key rotation and failure injection with no
+        authentication. It is a *test* fixture — bind it to loopback only. Do NOT
+        expose the booted mock OP on a routable interface.
         """
         try:
             payload = json.loads((await _read_body(receive)).decode() or "{}")
@@ -388,10 +436,16 @@ class MockOP:
             payload = {}
         if payload.pop("rotate", False):
             self.rotate_keys(publish=bool(payload.pop("publish", False)))
-        for name, value in payload.items():
-            if hasattr(self.controls, name):
-                setattr(self.controls, name, value)
-        await self._send_json(send, HTTP_OK, {"ok": True})
+        else:
+            # ``publish`` is only meaningful alongside ``rotate``; drop it so it
+            # is not mistaken for a control field below.
+            payload.pop("publish", None)
+        rejected = [
+            name
+            for name, value in payload.items()
+            if not _set_control(self.controls, name, value)
+        ]
+        await self._send_json(send, HTTP_OK, {"ok": True, "rejected": rejected})
 
     # -- ASGI helpers -------------------------------------------------------
 

--- a/src/tests/harness/mock_op.py
+++ b/src/tests/harness/mock_op.py
@@ -1,0 +1,444 @@
+"""Controllable mock OpenID Provider for the token-blaster harness (TH-1.1).
+
+The mock OP holds a *known* signing key (unlike real IdPs, whose keys are
+ephemeral and not exportable), which lets the harness:
+
+1. mint genuinely valid tokens, and
+2. forge the negative corpus (:mod:`corpus`) — tampered signatures, unknown
+   ``kid``, ``alg:none``, wrong ``iss``/``aud``, etc. — that a real OP will
+   never emit.
+
+It is a framework-free ASGI application (``fastapi``/``starlette`` are not root
+test dependencies), so it is both:
+
+* unit-testable in-process via ``httpx.ASGITransport`` (no network), and
+* bootable out-of-process under ``uvicorn`` for the load/soak suite (T311).
+
+The :class:`MockOPControls` object drives T311's failure injection: injected
+latency, ``429``/``Retry-After``, ``5xx``, key-rotation-on-command,
+``Cache-Control`` directives, and empty/oversized JWKS.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from collections.abc import Awaitable, Callable, MutableMapping
+from dataclasses import dataclass
+import json
+import time
+from typing import Any
+from urllib.parse import parse_qs
+
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+import jwt
+
+
+# HTTP status codes
+HTTP_OK = 200
+HTTP_NOT_FOUND = 404
+HTTP_TOO_MANY_REQUESTS = 429
+
+DEFAULT_ISSUER = "http://mock-op.local"
+DEFAULT_TOKEN_LIFETIME = 300  # seconds — mirrors the real-IdP 300s TTL (design §3)
+
+
+def _b64url_uint(value: int) -> str:
+    """Encode an unsigned integer as base64url (JWK ``n``/``e``/``x``/``y``)."""
+    length = (value.bit_length() + 7) // 8 or 1
+    return base64.urlsafe_b64encode(value.to_bytes(length, "big")).rstrip(b"=").decode()
+
+
+@dataclass(frozen=True)
+class SigningKey:
+    """A signing key the mock OP controls end-to-end.
+
+    Holds the private key (for signing / forging) and its public JWK (for the
+    ``/jwks`` document), so the harness can both mint valid tokens and forge
+    negatives keyed to a known public key.
+    """
+
+    alg: str
+    kid: str
+    private_key: Any  # cryptography private key object
+    public_jwk: dict[str, Any]
+
+
+def _rsa_signing_key(kid: str) -> SigningKey:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    numbers = private_key.public_key().public_numbers()
+    jwk = {
+        "kty": "RSA",
+        "use": "sig",
+        "alg": "RS256",
+        "kid": kid,
+        "n": _b64url_uint(numbers.n),
+        "e": _b64url_uint(numbers.e),
+    }
+    return SigningKey(alg="RS256", kid=kid, private_key=private_key, public_jwk=jwk)
+
+
+def _ec_signing_key(kid: str) -> SigningKey:
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    numbers = private_key.public_key().public_numbers()
+    jwk = {
+        "kty": "EC",
+        "use": "sig",
+        "alg": "ES256",
+        "kid": kid,
+        "crv": "P-256",
+        "x": _b64url_uint(numbers.x),
+        "y": _b64url_uint(numbers.y),
+    }
+    return SigningKey(alg="ES256", kid=kid, private_key=private_key, public_jwk=jwk)
+
+
+@dataclass
+class MockOPControls:
+    """Mutable failure-injection knobs (design §2).
+
+    Every request consults the *live* object, so a test (or a T311 control
+    route) can flip a knob between requests and observe the effect.
+    """
+
+    latency_seconds: float = 0.0
+    discovery_status: int = HTTP_OK
+    jwks_status: int = HTTP_OK
+    token_status: int = HTTP_OK
+    retry_after: str | None = None
+    discovery_cache_control: str | None = None
+    jwks_cache_control: str | None = None
+    serve_empty_jwks: bool = False
+    oversized_jwks_padding: int = 0
+
+
+# ASGI scope/messages are MutableMapping (matching httpx.ASGITransport's spec).
+ASGIScope = MutableMapping[str, Any]
+ASGIReceive = Callable[[], Awaitable[MutableMapping[str, Any]]]
+ASGISend = Callable[[MutableMapping[str, Any]], Awaitable[None]]
+ASGIApp = Callable[[ASGIScope, ASGIReceive, ASGISend], Awaitable[None]]
+
+
+class MockOP:
+    """A controllable OIDC provider serving discovery, JWKS, token, introspect.
+
+    Args:
+        issuer: The issuer / base URL. All endpoint URLs derive from it, and
+            minted tokens carry it as ``iss``.
+        controls: Failure-injection knobs. A fresh :class:`MockOPControls` is
+            created when omitted.
+    """
+
+    def __init__(
+        self,
+        issuer: str = DEFAULT_ISSUER,
+        *,
+        controls: MockOPControls | None = None,
+    ) -> None:
+        self.issuer = issuer.rstrip("/")
+        self.controls = controls or MockOPControls()
+        # Primary RS256 signs valid tokens and is published by default.
+        self.primary_key = _rsa_signing_key("mock-rs256-1")
+        # EC key exercises the ES256 path; also published.
+        self.ec_key = _ec_signing_key("mock-es256-1")
+        # Rotation spare — NOT published until :meth:`rotate_keys` publishes it,
+        # so a token freshly signed by it presents an unknown ``kid`` (design §2
+        # key-rotation-on-command failure injection).
+        self.rotation_key = _rsa_signing_key("mock-rs256-2")
+        # A key that is never published — the source of unknown-``kid`` forgeries.
+        self.unpublished_key = _rsa_signing_key("mock-rs256-unpublished")
+        self._signing_key = self.primary_key
+        self._published: list[SigningKey] = [self.primary_key, self.ec_key]
+
+    # -- URLs ---------------------------------------------------------------
+
+    @property
+    def discovery_url(self) -> str:
+        return f"{self.issuer}/.well-known/openid-configuration"
+
+    @property
+    def jwks_uri(self) -> str:
+        return f"{self.issuer}/jwks"
+
+    @property
+    def token_endpoint(self) -> str:
+        return f"{self.issuer}/token"
+
+    @property
+    def introspection_endpoint(self) -> str:
+        return f"{self.issuer}/introspect"
+
+    @property
+    def signing_key(self) -> SigningKey:
+        """The key currently used to sign freshly minted tokens."""
+        return self._signing_key
+
+    # -- Control ------------------------------------------------------------
+
+    def rotate_keys(self, *, publish: bool = False) -> SigningKey:
+        """Rotate the active signing key to the spare.
+
+        With ``publish=False`` (the default) the new key is withheld from the
+        JWKS, so tokens minted afterwards fail validation with an unknown
+        ``kid`` until :meth:`publish_signing_key` is called — the head-of-line
+        rotation scenario the harness needs to reproduce.
+        """
+        self._signing_key = self.rotation_key
+        if publish:
+            self.publish_signing_key()
+        return self._signing_key
+
+    def publish_signing_key(self) -> None:
+        """Add the active signing key to the published JWKS (idempotent)."""
+        if self._signing_key not in self._published:
+            self._published.append(self._signing_key)
+
+    # -- Documents ----------------------------------------------------------
+
+    def discovery_document(self) -> dict[str, Any]:
+        return {
+            "issuer": self.issuer,
+            "jwks_uri": self.jwks_uri,
+            "token_endpoint": self.token_endpoint,
+            "introspection_endpoint": self.introspection_endpoint,
+            "authorization_endpoint": f"{self.issuer}/authorize",
+            "response_types_supported": ["code", "token"],
+            "grant_types_supported": [
+                "client_credentials",
+                "authorization_code",
+                "refresh_token",
+            ],
+            "id_token_signing_alg_values_supported": ["RS256", "ES256"],
+            "scopes_supported": ["openid", "profile", "email"],
+            "code_challenge_methods_supported": ["S256"],
+            "subject_types_supported": ["public"],
+            "token_endpoint_auth_methods_supported": [
+                "client_secret_basic",
+                "client_secret_post",
+                "private_key_jwt",
+            ],
+        }
+
+    def jwks(self) -> dict[str, Any]:
+        if self.controls.serve_empty_jwks:
+            return {"keys": []}
+        keys = [dict(k.public_jwk) for k in self._published]
+        for i in range(self.controls.oversized_jwks_padding):
+            pad = _rsa_signing_key(f"mock-pad-{i}")
+            keys.append(dict(pad.public_jwk))
+        return {"keys": keys}
+
+    # -- Minting ------------------------------------------------------------
+
+    def sign(
+        self,
+        claims: dict[str, Any],
+        *,
+        key: SigningKey | None = None,
+        alg: str | None = None,
+        headers: dict[str, Any] | None = None,
+    ) -> str:
+        """Sign *claims* into a compact JWS with a mock-OP key.
+
+        Used both by the token endpoint (valid tokens) and by
+        :mod:`corpus` (forged negatives keyed to a known public key).
+        """
+        signing_key = key or self._signing_key
+        merged_headers = {"kid": signing_key.kid}
+        if headers:
+            merged_headers.update(headers)
+        return jwt.encode(
+            claims,
+            signing_key.private_key,
+            algorithm=alg or signing_key.alg,
+            headers=merged_headers,
+        )
+
+    def mint_access_token(
+        self,
+        *,
+        scopes: str | None = None,
+        tenant: str | None = None,
+        audience: str = "mock-api",
+        subject: str = "mock-subject",
+        lifetime: int = DEFAULT_TOKEN_LIFETIME,
+        extra_claims: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Mint a valid access token, returning an OAuth token-response dict.
+
+        ``tenant`` shapes the Descope-style multi-tenant claims (``dct`` +
+        ``tenants``) the node-oidc offline fixture also carries (design §2/§3).
+        """
+        now = int(time.time())
+        claims: dict[str, Any] = {
+            "iss": self.issuer,
+            "sub": subject,
+            "aud": audience,
+            "iat": now,
+            "nbf": now,
+            "exp": now + lifetime,
+            "client_id": "mock-client",
+            "scope": scopes or "read",
+        }
+        if tenant is not None:
+            claims["dct"] = tenant
+            claims["tenants"] = {tenant: {"roles": ["user"]}}
+        if extra_claims:
+            claims.update(extra_claims)
+        access_token = self.sign(claims)
+        return {
+            "access_token": access_token,
+            "token_type": "Bearer",
+            "expires_in": lifetime,
+            "scope": claims["scope"],
+        }
+
+    def introspect(self, token: str) -> dict[str, Any]:
+        """Best-effort introspection: decode without verification and echo."""
+        try:
+            claims = jwt.decode(token, options={"verify_signature": False})
+        except jwt.PyJWTError:
+            return {"active": False}
+        now = int(time.time())
+        active = int(claims.get("exp", 0)) > now
+        return {"active": active, **claims}
+
+    # -- ASGI application ---------------------------------------------------
+
+    @property
+    def app(self) -> ASGIApp:
+        """The ASGI application callable (uvicorn-bootable, httpx-drivable)."""
+        return self._app
+
+    async def _app(
+        self, scope: ASGIScope, receive: ASGIReceive, send: ASGISend
+    ) -> None:
+        if scope["type"] == "lifespan":
+            await self._handle_lifespan(receive, send)
+            return
+        if scope["type"] != "http":  # pragma: no cover - defensive
+            return
+        if self.controls.latency_seconds:
+            await asyncio.sleep(self.controls.latency_seconds)
+        path = scope["path"].rstrip("/") or "/"
+        method = scope["method"]
+        handler = self._route(method, path)
+        if handler is None:
+            await self._send_json(send, HTTP_NOT_FOUND, {"error": "not_found"})
+            return
+        await handler(receive, send)
+
+    def _route(
+        self, method: str, path: str
+    ) -> Callable[[ASGIReceive, ASGISend], Awaitable[None]] | None:
+        routes: dict[tuple[str, str], Callable[..., Awaitable[None]]] = {
+            ("GET", "/.well-known/openid-configuration"): self._handle_discovery,
+            ("GET", "/jwks"): self._handle_jwks,
+            ("POST", "/token"): self._handle_token,
+            ("POST", "/introspect"): self._handle_introspect,
+            ("POST", "/_control"): self._handle_control,
+        }
+        return routes.get((method, path))
+
+    async def _handle_lifespan(self, receive: ASGIReceive, send: ASGISend) -> None:
+        while True:
+            message = await receive()
+            if message["type"] == "lifespan.startup":
+                await send({"type": "lifespan.startup.complete"})
+            elif message["type"] == "lifespan.shutdown":
+                await send({"type": "lifespan.shutdown.complete"})
+                return
+
+    async def _handle_discovery(self, _receive: ASGIReceive, send: ASGISend) -> None:
+        headers = self._cache_control_headers(self.controls.discovery_cache_control)
+        if self.controls.discovery_status != HTTP_OK:
+            await self._send_status(send, self.controls.discovery_status, headers)
+            return
+        await self._send_json(send, HTTP_OK, self.discovery_document(), headers)
+
+    async def _handle_jwks(self, _receive: ASGIReceive, send: ASGISend) -> None:
+        headers = self._cache_control_headers(self.controls.jwks_cache_control)
+        if self.controls.jwks_status != HTTP_OK:
+            await self._send_status(send, self.controls.jwks_status, headers)
+            return
+        await self._send_json(send, HTTP_OK, self.jwks(), headers)
+
+    async def _handle_token(self, receive: ASGIReceive, send: ASGISend) -> None:
+        if self.controls.token_status != HTTP_OK:
+            await self._send_status(send, self.controls.token_status)
+            return
+        form = parse_qs((await _read_body(receive)).decode())
+        scope = form.get("scope", [None])[0]
+        await self._send_json(send, HTTP_OK, self.mint_access_token(scopes=scope))
+
+    async def _handle_introspect(self, receive: ASGIReceive, send: ASGISend) -> None:
+        form = parse_qs((await _read_body(receive)).decode())
+        token = form.get("token", [""])[0]
+        await self._send_json(send, HTTP_OK, self.introspect(token))
+
+    async def _handle_control(self, receive: ASGIReceive, send: ASGISend) -> None:
+        """Out-of-process control endpoint for the uvicorn-booted case (T311).
+
+        Accepts a JSON body: ``{"rotate": true, "publish": false}`` and/or any
+        subset of :class:`MockOPControls` field names to set.
+        """
+        try:
+            payload = json.loads((await _read_body(receive)).decode() or "{}")
+        except json.JSONDecodeError:
+            payload = {}
+        if payload.pop("rotate", False):
+            self.rotate_keys(publish=bool(payload.pop("publish", False)))
+        for name, value in payload.items():
+            if hasattr(self.controls, name):
+                setattr(self.controls, name, value)
+        await self._send_json(send, HTTP_OK, {"ok": True})
+
+    # -- ASGI helpers -------------------------------------------------------
+
+    def _cache_control_headers(
+        self, cache_control: str | None
+    ) -> list[tuple[bytes, bytes]]:
+        if cache_control is None:
+            return []
+        return [(b"cache-control", cache_control.encode())]
+
+    async def _send_status(
+        self,
+        send: ASGISend,
+        status: int,
+        headers: list[tuple[bytes, bytes]] | None = None,
+    ) -> None:
+        body = {"error": "injected_failure", "status": status}
+        extra = list(headers or [])
+        if status == HTTP_TOO_MANY_REQUESTS and self.controls.retry_after is not None:
+            extra.append((b"retry-after", self.controls.retry_after.encode()))
+        await self._send_json(send, status, body, extra)
+
+    async def _send_json(
+        self,
+        send: ASGISend,
+        status: int,
+        body: dict[str, Any],
+        headers: list[tuple[bytes, bytes]] | None = None,
+    ) -> None:
+        payload = json.dumps(body).encode()
+        response_headers = [(b"content-type", b"application/json")]
+        response_headers.extend(headers or [])
+        await send(
+            {
+                "type": "http.response.start",
+                "status": status,
+                "headers": response_headers,
+            }
+        )
+        await send({"type": "http.response.body", "body": payload})
+
+
+async def _read_body(receive: ASGIReceive) -> bytes:
+    body = b""
+    while True:
+        message = await receive()
+        body += message.get("body", b"")
+        if not message.get("more_body", False):
+            break
+    return body

--- a/src/tests/harness/token_source.py
+++ b/src/tests/harness/token_source.py
@@ -1,0 +1,462 @@
+"""Unified multi-provider ``TokenSource`` minter for the harness (TH-1.1, #463).
+
+One :meth:`TokenSource.mint` call unifies what the integration ``conftest``
+previously spread across ``client_credentials_token``, ``jwt_access_token``,
+``opaque_access_token`` and the ``auth_code_result`` helpers, plus the
+Descope-shaped multi-tenant minter — capability/credential-gated exactly like
+``provider_matrix.detect_capabilities``.
+
+* Real providers (node-oidc, Keycloak, Ory, Descope) mint through the library's
+  own token logic (``request_client_credentials_token`` / an injected auth-code
+  minter) — never reimplemented.
+* The ``MOCK`` provider mints valid tokens and, via ``malform=``, the forged
+  corpus (:mod:`corpus`) off the controllable mock OP (:mod:`mock_op`).
+
+Gating raises typed errors (:class:`HarnessCapabilityError` /
+:class:`HarnessCredentialError`) that the ``conftest`` fixture translates to
+``pytest.skip`` — so Ory/Descope skip cleanly when secret-gated, while ``MOCK``
+is always available.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import StrEnum
+import json
+import time
+from typing import TYPE_CHECKING, Any
+
+from py_identity_model import (
+    ClientCredentialsTokenRequest,
+    request_client_credentials_token,
+)
+
+from ..integration.provider_matrix import detect_capabilities
+from .corpus import build_corpus
+from .mock_op import MockOP
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+JWT_SEGMENT_SEPARATOR_COUNT = 2
+
+
+class Provider(StrEnum):
+    """Identity providers the harness can mint against."""
+
+    NODE_OIDC = "node-oidc"
+    KEYCLOAK = "keycloak"
+    ORY = "ory"
+    DESCOPE = "descope"
+    MOCK = "mock"
+
+
+class Grant(StrEnum):
+    """OAuth grant types the minter understands."""
+
+    CLIENT_CREDENTIALS = "client_credentials"
+    AUTHORIZATION_CODE = "authorization_code"
+    REFRESH_TOKEN = "refresh_token"
+    DEVICE_CODE = "device_code"
+
+
+class Malform(StrEnum):
+    """Forged-token classes (MOCK provider only)."""
+
+    VALID = "valid"
+    EXPIRED = "expired"
+    NBF_FUTURE = "nbf_future"
+    WRONG_ISS = "wrong_iss"
+    WRONG_AUD = "wrong_aud"
+    TAMPERED_SIG = "tampered_sig"
+    UNKNOWN_KID = "unknown_kid"
+    WRONG_ALG = "wrong_alg"
+    ALG_NONE = "alg_none"
+    ID_AS_ACCESS = "id_as_access"
+    CNF_BOUND = "cnf_bound"
+    OVERSIZED = "oversized"
+    MULTI_AUD_UNTRUSTED = "multi_aud_untrusted"
+
+
+# Grant -> provider_matrix capability key.
+_GRANT_CAPABILITY: dict[Grant, str] = {
+    Grant.CLIENT_CREDENTIALS: "client_credentials",
+    Grant.AUTHORIZATION_CODE: "authorization_code",
+    Grant.REFRESH_TOKEN: "refresh_token",
+    Grant.DEVICE_CODE: "device_authorization",
+}
+
+
+class HarnessError(Exception):
+    """Base class for token-harness errors."""
+
+
+class HarnessCapabilityError(HarnessError):
+    """The provider does not advertise the requested grant/capability."""
+
+
+class HarnessCredentialError(HarnessError):
+    """The provider supports the grant but the required credentials are absent."""
+
+
+@dataclass(frozen=True)
+class MintedToken:
+    """The result of a mint — a replayable token plus its provenance."""
+
+    access_token: str
+    provider: Provider
+    grant: Grant
+    token_type: str = "Bearer"
+    id_token: str | None = None
+    expires_at: float | None = None
+    tenant: str | None = None
+    alg: str | None = None
+    kid: str | None = None
+    malform: Malform | None = None
+
+    def is_expired(self, *, now: float | None = None, leeway: float = 0.0) -> bool:
+        """Whether the token is past its expiry (for T311 re-mint cadence)."""
+        if self.expires_at is None:
+            return False
+        return (now if now is not None else time.time()) >= self.expires_at - leeway
+
+
+# An auth-code minter returns an OAuth token-response dict (``access_token`` …),
+# letting the conftest inject ``perform_auth_code_flow`` without this module
+# importing pytest.
+AuthCodeMinter = Callable[[str | None, str | None], dict[str, Any]]
+
+
+@dataclass
+class ProviderConfig:
+    """Per-provider configuration and capabilities for the minter."""
+
+    provider: Provider
+    capabilities: set[str] = field(default_factory=set)
+    token_endpoint: str | None = None
+    client_id: str | None = None
+    client_secret: str | None = None
+    scope: str | None = None
+    mock_op: MockOP | None = None
+    auth_code_minter: AuthCodeMinter | None = None
+
+    @classmethod
+    def from_discovery(
+        cls,
+        provider: Provider,
+        raw_discovery: dict[str, Any],
+        *,
+        token_endpoint: str | None = None,
+        client_id: str | None = None,
+        client_secret: str | None = None,
+        scope: str | None = None,
+        auth_code_minter: AuthCodeMinter | None = None,
+    ) -> ProviderConfig:
+        """Build a real-provider config, deriving capabilities from discovery.
+
+        Reuses ``provider_matrix.detect_capabilities`` so the harness and the
+        capability matrix never drift.
+        """
+        caps = {name for name, ok in detect_capabilities(raw_discovery).items() if ok}
+        return cls(
+            provider=provider,
+            capabilities=caps,
+            token_endpoint=token_endpoint or raw_discovery.get("token_endpoint"),
+            client_id=client_id,
+            client_secret=client_secret,
+            scope=scope,
+            auth_code_minter=auth_code_minter,
+        )
+
+
+class TokenSource:
+    """The unified minter. One :meth:`mint` for every provider/grant/forgery."""
+
+    def __init__(self, configs: Iterable[ProviderConfig]) -> None:
+        self._configs: dict[Provider, ProviderConfig] = {
+            cfg.provider: cfg for cfg in configs
+        }
+
+    @classmethod
+    def with_mock(
+        cls, mock_op: MockOP | None = None, *, extra: Iterable[ProviderConfig] = ()
+    ) -> TokenSource:
+        """Convenience builder wiring a ``MOCK`` provider (always mintable)."""
+        mock = mock_op or MockOP()
+        mock_cfg = ProviderConfig(
+            provider=Provider.MOCK,
+            capabilities={_GRANT_CAPABILITY[g] for g in Grant},
+            mock_op=mock,
+        )
+        return cls([mock_cfg, *extra])
+
+    @property
+    def providers(self) -> list[Provider]:
+        return list(self._configs)
+
+    def config(self, provider: Provider) -> ProviderConfig:
+        try:
+            return self._configs[provider]
+        except KeyError:
+            raise HarnessCapabilityError(
+                f"provider {provider.value} is not configured in this TokenSource"
+            ) from None
+
+    def mint(
+        self,
+        provider: Provider,
+        grant: Grant = Grant.CLIENT_CREDENTIALS,
+        *,
+        tenant: str | None = None,
+        scopes: str | None = None,
+        malform: Malform | None = None,
+    ) -> MintedToken:
+        """Mint a token.
+
+        Args:
+            provider: The provider to mint against.
+            grant: The grant type (``client_credentials`` by default).
+            tenant: Optional tenant, shaping Descope-style multi-tenant claims.
+            scopes: Space-delimited scopes.
+            malform: A forged class — MOCK-only; raises
+                :class:`HarnessCapabilityError` for any real provider.
+
+        Raises:
+            HarnessCapabilityError: provider/grant/forgery unsupported.
+            HarnessCredentialError: grant supported but credentials absent.
+        """
+        cfg = self.config(provider)
+        if malform is not None:
+            return self._mint_forged(cfg, grant, tenant, malform)
+        if provider is Provider.MOCK:
+            return self._mint_mock_valid(cfg, grant, tenant, scopes)
+        self._check_capability(cfg, grant)
+        self._check_credentials(cfg, grant)
+        if grant is Grant.CLIENT_CREDENTIALS:
+            return self._mint_client_credentials(cfg, tenant, scopes)
+        if grant is Grant.AUTHORIZATION_CODE:
+            return self._mint_auth_code(cfg, tenant, scopes)
+        raise HarnessCapabilityError(
+            f"grant {grant.value} is not implemented for provider {provider.value}"
+        )
+
+    # -- Gating -------------------------------------------------------------
+
+    def _check_capability(self, cfg: ProviderConfig, grant: Grant) -> None:
+        capability = _GRANT_CAPABILITY[grant]
+        if capability not in cfg.capabilities:
+            raise HarnessCapabilityError(
+                f"{cfg.provider.value} does not advertise {capability} "
+                f"(grant {grant.value})"
+            )
+
+    def _check_credentials(self, cfg: ProviderConfig, grant: Grant) -> None:
+        if grant is Grant.CLIENT_CREDENTIALS:
+            if not (cfg.client_id and cfg.client_secret and cfg.token_endpoint):
+                raise HarnessCredentialError(
+                    f"{cfg.provider.value}: client_credentials requires "
+                    f"client_id, client_secret and a token endpoint"
+                )
+        elif grant is Grant.AUTHORIZATION_CODE and cfg.auth_code_minter is None:
+            raise HarnessCredentialError(
+                f"{cfg.provider.value}: no auth-code minter configured"
+            )
+
+    # -- Real-provider mints ------------------------------------------------
+
+    def _mint_client_credentials(
+        self, cfg: ProviderConfig, tenant: str | None, scopes: str | None
+    ) -> MintedToken:
+        assert cfg.token_endpoint
+        assert cfg.client_id
+        assert cfg.client_secret
+        response = request_client_credentials_token(
+            ClientCredentialsTokenRequest(
+                client_id=cfg.client_id,
+                client_secret=cfg.client_secret,
+                address=cfg.token_endpoint,
+                scope=scopes or cfg.scope,
+            )
+        )
+        if not response.is_successful:
+            raise HarnessError(
+                f"{cfg.provider.value}: client_credentials mint failed: "
+                f"{response.error}"
+            )
+        assert response.token is not None
+        return self._from_token_response(
+            cfg.provider, Grant.CLIENT_CREDENTIALS, response.token, tenant
+        )
+
+    def _mint_auth_code(
+        self, cfg: ProviderConfig, tenant: str | None, scopes: str | None
+    ) -> MintedToken:
+        assert cfg.auth_code_minter is not None
+        token = cfg.auth_code_minter(tenant, scopes)
+        return self._from_token_response(
+            cfg.provider, Grant.AUTHORIZATION_CODE, token, tenant
+        )
+
+    def _from_token_response(
+        self,
+        provider: Provider,
+        grant: Grant,
+        token: dict[str, Any],
+        tenant: str | None,
+    ) -> MintedToken:
+        access_token = token["access_token"]
+        expires_in = token.get("expires_in")
+        expires_at = time.time() + expires_in if expires_in else None
+        alg, kid = _peek_jwt_header(access_token)
+        return MintedToken(
+            access_token=access_token,
+            provider=provider,
+            grant=grant,
+            token_type=token.get("token_type", "Bearer"),
+            id_token=token.get("id_token"),
+            expires_at=expires_at,
+            tenant=tenant,
+            alg=alg,
+            kid=kid,
+        )
+
+    # -- MOCK mints ---------------------------------------------------------
+
+    def _mint_mock_valid(
+        self,
+        cfg: ProviderConfig,
+        grant: Grant,
+        tenant: str | None,
+        scopes: str | None,
+    ) -> MintedToken:
+        mock = self._require_mock(cfg)
+        token = mock.mint_access_token(scopes=scopes, tenant=tenant)
+        return MintedToken(
+            access_token=token["access_token"],
+            provider=Provider.MOCK,
+            grant=grant,
+            token_type=token["token_type"],
+            expires_at=time.time() + token["expires_in"],
+            tenant=tenant,
+            alg=mock.signing_key.alg,
+            kid=mock.signing_key.kid,
+            malform=Malform.VALID,
+        )
+
+    def _mint_forged(
+        self,
+        cfg: ProviderConfig,
+        grant: Grant,
+        tenant: str | None,
+        malform: Malform,
+    ) -> MintedToken:
+        if cfg.provider is not Provider.MOCK:
+            raise HarnessCapabilityError(
+                "forged tokens are only available from the MOCK provider "
+                "(real OPs will not emit invalid tokens)"
+            )
+        mock = self._require_mock(cfg)
+        forged = build_corpus(mock)[malform.value]
+        return MintedToken(
+            access_token=forged.jwt,
+            provider=Provider.MOCK,
+            grant=grant,
+            tenant=tenant,
+            malform=malform,
+        )
+
+    def _require_mock(self, cfg: ProviderConfig) -> MockOP:
+        if cfg.mock_op is None:
+            raise HarnessCapabilityError("MOCK provider has no mock OP configured")
+        return cfg.mock_op
+
+
+def _peek_jwt_header(token: str) -> tuple[str | None, str | None]:
+    """Best-effort ``(alg, kid)`` from a compact JWT header; ``(None, None)``
+    for opaque tokens."""
+    if token.count(".") != JWT_SEGMENT_SEPARATOR_COUNT:
+        return None, None
+    header_segment = token.split(".", 1)[0]
+    padding = "=" * (-len(header_segment) % 4)
+    try:
+        header = json.loads(base64.urlsafe_b64decode(header_segment + padding))
+    except (ValueError, json.JSONDecodeError):
+        return None, None
+    return header.get("alg"), header.get("kid")
+
+
+# -- Replay pool ------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MintSpec:
+    """A single mint request for :func:`prime_pool`."""
+
+    provider: Provider
+    grant: Grant = Grant.CLIENT_CREDENTIALS
+    tenant: str | None = None
+    scopes: str | None = None
+    malform: Malform | None = None
+
+    def key(self) -> str:
+        parts = [
+            self.provider.value,
+            self.grant.value,
+            self.tenant or "-",
+            self.scopes or "-",
+            self.malform.value if self.malform else "-",
+        ]
+        return "|".join(parts)
+
+
+class ReplayPool:
+    """Pre-mint once, replay many (design §3).
+
+    Real IdPs rate-limit and validation is stateless, so the harness mints each
+    distinct spec a single time and replays the token. ``expires_at`` is tracked
+    so T311 can re-mint across the 300s TTL / classify post-expiry 401s as
+    expected rather than error-budget.
+    """
+
+    def __init__(self) -> None:
+        self._by_key: dict[str, MintedToken] = {}
+
+    def add(self, spec: MintSpec, token: MintedToken) -> None:
+        self._by_key[spec.key()] = token
+
+    def get(self, spec: MintSpec) -> MintedToken:
+        return self._by_key[spec.key()]
+
+    def all(self) -> list[MintedToken]:
+        return list(self._by_key.values())
+
+    def __len__(self) -> int:
+        return len(self._by_key)
+
+    def __iter__(self):
+        return iter(self._by_key.values())
+
+
+def prime_pool(source: TokenSource, specs: Iterable[MintSpec]) -> ReplayPool:
+    """Mint each spec once into a :class:`ReplayPool` (skips duplicate specs)."""
+    pool = ReplayPool()
+    seen: set[str] = set()
+    for spec in specs:
+        if spec.key() in seen:
+            continue
+        seen.add(spec.key())
+        pool.add(
+            spec,
+            source.mint(
+                spec.provider,
+                spec.grant,
+                tenant=spec.tenant,
+                scopes=spec.scopes,
+                malform=spec.malform,
+            ),
+        )
+    return pool

--- a/src/tests/harness/token_source.py
+++ b/src/tests/harness/token_source.py
@@ -462,11 +462,13 @@ def _descope_accesskey_exchange(
         data = created.json()
         key_id = data.get("key", {}).get("id", "")
         cleartext = data.get("cleartext", "")
+    # Once a key exists, the finally must delete it — even if ``cleartext`` is
+    # absent — so the raise lives inside the try, not before it.
+    try:
         if not cleartext:
             raise HarnessError(
                 f"descope access-key create returned no cleartext: {data}"
             )
-    try:
         with httpx.Client(timeout=_DESCOPE_HTTP_TIMEOUT) as client:
             exchanged = client.post(
                 f"{base}/v1/auth/accesskey/exchange",
@@ -482,15 +484,16 @@ def _descope_accesskey_exchange(
                 )
             return session_jwt
     finally:
-        with (
-            contextlib.suppress(Exception),
-            httpx.Client(timeout=_DESCOPE_HTTP_TIMEOUT) as client,
-        ):
-            client.post(
-                f"{base}/v1/mgmt/accesskey/delete",
-                headers=mgmt_headers,
-                json={"id": key_id},
-            )
+        if key_id:
+            with (
+                contextlib.suppress(Exception),
+                httpx.Client(timeout=_DESCOPE_HTTP_TIMEOUT) as client,
+            ):
+                client.post(
+                    f"{base}/v1/mgmt/accesskey/delete",
+                    headers=mgmt_headers,
+                    json={"id": key_id},
+                )
 
 
 def _peek_jwt_header(token: str) -> tuple[str | None, str | None]:

--- a/src/tests/harness/token_source.py
+++ b/src/tests/harness/token_source.py
@@ -22,11 +22,15 @@ from __future__ import annotations
 
 import base64
 from collections.abc import Callable
+import contextlib
 from dataclasses import dataclass, field
 from enum import StrEnum
 import json
 import time
 from typing import TYPE_CHECKING, Any
+import uuid
+
+import httpx
 
 from py_identity_model import (
     ClientCredentialsTokenRequest,
@@ -143,6 +147,12 @@ class ProviderConfig:
     scope: str | None = None
     mock_op: MockOP | None = None
     auth_code_minter: AuthCodeMinter | None = None
+    # Descope multi-tenant (access-key -> /v1/auth/accesskey/exchange) config.
+    # When present, ``mint(DESCOPE, tenant=…)`` produces a session JWT carrying
+    # distinct ``dct``/``tenants`` claims (AC-3); absent -> credential skip.
+    descope_project_id: str | None = None
+    descope_management_key: str | None = None
+    descope_base_url: str | None = None
 
     @classmethod
     def from_discovery(
@@ -155,6 +165,9 @@ class ProviderConfig:
         client_secret: str | None = None,
         scope: str | None = None,
         auth_code_minter: AuthCodeMinter | None = None,
+        descope_project_id: str | None = None,
+        descope_management_key: str | None = None,
+        descope_base_url: str | None = None,
     ) -> ProviderConfig:
         """Build a real-provider config, deriving capabilities from discovery.
 
@@ -170,6 +183,9 @@ class ProviderConfig:
             client_secret=client_secret,
             scope=scope,
             auth_code_minter=auth_code_minter,
+            descope_project_id=descope_project_id,
+            descope_management_key=descope_management_key,
+            descope_base_url=descope_base_url,
         )
 
 
@@ -234,6 +250,14 @@ class TokenSource:
             return self._mint_forged(cfg, grant, tenant, malform)
         if provider is Provider.MOCK:
             return self._mint_mock_valid(cfg, grant, tenant, scopes)
+        if (
+            provider is Provider.DESCOPE
+            and grant is Grant.CLIENT_CREDENTIALS
+            and tenant is not None
+        ):
+            # AC-3: the Descope multi-tenant path is the access-key -> session-JWT
+            # exchange (distinct dct/tenants), NOT the plain OIDC token endpoint.
+            return self._mint_descope_tenant(cfg, tenant)
         self._check_capability(cfg, grant)
         self._check_credentials(cfg, grant)
         if grant is Grant.CLIENT_CREDENTIALS:
@@ -299,6 +323,37 @@ class TokenSource:
         token = cfg.auth_code_minter(tenant, scopes)
         return self._from_token_response(
             cfg.provider, Grant.AUTHORIZATION_CODE, token, tenant
+        )
+
+    def _mint_descope_tenant(self, cfg: ProviderConfig, tenant: str) -> MintedToken:
+        """Reuse the identity-stack access-key -> session-JWT exchange (AC-3).
+
+        Creates a temporary tenant-scoped access key, exchanges it via
+        ``/v1/auth/accesskey/exchange`` for a Descope *session JWT* carrying
+        distinct ``dct``/``tenants`` claims, then deletes the key. Credential-
+        gated: absent Descope management config raises
+        :class:`HarnessCredentialError` (translated to ``pytest.skip``).
+        """
+        if not (
+            cfg.descope_project_id
+            and cfg.descope_management_key
+            and cfg.descope_base_url
+        ):
+            raise HarnessCredentialError(
+                "descope: multi-tenant mint requires descope_project_id, "
+                "descope_management_key and descope_base_url"
+            )
+        session_jwt = _descope_accesskey_exchange(
+            base_url=cfg.descope_base_url,
+            project_id=cfg.descope_project_id,
+            management_key=cfg.descope_management_key,
+            tenant=tenant,
+        )
+        return self._from_token_response(
+            Provider.DESCOPE,
+            Grant.CLIENT_CREDENTIALS,
+            {"access_token": session_jwt, "token_type": "Bearer"},
+            tenant,
         )
 
     def _from_token_response(
@@ -375,6 +430,69 @@ class TokenSource:
         return cfg.mock_op
 
 
+_DESCOPE_HTTP_TIMEOUT = 30.0
+
+
+def _descope_accesskey_exchange(
+    *,
+    base_url: str,
+    project_id: str,
+    management_key: str,
+    tenant: str,
+    roles: Iterable[str] = ("owner", "admin"),
+) -> str:
+    """Access-key create -> exchange -> delete, returning the session JWT.
+
+    Mirrors the identity-stack e2e minter: a ``keyTenants`` (array) access key
+    is required so the exchanged session JWT includes ``dct``/``tenants`` claims
+    (a top-level ``tenantId`` does not). The temporary key is deleted best-effort.
+    """
+    base = base_url.rstrip("/")
+    mgmt_headers = {"Authorization": f"Bearer {project_id}:{management_key}"}
+    with httpx.Client(timeout=_DESCOPE_HTTP_TIMEOUT) as client:
+        created = client.post(
+            f"{base}/v1/mgmt/accesskey/create",
+            headers=mgmt_headers,
+            json={
+                "name": f"harness-{uuid.uuid4().hex[:8]}",
+                "keyTenants": [{"tenantId": tenant, "roleNames": list(roles)}],
+            },
+        )
+        created.raise_for_status()
+        data = created.json()
+        key_id = data.get("key", {}).get("id", "")
+        cleartext = data.get("cleartext", "")
+        if not cleartext:
+            raise HarnessError(
+                f"descope access-key create returned no cleartext: {data}"
+            )
+    try:
+        with httpx.Client(timeout=_DESCOPE_HTTP_TIMEOUT) as client:
+            exchanged = client.post(
+                f"{base}/v1/auth/accesskey/exchange",
+                headers={"Authorization": f"Bearer {project_id}:{cleartext}"},
+                json={},
+            )
+            exchanged.raise_for_status()
+            session_jwt = exchanged.json().get("sessionJwt", "")
+            if not session_jwt:
+                raise HarnessError(
+                    f"descope access-key exchange returned no sessionJwt: "
+                    f"{exchanged.json()}"
+                )
+            return session_jwt
+    finally:
+        with (
+            contextlib.suppress(Exception),
+            httpx.Client(timeout=_DESCOPE_HTTP_TIMEOUT) as client,
+        ):
+            client.post(
+                f"{base}/v1/mgmt/accesskey/delete",
+                headers=mgmt_headers,
+                json={"id": key_id},
+            )
+
+
 def _peek_jwt_header(token: str) -> tuple[str | None, str | None]:
     """Best-effort ``(alg, kid)`` from a compact JWT header; ``(None, None)``
     for opaque tokens."""
@@ -385,6 +503,8 @@ def _peek_jwt_header(token: str) -> tuple[str | None, str | None]:
     try:
         header = json.loads(base64.urlsafe_b64decode(header_segment + padding))
     except (ValueError, json.JSONDecodeError):
+        return None, None
+    if not isinstance(header, dict):
         return None, None
     return header.get("alg"), header.get("kid")
 

--- a/src/tests/integration/.env.descope.example
+++ b/src/tests/integration/.env.descope.example
@@ -29,3 +29,12 @@ TEST_AUDIENCE=
 
 # Expired token for testing (generate a token and let it expire, or use an invalid token)
 TEST_EXPIRED_TOKEN=
+
+# Multi-tenant access-key exchange (TH-1.1 AC-3). When all four are set, the
+# harness TokenSource.mint(Provider.DESCOPE, tenant=…) reuses the identity-stack
+# access-key -> /v1/auth/accesskey/exchange flow to produce a session JWT
+# carrying distinct dct/tenants claims. Absent -> the multi-tenant test skips.
+DESCOPE_BASE_URL=https://api.descope.com
+DESCOPE_PROJECT_ID=
+DESCOPE_MANAGEMENT_KEY=
+DESCOPE_TEST_TENANT_ID=

--- a/src/tests/integration/README.md
+++ b/src/tests/integration/README.md
@@ -80,6 +80,15 @@ TEST_AUDIENCE=YOUR_PROJECT_ID
 
 # Optional: Generate an expired token for expiration tests
 TEST_EXPIRED_TOKEN=
+
+# Optional: Multi-tenant access-key exchange (harness TokenSource).
+# When all four are set, `TokenSource.mint(Provider.DESCOPE, tenant=…)` reuses
+# the access-key -> /v1/auth/accesskey/exchange flow to produce a session JWT
+# carrying distinct dct/tenants claims; absent, the multi-tenant test skips.
+DESCOPE_BASE_URL=https://api.descope.com
+DESCOPE_PROJECT_ID=
+DESCOPE_MANAGEMENT_KEY=
+DESCOPE_TEST_TENANT_ID=
 ```
 
 3. Load the environment variables:

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -705,6 +705,10 @@ def token_source(
         client_secret=test_config.get("TEST_CLIENT_SECRET"),
         scope=test_config.get("TEST_SCOPE"),
         auth_code_minter=auth_code_minter,
+        # Descope multi-tenant access-key exchange (AC-3); absent -> skip.
+        descope_project_id=test_config.get("DESCOPE_PROJECT_ID"),
+        descope_management_key=test_config.get("DESCOPE_MANAGEMENT_KEY"),
+        descope_base_url=test_config.get("DESCOPE_BASE_URL"),
     )
     return TokenSource.with_mock(extra=[real_cfg])
 

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -57,6 +57,12 @@ from py_identity_model.core.pkce import generate_pkce_pair
 from py_identity_model.exceptions import TokenValidationException
 from py_identity_model.sync.http_client import close_http_client
 
+from ..harness import (
+    HarnessError,
+    Provider,
+    ProviderConfig,
+    TokenSource,
+)
 from .test_utils import get_config
 
 
@@ -610,6 +616,97 @@ def opaque_access_token(
         access_token = response.token["access_token"]
         cache_file.write_text(json.dumps({"access_token": access_token}))
         return access_token
+
+
+# ============================================================================
+# Unified token-source harness (TH-1.1, #463)
+# ============================================================================
+
+# The provider slug (derived from the ``.env.<slug>`` file) maps onto the
+# harness ``Provider`` enum. An unrecognised slug (e.g. ``.env.local``) leaves
+# the real provider unwired, so only the always-available MOCK provider is
+# offered and the real-IdP tests skip cleanly.
+_SLUG_TO_PROVIDER: dict[str, Provider] = {
+    "node-oidc": Provider.NODE_OIDC,
+    "keycloak": Provider.KEYCLOAK,
+    "ory": Provider.ORY,
+    "descope": Provider.DESCOPE,
+}
+
+
+@pytest.fixture(scope="session")
+def harness_provider(provider_slug) -> Provider | None:
+    """The real :class:`Provider` under test, or ``None`` for an unknown slug."""
+    return _SLUG_TO_PROVIDER.get(provider_slug)
+
+
+@pytest.fixture(scope="session")
+def token_source(
+    harness_provider,
+    raw_discovery,
+    discovery_document,
+    provider_capabilities,
+    test_config,
+) -> TokenSource:
+    """Session-scoped unified minter (:class:`TokenSource`) for the harness.
+
+    Wires the real provider under test — capabilities derived from live
+    discovery via ``provider_matrix.detect_capabilities`` (so the harness and
+    the capability matrix never drift), credentials from the env file — plus
+    the always-available MOCK provider. When the provider supports automated
+    auth-code flows (devInteractions) and the auth-code client is configured,
+    an ``auth_code_minter`` wrapping :func:`perform_auth_code_flow` is injected
+    so ``Grant.AUTHORIZATION_CODE`` mints end-to-end.
+
+    Tests translate the typed gating errors
+    (:class:`HarnessCapabilityError` / :class:`HarnessCredentialError`) to
+    ``pytest.skip`` so secret-gated providers (Ory/Descope) skip cleanly while
+    MOCK is always mintable.
+    """
+    if harness_provider is None:
+        return TokenSource.with_mock()
+
+    auth_code_minter = None
+    if "dev_interactions" in provider_capabilities:
+        client_id = test_config.get("TEST_AUTH_CODE_CLIENT_ID")
+        redirect_uri = test_config.get("TEST_AUTH_CODE_REDIRECT_URI")
+        client_secret = test_config.get("TEST_AUTH_CODE_CLIENT_SECRET")
+        if client_id and redirect_uri:
+
+            def auth_code_minter(
+                tenant: str | None,
+                scopes: str | None,
+                *,
+                _client_id: str = client_id,
+                _redirect_uri: str = redirect_uri,
+                _client_secret: str | None = client_secret,
+            ) -> dict[str, Any]:
+                del tenant  # single-tenant local fixtures ignore tenant shaping
+                result = perform_auth_code_flow(
+                    discovery=discovery_document,
+                    client_id=_client_id,
+                    redirect_uri=_redirect_uri,
+                    config=AuthCodeFlowConfig(
+                        client_secret=_client_secret,
+                        scope=scopes or "openid profile email offline_access",
+                        resource="urn:test:api",
+                    ),
+                )
+                token_response = result["token_response"]
+                if not token_response.is_successful or token_response.token is None:
+                    raise HarnessError(f"auth-code mint failed: {token_response.error}")
+                return dict(token_response.token)
+
+    real_cfg = ProviderConfig.from_discovery(
+        harness_provider,
+        raw_discovery,
+        token_endpoint=discovery_document.token_endpoint,
+        client_id=test_config.get("TEST_CLIENT_ID"),
+        client_secret=test_config.get("TEST_CLIENT_SECRET"),
+        scope=test_config.get("TEST_SCOPE"),
+        auth_code_minter=auth_code_minter,
+    )
+    return TokenSource.with_mock(extra=[real_cfg])
 
 
 @pytest.fixture(autouse=True)

--- a/src/tests/integration/test_token_source.py
+++ b/src/tests/integration/test_token_source.py
@@ -15,6 +15,9 @@ signature-valid token the library accepts.
 
 from __future__ import annotations
 
+import base64
+import json
+
 import pytest
 
 from py_identity_model import (
@@ -144,6 +147,34 @@ def test_forged_tokens_require_mock_provider(token_source, harness_provider):
             Grant.CLIENT_CREDENTIALS,
             malform=Malform.TAMPERED_SIG,
         )
+
+
+def test_descope_multitenant_mint_carries_dct_tenants(
+    token_source, harness_provider, test_config
+):
+    """AC-3: the Descope multi-tenant path yields distinct ``dct``/``tenants``.
+
+    Reuses the identity-stack access-key -> ``/v1/auth/accesskey/exchange`` flow
+    (credential-gated on ``DESCOPE_PROJECT_ID``/``DESCOPE_MANAGEMENT_KEY``/
+    ``DESCOPE_BASE_URL`` + a tenant id) so it skips cleanly off Descope.
+    """
+    if harness_provider is not Provider.DESCOPE:
+        pytest.skip("Descope-only: multi-tenant access-key exchange")
+    tenant = test_config.get("DESCOPE_TEST_TENANT_ID")
+    if not tenant:
+        pytest.skip("DESCOPE_TEST_TENANT_ID not configured")
+
+    minted = _mint_or_skip(
+        token_source, Provider.DESCOPE, Grant.CLIENT_CREDENTIALS, tenant=tenant
+    )
+    assert minted.tenant == tenant
+    # Session JWT must carry the Descope multi-tenant claims (dct/tenants).
+    payload_segment = minted.access_token.split(".")[1]
+    payload = json.loads(
+        base64.urlsafe_b64decode(payload_segment + "=" * (-len(payload_segment) % 4))
+    )
+    assert payload.get("dct") == tenant
+    assert tenant in payload.get("tenants", {})
 
 
 def test_mock_provider_always_mintable(token_source):

--- a/src/tests/integration/test_token_source.py
+++ b/src/tests/integration/test_token_source.py
@@ -1,0 +1,170 @@
+"""DoD: real-IdP proof for the unified ``TokenSource`` minter (TH-1.1, #463).
+
+This is the Definition-of-Done evidence for the minter: it mints tokens through
+a **live** identity provider (node-oidc / Keycloak under ``make
+test-integration-node-oidc`` / ``-keycloak``; Ory / Descope when secret-gated)
+and validates them end-to-end with the real library
+(:func:`py_identity_model.validate_token`) against the provider's live JWKS.
+
+The deterministic, network-free proofs (forged corpus, mock-OP failure
+injection, capability/credential gating) live in the unit suite
+(``test_mock_op.py`` / ``test_token_source_gating.py``); here we prove the one
+thing only a real IdP can: that a ``TokenSource.mint`` result is a genuine,
+signature-valid token the library accepts.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from py_identity_model import (
+    TokenValidationConfig,
+    validate_token,
+)
+
+from ..harness import (
+    Grant,
+    HarnessCapabilityError,
+    HarnessCredentialError,
+    Malform,
+    MintSpec,
+    Provider,
+    ProviderConfig,
+    TokenSource,
+    prime_pool,
+)
+from .conftest import DEFAULT_VALIDATION_OPTIONS
+
+
+pytestmark = pytest.mark.integration
+
+# JWT format: three dot-separated segments (two separators).
+JWT_SEGMENT_SEPARATOR_COUNT = 2
+
+
+def _mint_or_skip(source: TokenSource, provider: Provider, grant: Grant, **kwargs):
+    """Mint, translating the typed gating errors to ``pytest.skip``.
+
+    This is the contract the harness relies on: secret-gated providers
+    (Ory/Descope) and unsupported grants skip cleanly rather than failing.
+    """
+    try:
+        return source.mint(provider, grant, **kwargs)
+    except HarnessCapabilityError as exc:
+        pytest.skip(f"capability-gated: {exc}")
+    except HarnessCredentialError as exc:
+        pytest.skip(f"credential-gated: {exc}")
+
+
+def _validate(token: str, test_config, require_https) -> dict:
+    """Validate a token against the live provider's discovery + JWKS."""
+    config = TokenValidationConfig(
+        perform_disco=True,
+        audience=test_config["TEST_AUDIENCE"],
+        options=DEFAULT_VALIDATION_OPTIONS,
+        require_https=require_https,
+    )
+    return validate_token(
+        jwt=token,
+        disco_doc_address=test_config["TEST_DISCO_ADDRESS"],
+        token_validation_config=config,
+    )
+
+
+def test_client_credentials_mint_validates_end_to_end(
+    token_source, harness_provider, test_config, require_https
+):
+    """DoD: a client-credentials mint validates against the live JWKS."""
+    if harness_provider is None:
+        pytest.skip("no real provider wired for this env file")
+
+    minted = _mint_or_skip(token_source, harness_provider, Grant.CLIENT_CREDENTIALS)
+    assert minted.access_token
+    assert minted.provider is harness_provider
+    assert minted.grant is Grant.CLIENT_CREDENTIALS
+
+    claims = _validate(minted.access_token, test_config, require_https)
+    assert claims["iss"]
+    assert claims["exp"]
+
+
+def test_auth_code_mint_validates_when_capable(
+    token_source, harness_provider, test_config, require_https
+):
+    """Auth-code mint validates end-to-end where the provider supports it.
+
+    Skips (capability/credential-gated) on providers without devInteractions
+    or an auth-code client — the same gating the correctness matrix relies on.
+    """
+    if harness_provider is None:
+        pytest.skip("no real provider wired for this env file")
+
+    minted = _mint_or_skip(token_source, harness_provider, Grant.AUTHORIZATION_CODE)
+    assert minted.access_token
+    assert minted.grant is Grant.AUTHORIZATION_CODE
+
+    # Only JWT-format access tokens are library-validatable; opaque tokens are
+    # a legitimate outcome for some providers (introspection territory).
+    if minted.access_token.count(".") == JWT_SEGMENT_SEPARATOR_COUNT:
+        claims = _validate(minted.access_token, test_config, require_https)
+        assert claims["iss"]
+
+
+def test_replay_pool_mints_once_and_replays(token_source, harness_provider):
+    """The pre-minted pool mints each spec once and replays the same token."""
+    if harness_provider is None:
+        pytest.skip("no real provider wired for this env file")
+
+    spec = MintSpec(provider=harness_provider, grant=Grant.CLIENT_CREDENTIALS)
+    try:
+        pool = prime_pool(token_source, [spec, spec])
+    except (HarnessCapabilityError, HarnessCredentialError) as exc:
+        pytest.skip(f"gated: {exc}")
+
+    # Duplicate specs collapse to a single mint (rate-limit friendly).
+    assert len(pool) == 1
+    minted = pool.get(spec)
+    assert minted.access_token
+    # expires_at is tracked so T311 can re-mint across the 300s TTL.
+    assert minted.expires_at is None or minted.expires_at > 0
+
+
+def test_forged_tokens_require_mock_provider(token_source, harness_provider):
+    """A real provider refuses to emit forged tokens (deterministic gating).
+
+    Real OPs will not mint invalid tokens; the harness enforces that forgery
+    is MOCK-only, so the forged corpus stays in one controllable place.
+    """
+    if harness_provider is None:
+        pytest.skip("no real provider wired for this env file")
+
+    with pytest.raises(HarnessCapabilityError):
+        token_source.mint(
+            harness_provider,
+            Grant.CLIENT_CREDENTIALS,
+            malform=Malform.TAMPERED_SIG,
+        )
+
+
+def test_mock_provider_always_mintable(token_source):
+    """MOCK is always available regardless of which real provider is wired."""
+    minted = token_source.mint(Provider.MOCK, Grant.CLIENT_CREDENTIALS)
+    assert minted.provider is Provider.MOCK
+    assert minted.malform is Malform.VALID
+    assert minted.access_token.count(".") == JWT_SEGMENT_SEPARATOR_COUNT
+
+
+def test_credential_gating_raises_typed_error():
+    """A real provider without credentials raises ``HarnessCredentialError``.
+
+    Proves the contract the ``token_source`` fixture leans on to turn
+    secret-gated providers (Ory/Descope) into clean ``pytest.skip``.
+    """
+    credentialless = ProviderConfig(
+        provider=Provider.ORY,
+        capabilities={"client_credentials"},
+        token_endpoint="https://example.test/oauth2/token",
+    )
+    source = TokenSource.with_mock(extra=[credentialless])
+    with pytest.raises(HarnessCredentialError):
+        source.mint(Provider.ORY, Grant.CLIENT_CREDENTIALS)

--- a/src/tests/unit/test_mock_op.py
+++ b/src/tests/unit/test_mock_op.py
@@ -1,0 +1,228 @@
+"""Unit tests for the controllable mock OP and forged corpus (TH-1.1, #463).
+
+Deterministic and network-free: the framework-free ASGI app is driven in-process
+via ``httpx.ASGITransport``, and the *real* library
+(:func:`py_identity_model.aio.validate_token`) validates minted / forged tokens
+through the mock OP's discovery + JWKS documents.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from py_identity_model.aio.managed_client import AsyncHTTPClient
+from py_identity_model.aio.token_validation import validate_token
+from py_identity_model.core.models import TokenValidationConfig
+from py_identity_model.exceptions import PyIdentityModelException
+
+from ..harness import CORPUS_AUDIENCE, MockOP, build_corpus
+from ..harness import mock_op as mock_op_mod
+
+
+HTTP_OK = 200
+HTTP_TOO_MANY_REQUESTS = 429
+HTTP_SERVICE_UNAVAILABLE = 503
+PUBLISHED_KEY_COUNT = 2
+OVERSIZED_PADDING = 50
+
+
+def _client(mock: MockOP) -> AsyncHTTPClient:
+    """An AsyncHTTPClient routed at the in-process mock OP (no network)."""
+    transport = httpx.ASGITransport(app=mock.app)
+    return AsyncHTTPClient(
+        client=httpx.AsyncClient(
+            transport=transport, base_url=mock.issuer, follow_redirects=False
+        )
+    )
+
+
+def _validation_config() -> TokenValidationConfig:
+    return TokenValidationConfig(
+        perform_disco=True,
+        audience=CORPUS_AUDIENCE,
+        algorithms=["RS256", "ES256"],
+        require_https=False,
+    )
+
+
+async def _validate(mock: MockOP, token: str) -> dict:
+    client = _client(mock)
+    try:
+        return await validate_token(
+            token,
+            _validation_config(),
+            disco_doc_address=mock.discovery_url,
+            http_client=client,
+        )
+    finally:
+        await client.close()
+
+
+# -- Documents served over ASGI --------------------------------------------
+
+
+async def test_discovery_document_served() -> None:
+    mock = MockOP()
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        resp = await client.get(mock.discovery_url)
+    assert resp.status_code == HTTP_OK
+    doc = resp.json()
+    assert doc["issuer"] == mock.issuer
+    assert doc["jwks_uri"] == mock.jwks_uri
+    assert doc["token_endpoint"] == mock.token_endpoint
+
+
+async def test_jwks_served_with_published_keys() -> None:
+    mock = MockOP()
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        resp = await client.get(mock.jwks_uri)
+    kids = {k["kid"] for k in resp.json()["keys"]}
+    assert mock.primary_key.kid in kids
+    assert mock.ec_key.kid in kids
+    assert mock.unpublished_key.kid not in kids
+
+
+async def test_token_endpoint_mints_valid_token() -> None:
+    mock = MockOP()
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        resp = await client.post(
+            mock.token_endpoint,
+            data={"grant_type": "client_credentials", "scope": "read"},
+        )
+    body = resp.json()
+    assert body["token_type"] == "Bearer"
+    claims = await _validate(mock, body["access_token"])
+    assert claims["iss"] == mock.issuer
+
+
+# -- End-to-end validation of the corpus -----------------------------------
+
+
+async def test_valid_token_validates_end_to_end() -> None:
+    mock = MockOP()
+    corpus = build_corpus(mock)
+    claims = await _validate(mock, corpus["valid"].jwt)
+    assert claims["scope"] == "read"
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "expired",
+        "nbf_future",
+        "wrong_iss",
+        "wrong_aud",
+        "tampered_sig",
+        "unknown_kid",
+        "wrong_alg",
+        "alg_none",
+    ],
+)
+async def test_forged_tokens_are_rejected(name: str) -> None:
+    mock = MockOP()
+    forged = build_corpus(mock)[name]
+    assert forged.library_rejects is True
+    with pytest.raises(PyIdentityModelException):
+        await _validate(mock, forged.jwt)
+
+
+@pytest.mark.parametrize("name", ["id_as_access", "cnf_bound", "oversized"])
+async def test_library_accepted_classes_are_signature_valid(name: str) -> None:
+    # These are validly signed for the audience — the library ACCEPTS them.
+    # Only the RS access-token marker / require_scope layer (F-07/F-02) rejects
+    # them; that distinction is proven in T302, not here.
+    mock = MockOP()
+    forged = build_corpus(mock)[name]
+    assert forged.library_rejects is False
+    claims = await _validate(mock, forged.jwt)
+    assert claims["iss"] == mock.issuer
+
+
+# -- Failure injection (design §2) -----------------------------------------
+
+
+async def test_key_rotation_then_republish() -> None:
+    mock = MockOP()
+    # Rotate to the spare WITHOUT publishing -> tokens present an unknown kid.
+    mock.rotate_keys(publish=False)
+    token = mock.mint_access_token()["access_token"]
+    with pytest.raises(PyIdentityModelException):
+        await _validate(mock, token)
+    # Publishing the rotated key lets the same token validate on refetch.
+    mock.publish_signing_key()
+    claims = await _validate(mock, token)
+    assert claims["iss"] == mock.issuer
+
+
+async def test_empty_jwks_control() -> None:
+    mock = MockOP()
+    mock.controls.serve_empty_jwks = True
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        resp = await client.get(mock.jwks_uri)
+    assert resp.json()["keys"] == []
+
+
+async def test_oversized_jwks_control() -> None:
+    mock = MockOP()
+    mock.controls.oversized_jwks_padding = OVERSIZED_PADDING
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        resp = await client.get(mock.jwks_uri)
+    assert len(resp.json()["keys"]) == PUBLISHED_KEY_COUNT + OVERSIZED_PADDING
+
+
+async def test_rate_limit_control_sets_retry_after() -> None:
+    mock = MockOP()
+    mock.controls.discovery_status = HTTP_TOO_MANY_REQUESTS
+    mock.controls.retry_after = "3"
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        resp = await client.get(mock.discovery_url)
+    assert resp.status_code == HTTP_TOO_MANY_REQUESTS
+    assert resp.headers["retry-after"] == "3"
+
+
+async def test_no_store_cache_control_on_jwks() -> None:
+    mock = MockOP()
+    mock.controls.jwks_cache_control = "no-store"
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        resp = await client.get(mock.jwks_uri)
+    assert resp.headers["cache-control"] == "no-store"
+
+
+async def test_injected_latency(monkeypatch: pytest.MonkeyPatch) -> None:
+    mock = MockOP()
+    slept: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        slept.append(seconds)
+
+    monkeypatch.setattr(mock_op_mod.asyncio, "sleep", fake_sleep)
+    mock.controls.latency_seconds = 0.25
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        await client.get(mock.discovery_url)
+    assert slept == [0.25]
+
+
+async def test_control_route_rotates_and_sets_knobs() -> None:
+    mock = MockOP()
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        resp = await client.post(
+            f"{mock.issuer}/_control",
+            json={
+                "rotate": True,
+                "publish": True,
+                "jwks_status": HTTP_SERVICE_UNAVAILABLE,
+            },
+        )
+    assert resp.json() == {"ok": True}
+    assert mock.controls.jwks_status == HTTP_SERVICE_UNAVAILABLE
+    assert mock.signing_key is mock.rotation_key

--- a/src/tests/unit/test_mock_op.py
+++ b/src/tests/unit/test_mock_op.py
@@ -9,6 +9,7 @@ through the mock OP's discovery + JWKS documents.
 from __future__ import annotations
 
 import httpx
+import jwt
 import pytest
 
 from py_identity_model.aio.managed_client import AsyncHTTPClient
@@ -223,6 +224,59 @@ async def test_control_route_rotates_and_sets_knobs() -> None:
                 "jwks_status": HTTP_SERVICE_UNAVAILABLE,
             },
         )
-    assert resp.json() == {"ok": True}
+    assert resp.json() == {"ok": True, "rejected": []}
     assert mock.controls.jwks_status == HTTP_SERVICE_UNAVAILABLE
     assert mock.signing_key is mock.rotation_key
+
+
+async def test_control_route_rejects_type_mismatched_values() -> None:
+    """A stray JSON type must be rejected at the control call, not crash a later
+    request (design: fail local, not downstream)."""
+    mock = MockOP()
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        resp = await client.post(
+            f"{mock.issuer}/_control",
+            json={
+                "jwks_status": "boom",  # str for an int field -> reject
+                "retry_after": 3,  # int for a str|None field -> reject
+                "oversized_jwks_padding": "big",  # str for an int field -> reject
+                "discovery_status": HTTP_SERVICE_UNAVAILABLE,  # valid int -> apply
+            },
+        )
+        body = resp.json()
+        # The valid knob applied; the mismatches were reported, not applied.
+        assert body["ok"] is True
+        assert set(body["rejected"]) == {
+            "jwks_status",
+            "retry_after",
+            "oversized_jwks_padding",
+        }
+        assert mock.controls.jwks_status == HTTP_OK
+        assert mock.controls.retry_after is None
+        assert mock.controls.oversized_jwks_padding == 0
+        assert mock.controls.discovery_status == HTTP_SERVICE_UNAVAILABLE
+        # The next /jwks request must still succeed (no poisoned state).
+        mock.controls.jwks_status = HTTP_OK
+        jwks = await client.get(mock.jwks_uri)
+        assert jwks.status_code == HTTP_OK
+
+
+def test_introspect_reports_active_for_valid_token() -> None:
+    mock = MockOP()
+    minted = mock.mint_access_token()
+    result = mock.introspect(minted["access_token"])
+    assert result["active"] is True
+
+
+def test_introspect_survives_malformed_exp() -> None:
+    """A token with a non-numeric ``exp`` (exactly what this harness forges)
+    must report inactive, not 500 the introspect endpoint."""
+    token = jwt.encode({"exp": "not-a-number"}, "x" * 32, algorithm="HS256")
+    result = MockOP().introspect(token)
+    assert result["active"] is False
+
+
+def test_introspect_reports_inactive_for_non_jwt() -> None:
+    result = MockOP().introspect("not.a.jwt")
+    assert result["active"] is False

--- a/src/tests/unit/test_token_source_gating.py
+++ b/src/tests/unit/test_token_source_gating.py
@@ -8,7 +8,12 @@ is always mintable (valid + forged).
 
 from __future__ import annotations
 
+import base64
+import json
+
+import jwt
 import pytest
+import respx
 
 from ..harness import (
     Grant,
@@ -21,6 +26,7 @@ from ..harness import (
     TokenSource,
     prime_pool,
 )
+from ..harness.token_source import _peek_jwt_header
 
 
 JWT_SEGMENT_COUNT = 2
@@ -135,6 +141,72 @@ def test_auth_code_minter_is_invoked() -> None:
     )
     assert token.access_token == "opaque-token"
     assert calls == [("t1", "openid")]
+
+
+def test_descope_multitenant_requires_management_creds() -> None:
+    # Plain CC creds present, but the multi-tenant (tenant=…) path needs the
+    # access-key exchange config; absent -> credential error (drives skip).
+    descope = ProviderConfig(
+        provider=Provider.DESCOPE,
+        capabilities={"client_credentials"},
+        token_endpoint="https://api.descope.com/oauth2/v1/token",
+        client_id="cid",
+        client_secret="secret",
+    )
+    source = TokenSource([descope])
+    with pytest.raises(HarnessCredentialError, match="multi-tenant"):
+        source.mint(Provider.DESCOPE, Grant.CLIENT_CREDENTIALS, tenant="t1")
+
+
+@respx.mock
+def test_descope_multitenant_exchange_produces_dct_tenants() -> None:
+    # AC-3: the multi-tenant path reuses access-key create -> exchange -> delete
+    # and returns the session JWT carrying distinct dct/tenants claims.
+    base = "https://api.descope.com"
+    session_jwt = jwt.encode(
+        {"sub": "u1", "dct": "t1", "tenants": {"t1": {"roles": ["admin"]}}},
+        "x" * 32,
+        algorithm="HS256",
+    )
+    create = respx.post(f"{base}/v1/mgmt/accesskey/create").respond(
+        json={"key": {"id": "k1"}, "cleartext": "ck"}
+    )
+    exchange = respx.post(f"{base}/v1/auth/accesskey/exchange").respond(
+        json={"sessionJwt": session_jwt}
+    )
+    delete = respx.post(f"{base}/v1/mgmt/accesskey/delete").respond(json={})
+
+    cfg = ProviderConfig(
+        provider=Provider.DESCOPE,
+        capabilities={"client_credentials"},
+        descope_project_id="P1",
+        descope_management_key="MK",
+        descope_base_url=base,
+    )
+    token = TokenSource([cfg]).mint(
+        Provider.DESCOPE, Grant.CLIENT_CREDENTIALS, tenant="t1"
+    )
+
+    assert token.access_token == session_jwt
+    assert token.tenant == "t1"
+    # keyTenants array shaping (not top-level tenantId) is what yields dct/tenants.
+    body = json.loads(create.calls.last.request.content)
+    assert body["keyTenants"] == [{"tenantId": "t1", "roleNames": ["owner", "admin"]}]
+    payload = json.loads(
+        base64.urlsafe_b64decode(token.access_token.split(".")[1] + "==").decode()
+    )
+    assert payload["dct"] == "t1"
+    assert "t1" in payload["tenants"]
+    assert exchange.called
+    assert delete.called  # temporary key cleaned up
+
+
+def test_peek_jwt_header_guards_non_object_header() -> None:
+    """A JWT whose header segment decodes to a non-object (e.g. ``5``) must not
+    crash header inspection — return ``(None, None)`` like an opaque token."""
+    non_object_header = base64.urlsafe_b64encode(b"5").rstrip(b"=").decode()
+    token = f"{non_object_header}.{non_object_header}.sig"
+    assert _peek_jwt_header(token) == (None, None)
 
 
 def test_replay_pool_mints_once() -> None:

--- a/src/tests/unit/test_token_source_gating.py
+++ b/src/tests/unit/test_token_source_gating.py
@@ -1,0 +1,150 @@
+"""Unit tests for TokenSource capability/credential gating (TH-1.1, #463).
+
+The gating mirrors ``provider_matrix.detect_capabilities``: an unsupported
+grant raises :class:`HarnessCapabilityError`, a supported grant with absent
+credentials raises :class:`HarnessCredentialError`, and the ``MOCK`` provider
+is always mintable (valid + forged).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ..harness import (
+    Grant,
+    HarnessCapabilityError,
+    HarnessCredentialError,
+    Malform,
+    MintSpec,
+    Provider,
+    ProviderConfig,
+    TokenSource,
+    prime_pool,
+)
+
+
+JWT_SEGMENT_COUNT = 2
+DEDUPED_POOL_SIZE = 2
+
+
+def test_mock_provider_is_always_mintable() -> None:
+    source = TokenSource.with_mock()
+    token = source.mint(Provider.MOCK, Grant.CLIENT_CREDENTIALS)
+    assert token.provider is Provider.MOCK
+    assert token.malform is Malform.VALID
+    assert token.access_token.count(".") == JWT_SEGMENT_COUNT  # a real JWT
+    assert token.expires_at is not None
+    assert token.alg == "RS256"
+
+
+def test_mock_provider_mints_every_forged_class() -> None:
+    source = TokenSource.with_mock()
+    for malform in Malform:
+        token = source.mint(Provider.MOCK, malform=malform)
+        assert token.malform is malform
+        assert token.access_token  # non-empty
+
+
+def test_forged_tokens_are_mock_only() -> None:
+    node = ProviderConfig(
+        provider=Provider.NODE_OIDC,
+        capabilities={"client_credentials"},
+        token_endpoint="https://issuer.example/token",
+        client_id="cid",
+        client_secret="secret",
+    )
+    source = TokenSource([node])
+    with pytest.raises(HarnessCapabilityError, match="MOCK provider"):
+        source.mint(Provider.NODE_OIDC, malform=Malform.ALG_NONE)
+
+
+def test_capability_gating_rejects_unsupported_grant() -> None:
+    # Advertises only client_credentials — auth_code must be capability-gated.
+    node = ProviderConfig(
+        provider=Provider.NODE_OIDC,
+        capabilities={"client_credentials"},
+        token_endpoint="https://issuer.example/token",
+        client_id="cid",
+        client_secret="secret",
+    )
+    source = TokenSource([node])
+    with pytest.raises(HarnessCapabilityError, match="authorization_code"):
+        source.mint(Provider.NODE_OIDC, Grant.AUTHORIZATION_CODE)
+
+
+def test_credential_gating_when_secret_absent() -> None:
+    # Capability present, credentials missing -> credential error (drives skip).
+    ory = ProviderConfig(
+        provider=Provider.ORY,
+        capabilities={"client_credentials"},
+        token_endpoint="https://issuer.example/token",
+        client_id=None,
+        client_secret=None,
+    )
+    source = TokenSource([ory])
+    with pytest.raises(HarnessCredentialError):
+        source.mint(Provider.ORY, Grant.CLIENT_CREDENTIALS)
+
+
+def test_auth_code_requires_injected_minter() -> None:
+    keycloak = ProviderConfig(
+        provider=Provider.KEYCLOAK,
+        capabilities={"authorization_code"},
+    )
+    source = TokenSource([keycloak])
+    with pytest.raises(HarnessCredentialError, match="auth-code minter"):
+        source.mint(Provider.KEYCLOAK, Grant.AUTHORIZATION_CODE)
+
+
+def test_unconfigured_provider_raises_capability_error() -> None:
+    source = TokenSource.with_mock()
+    with pytest.raises(HarnessCapabilityError, match="not configured"):
+        source.mint(Provider.DESCOPE, Grant.CLIENT_CREDENTIALS)
+
+
+def test_from_discovery_derives_capabilities() -> None:
+    disco = {
+        "issuer": "http://localhost:9000",
+        "token_endpoint": "http://localhost:9000/token",
+        "authorization_endpoint": "http://localhost:9000/auth",
+        "grant_types_supported": ["client_credentials", "authorization_code"],
+    }
+    cfg = ProviderConfig.from_discovery(
+        Provider.NODE_OIDC, disco, client_id="cid", client_secret="secret"
+    )
+    assert "client_credentials" in cfg.capabilities
+    assert "authorization_code" in cfg.capabilities
+    assert cfg.token_endpoint == "http://localhost:9000/token"
+
+
+def test_auth_code_minter_is_invoked() -> None:
+    calls: list[tuple[str | None, str | None]] = []
+
+    def minter(tenant: str | None, scopes: str | None) -> dict:
+        calls.append((tenant, scopes))
+        return {"access_token": "opaque-token", "token_type": "Bearer"}
+
+    cfg = ProviderConfig(
+        provider=Provider.KEYCLOAK,
+        capabilities={"authorization_code"},
+        auth_code_minter=minter,
+    )
+    source = TokenSource([cfg])
+    token = source.mint(
+        Provider.KEYCLOAK, Grant.AUTHORIZATION_CODE, tenant="t1", scopes="openid"
+    )
+    assert token.access_token == "opaque-token"
+    assert calls == [("t1", "openid")]
+
+
+def test_replay_pool_mints_once() -> None:
+    source = TokenSource.with_mock()
+    specs = [
+        MintSpec(Provider.MOCK, Grant.CLIENT_CREDENTIALS),
+        MintSpec(Provider.MOCK, Grant.CLIENT_CREDENTIALS),  # duplicate -> deduped
+        MintSpec(Provider.MOCK, malform=Malform.EXPIRED),
+    ]
+    pool = prime_pool(source, specs)
+    assert len(pool) == DEDUPED_POOL_SIZE
+    valid = pool.get(MintSpec(Provider.MOCK, Grant.CLIENT_CREDENTIALS))
+    assert valid.malform is Malform.VALID


### PR DESCRIPTION
## Summary
Introduces the shared token-harness package `src/tests/harness/` (TH-1.1), the foundation for the E2E Token-Blaster harness (epic #462):

- **`token_source.py`** — one unified `TokenSource.mint(provider, grant, tenant, scopes, malform)` consolidating the per-provider conftest minters (client-credentials, JWT/opaque access, auth-code) and the Descope multi-tenant access-key exchange minter. Capability/credential-gated via `provider_matrix.detect_capabilities`, raising typed `HarnessCapabilityError`/`HarnessCredentialError` that conftest translates to `pytest.skip`. Includes the pre-minted **replay pool** (`prime_pool`, xdist FileLock + JSON cache) tracking `expires_at` for the 300s TTL.
- **`mock_op.py`** — a framework-free ASGI OIDC stub holding a known RS256+ES256 signing key. Serves discovery/JWKS/token/optional introspection, with T311 failure-injection tunables (latency, 429/Retry-After, 5xx, rotate-key-on-command, no-store, empty/oversized JWKS) via a mutable `MockOPControls` + loopback-only `/_control` route.
- **`corpus.py`** — the forged/negative token corpus off the mock-OP key: tampered-sig, unknown-kid, wrong-alg/`alg:none`, wrong-iss/aud, id-as-access, cnf-bound-as-bearer, oversized/many-claim, multi-aud.
- **conftest** — additive session `token_source` + `harness_provider` fixtures; the 32 existing integration tests stay green (no minter fixtures rewritten).

Real Descope multi-tenant exchange (`/v1/auth/accesskey/exchange`) mirrors the identity-stack e2e helpers, credential-gated on `DESCOPE_PROJECT_ID`/`MANAGEMENT_KEY`/`BASE_URL`/`TEST_TENANT_ID`.

Refs #463
Epic #462

## Review Findings Addressed
3 adversarial reviewers (Blind + Edge + Acceptance). All P0 fixed:
- mock OP introspect non-numeric `exp` → try/except (`active:false`)
- mock OP `/_control` untyped setattr → `_set_control` type-checks vs `MockOPControls` fields
- `_peek_jwt_header` non-object JWT header → `isinstance(dict)` guard
- AC-3 Descope multi-tenant `dct`/`tenants` → real access-key exchange implemented
- P1: `/_control` documented loopback-only. P2: delete access-key even on empty-cleartext.

## Test plan
- [x] Unit tests pass — `make test-unit`: 1586 passed, 13 xfailed
- [x] Integration tests pass — `make test-integration-node-oidc` (Docker, no creds): 139 passed, 13 skipped, EXIT=0 (DoD real-IdP proof green; new Descope test skips off-Descope)
- [ ] E2E tests pass (n/a — test harness)
- [x] Lint passes — `make lint` (ruff + ruff-format + pyrefly + pytest-cov)
- [x] Independent review agents passed
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)