### PR TITLE
test(harness): boot fastapi-identity-model as a real resource server (TH-1.2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,15 @@ test-integration-keycloak: ## Run integration tests against Keycloak
 		(docker compose -f test-fixtures/keycloak/docker-compose.yml down && exit 1)
 	docker compose -f test-fixtures/keycloak/docker-compose.yml down
 
+.PHONY: test-harness-rs
+test-harness-rs: ## Boot the RS (uvicorn) against node-oidc and run the TH-1.2 real-HTTP proof
+	@echo "Starting node-oidc-provider fixture..."
+	docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml up -d --build --wait
+	@echo "Booting fastapi-identity-model RS under uvicorn (real HTTP)..."
+	uv run --all-packages pytest src/tests/integration/test_rs_boot.py -m integration --env-file=.env.node-oidc -v || \
+		(docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml down && exit 1)
+	docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml down
+
 .PHONY: test-benchmark
 test-benchmark: ## Run benchmarks
 	uv run pytest src/tests/benchmarks -v --benchmark-only --benchmark-sort=name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,10 @@ project_excludes = [
     "examples/descope/",
     "packages/fastapi-identity-model/",
     "conformance/",
+    # Harness RS app imports the fastapi stack, unresolved in the root lint env
+    # (same rationale as packages/). Exercised via `make test-harness-rs`
+    # under `uv run --all-packages`.
+    "src/tests/harness/rs_app.py",
     # release tooling imports python-semantic-release, which the dev env
     # doesn't install; validated by the release pipeline itself
     "tools/",

--- a/src/tests/harness/__init__.py
+++ b/src/tests/harness/__init__.py
@@ -1,0 +1,5 @@
+"""Token-blaster harness helpers (TH-1.x).
+
+Test-only infrastructure for booting py-identity-model as a real resource
+server and driving it over HTTP. Not part of the shipped library.
+"""

--- a/src/tests/harness/rs_app.py
+++ b/src/tests/harness/rs_app.py
@@ -33,11 +33,16 @@ def _truthy(value: str | None) -> bool:
 
 def _excluded_paths() -> list[str] | None:
     """Parse ``RS_EXCLUDED_PATHS`` (comma-separated) or return ``None`` so the
-    middleware falls back to its own defaults (which include ``/health``)."""
+    middleware falls back to its own defaults (which include ``/health``).
+
+    An unset OR empty ``RS_EXCLUDED_PATHS`` both fall back to the middleware
+    defaults. An empty string (which is what ``boot_rs(excluded_paths=[])``
+    serializes to) must NOT be read as an explicit "exclude nothing" list —
+    that would drop the ``/health`` exclusion and break the readiness poll."""
     raw = os.environ.get("RS_EXCLUDED_PATHS")
-    if raw is None:
+    if not raw:
         return None
-    return [p for p in raw.split(",") if p]
+    return [p for p in raw.split(",") if p] or None
 
 
 def create_app() -> FastAPI:

--- a/src/tests/harness/rs_app.py
+++ b/src/tests/harness/rs_app.py
@@ -1,0 +1,90 @@
+"""Greenfield FastAPI resource server for the token-blaster harness (TH-1.2).
+
+A minimal RS that mounts ``TokenValidationMiddleware`` and guards routes with
+``require_scope``. All configuration comes from ``RS_*`` environment variables
+so uvicorn ``--workers N`` forked workers each re-import this module and rebuild
+an identical app (the workers are forked *after* import-string resolution, so
+they cannot share a closure — only the env).
+
+This is the ONLY harness module that imports FastAPI / fastapi-identity-model.
+It is excluded from the root pyrefly lint env (see ``[tool.pyrefly]
+project_excludes`` in ``pyproject.toml``) because that env installs only
+py-identity-model and cannot resolve the fastapi stack; it is exercised via
+``make test-harness-rs`` under ``uv run --all-packages``.
+"""
+
+from __future__ import annotations
+
+import os
+
+from fastapi import Depends, FastAPI
+
+from fastapi_identity_model import (
+    Claims,
+    CurrentUser,
+    TokenValidationMiddleware,
+    require_scope,
+)
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _excluded_paths() -> list[str] | None:
+    """Parse ``RS_EXCLUDED_PATHS`` (comma-separated) or return ``None`` so the
+    middleware falls back to its own defaults (which include ``/health``)."""
+    raw = os.environ.get("RS_EXCLUDED_PATHS")
+    if raw is None:
+        return None
+    return [p for p in raw.split(",") if p]
+
+
+def create_app() -> FastAPI:
+    """Build the resource-server app from ``RS_*`` env config.
+
+    Required env: ``RS_DISCOVERY_URL``, ``RS_AUDIENCE``.
+    Optional env: ``RS_REQUIRE_SCOPE`` (default ``api``),
+    ``RS_REQUIRE_ACCESS_TOKEN_MARKER`` (bool, F-07 opt-in),
+    ``RS_EXCLUDED_PATHS`` (comma-separated).
+    """
+    discovery_url = os.environ["RS_DISCOVERY_URL"]
+    audience = os.environ["RS_AUDIENCE"]
+    required_scope = os.environ.get("RS_REQUIRE_SCOPE", "api")
+
+    app = FastAPI(title="token-harness-rs")
+    app.add_middleware(
+        TokenValidationMiddleware,
+        discovery_url=discovery_url,
+        audience=audience,
+        excluded_paths=_excluded_paths(),
+        require_access_token_marker=_truthy(
+            os.environ.get("RS_REQUIRE_ACCESS_TOKEN_MARKER")
+        ),
+    )
+
+    @app.get("/health")
+    def health() -> dict:
+        # Excluded from auth (middleware default) — the readiness probe target.
+        return {"status": "ok"}
+
+    @app.get("/protected", dependencies=[Depends(require_scope(required_scope))])
+    def protected(claims: Claims) -> dict:
+        # Reached only after the middleware validated the token AND the token
+        # carries ``required_scope`` (else require_scope raises 403).
+        return {
+            "sub": claims.get("sub"),
+            "scope": claims.get("scope") or claims.get("scp"),
+        }
+
+    @app.get("/whoami")
+    def whoami(user: CurrentUser) -> dict:
+        identity = user.identity
+        return {"name": identity.name if identity is not None else None}
+
+    return app
+
+
+# Module-level app so uvicorn can boot it by import string
+# (``src.tests.harness.rs_app:app``) and forked workers re-import identically.
+app = create_app()

--- a/src/tests/harness/rs_server.py
+++ b/src/tests/harness/rs_server.py
@@ -15,8 +15,9 @@ from pathlib import Path
 import socket
 import subprocess
 import sys
+import tempfile
 import time
-from typing import TYPE_CHECKING
+from typing import IO, TYPE_CHECKING
 
 import httpx
 
@@ -43,12 +44,23 @@ def _free_port() -> int:
         return int(sock.getsockname()[1])
 
 
-def _drain(proc: subprocess.Popen[str]) -> str:
-    return proc.stdout.read() if proc.stdout is not None else ""
+def _drain(log: IO[str]) -> str:
+    """Return everything uvicorn has written to its capture file so far.
+
+    Reading from a seekable temp file (not a live PIPE) never blocks: the child
+    writes to its own inherited fd and we snapshot from position 0. This also
+    means the child can emit an arbitrarily large traceback without filling an
+    OS pipe buffer and deadlocking on ``write()`` (blind/edge SHOULD-FIX).
+    """
+    try:
+        log.seek(0)
+        return log.read()
+    except (OSError, ValueError):  # pragma: no cover - defensive, file closed
+        return ""
 
 
 def _wait_for_health(
-    proc: subprocess.Popen[str], base_url: str, timeout: float
+    proc: subprocess.Popen[str], log: IO[str], base_url: str, timeout: float
 ) -> None:
     deadline = time.monotonic() + timeout
     last_error = "no attempt made"
@@ -56,7 +68,7 @@ def _wait_for_health(
         if proc.poll() is not None:
             raise RuntimeError(
                 f"uvicorn exited before becoming healthy "
-                f"(code {proc.returncode}):\n{_drain(proc)}"
+                f"(code {proc.returncode}):\n{_drain(log)}"
             )
         try:
             response = httpx.get(f"{base_url}/health", timeout=2.0)
@@ -70,7 +82,7 @@ def _wait_for_health(
     proc.terminate()
     raise RuntimeError(
         f"resource server did not become healthy within {timeout}s "
-        f"(last: {last_error}):\n{_drain(proc)}"
+        f"(last: {last_error}):\n{_drain(log)}"
     )
 
 
@@ -117,40 +129,46 @@ def boot_rs(  # noqa: PLR0913 — each RS knob (issuer/audience/scope/workers/..
     if extra_env:
         env.update(extra_env)
 
-    proc = subprocess.Popen(  # noqa: S603 — fixed argv, no shell, test-only
-        [
-            sys.executable,
-            "-m",
-            "uvicorn",
-            "src.tests.harness.rs_app:app",
-            "--host",
-            "127.0.0.1",
-            "--port",
-            str(port),
-            "--workers",
-            str(workers),
-            "--log-level",
-            "warning",
-        ],
-        cwd=str(_REPO_ROOT),
-        env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-    )
-    try:
-        _wait_for_health(proc, base_url, timeout)
-        yield base_url
-    finally:
-        proc.terminate()
+    # Capture uvicorn output to a seekable temp file rather than a PIPE. A PIPE
+    # is only drained on the failure path, so a healthy-but-chatty worker could
+    # fill the ~64KB OS pipe buffer and block on ``write()``, hanging the server
+    # (blind/edge SHOULD-FIX). A temp file has no such backpressure and reading
+    # it back on failure never blocks. ``TemporaryFile`` also unlinks itself on
+    # close, so there is no lingering fd for the GC to ResourceWarning over.
+    with tempfile.TemporaryFile(mode="w+") as log:
+        proc = subprocess.Popen(  # noqa: S603 — fixed argv, no shell, test-only
+            [
+                sys.executable,
+                "-m",
+                "uvicorn",
+                "src.tests.harness.rs_app:app",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(port),
+                "--workers",
+                str(workers),
+                "--log-level",
+                "warning",
+            ],
+            cwd=str(_REPO_ROOT),
+            env=env,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
         try:
-            proc.wait(timeout=_TERMINATE_GRACE)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            proc.wait(timeout=_TERMINATE_GRACE)
+            _wait_for_health(proc, log, base_url, timeout)
+            yield base_url
         finally:
-            # Close the inherited stdout pipe explicitly. Leaving it to the GC
-            # raises ResourceWarning, which pytest's ``filterwarnings=error``
-            # promotes to an unraisable-exception failure in a later test.
-            if proc.stdout is not None:
-                proc.stdout.close()
+            proc.terminate()
+            try:
+                proc.wait(timeout=_TERMINATE_GRACE)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                # A SIGKILL'd process stuck in uninterruptible I/O may still not
+                # reap within the grace window. Swallow the second timeout so
+                # teardown never raises out of ``finally`` and masks the real
+                # test result (edge [CRASH]).
+                with contextlib.suppress(subprocess.TimeoutExpired):
+                    proc.wait(timeout=_TERMINATE_GRACE)

--- a/src/tests/harness/rs_server.py
+++ b/src/tests/harness/rs_server.py
@@ -1,0 +1,150 @@
+"""Boot the harness resource server (:mod:`rs_app`) under real uvicorn workers.
+
+``boot_rs`` is deliberately free of any FastAPI / fastapi-identity-model import
+so it stays inside the root pyrefly lint env. It launches uvicorn as a
+subprocess by import-string (``src.tests.harness.rs_app:app``), passes RS
+configuration through inherited ``RS_*`` environment variables, waits for the
+``/health`` endpoint to answer over real HTTP, then tears the process down.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from pathlib import Path
+import socket
+import subprocess
+import sys
+import time
+from typing import TYPE_CHECKING
+
+import httpx
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Mapping
+
+
+# src/tests/harness/rs_server.py -> parents[3] is the repo root (holds ``src/``).
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_HEALTH_POLL_INTERVAL = 0.25
+_TERMINATE_GRACE = 10.0
+
+
+def _free_port() -> int:
+    """Bind to an ephemeral port, then release it for uvicorn to reuse.
+
+    A TOCTOU window exists between close and re-bind; the ``/health`` readiness
+    poll (which fails loudly if uvicorn never binds) is the real guard.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _drain(proc: subprocess.Popen[str]) -> str:
+    return proc.stdout.read() if proc.stdout is not None else ""
+
+
+def _wait_for_health(
+    proc: subprocess.Popen[str], base_url: str, timeout: float
+) -> None:
+    deadline = time.monotonic() + timeout
+    last_error = "no attempt made"
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(
+                f"uvicorn exited before becoming healthy "
+                f"(code {proc.returncode}):\n{_drain(proc)}"
+            )
+        try:
+            response = httpx.get(f"{base_url}/health", timeout=2.0)
+            if response.status_code == httpx.codes.OK:
+                return
+            last_error = f"HTTP {response.status_code}"
+        except httpx.HTTPError as exc:
+            last_error = str(exc)
+        time.sleep(_HEALTH_POLL_INTERVAL)
+
+    proc.terminate()
+    raise RuntimeError(
+        f"resource server did not become healthy within {timeout}s "
+        f"(last: {last_error}):\n{_drain(proc)}"
+    )
+
+
+@contextlib.contextmanager
+def boot_rs(  # noqa: PLR0913 — each RS knob (issuer/audience/scope/workers/...) is an explicit keyword
+    *,
+    discovery_url: str,
+    audience: str,
+    require_scope: str = "api",
+    workers: int = 1,
+    require_access_token_marker: bool = False,
+    excluded_paths: list[str] | None = None,
+    extra_env: Mapping[str, str] | None = None,
+    timeout: float = 30.0,
+) -> Iterator[str]:
+    """Boot a single-issuer resource server and yield its base URL.
+
+    Args:
+        discovery_url: OIDC discovery URL the middleware binds to.
+        audience: Expected ``aud`` claim (middleware requires non-empty).
+        require_scope: Scope enforced on ``/protected`` (403 if absent).
+        workers: uvicorn ``--workers`` count (>=2 proves multi-worker boot).
+        require_access_token_marker: F-07 ID-token-substitution defence opt-in.
+        excluded_paths: Override middleware excluded paths (must keep
+            ``/health`` for the readiness poll to pass).
+        extra_env: Additional environment for the uvicorn subprocess.
+        timeout: Seconds to wait for the first healthy ``/health`` response.
+
+    Yields:
+        The ``http://127.0.0.1:<port>`` base URL of the running server.
+    """
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+
+    env = dict(os.environ)
+    env["RS_DISCOVERY_URL"] = discovery_url
+    env["RS_AUDIENCE"] = audience
+    env["RS_REQUIRE_SCOPE"] = require_scope
+    env["RS_REQUIRE_ACCESS_TOKEN_MARKER"] = (
+        "true" if require_access_token_marker else "false"
+    )
+    if excluded_paths is not None:
+        env["RS_EXCLUDED_PATHS"] = ",".join(excluded_paths)
+    if extra_env:
+        env.update(extra_env)
+
+    proc = subprocess.Popen(  # noqa: S603 — fixed argv, no shell, test-only
+        [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            "src.tests.harness.rs_app:app",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--workers",
+            str(workers),
+            "--log-level",
+            "warning",
+        ],
+        cwd=str(_REPO_ROOT),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        _wait_for_health(proc, base_url, timeout)
+        yield base_url
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=_TERMINATE_GRACE)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=_TERMINATE_GRACE)

--- a/src/tests/harness/rs_server.py
+++ b/src/tests/harness/rs_server.py
@@ -148,3 +148,9 @@ def boot_rs(  # noqa: PLR0913 — each RS knob (issuer/audience/scope/workers/..
         except subprocess.TimeoutExpired:
             proc.kill()
             proc.wait(timeout=_TERMINATE_GRACE)
+        finally:
+            # Close the inherited stdout pipe explicitly. Leaving it to the GC
+            # raises ResourceWarning, which pytest's ``filterwarnings=error``
+            # promotes to an unraisable-exception failure in a later test.
+            if proc.stdout is not None:
+                proc.stdout.close()

--- a/src/tests/integration/test_rs_boot.py
+++ b/src/tests/integration/test_rs_boot.py
@@ -11,6 +11,8 @@ so ``fastapi_identity_model`` and ``uvicorn`` resolve). Under plain
 importorskips cleanly.
 """
 
+from urllib.parse import urlparse
+
 import httpx
 import jwt
 import pytest
@@ -26,6 +28,22 @@ pytestmark = pytest.mark.integration
 # resourceIndicators.defaultResource (test-fixtures/node-oidc-provider).
 RS_AUDIENCE = "urn:test:api"
 GENERIC_401_DETAIL = "Invalid or unauthorized token"
+
+
+def _is_node_oidc_fixture(raw_discovery: dict) -> bool:
+    """Whether the active provider is the bundled node-oidc-provider fixture.
+
+    The fixed ``urn:test:api`` audience and ``api`` scope this suite asserts on
+    only exist in the local node-oidc-provider (``resourceIndicators``); the
+    remote CI-matrix providers (Keycloak/Ory/Descope) mint tokens with a
+    different audience/scope, so they must skip. node-oidc serves discovery at
+    the localhost host root — the check that distinguishes it from Keycloak,
+    which also runs on localhost but under ``/realms/<realm>``.
+    """
+    parsed = urlparse(raw_discovery.get("issuer", ""))
+    is_local = parsed.hostname in ("localhost", "127.0.0.1")
+    at_host_root = parsed.path in ("", "/")
+    return is_local and at_host_root
 
 
 def _access_token(client_credentials_token) -> str:
@@ -44,7 +62,12 @@ def _granted_scopes(access_token: str) -> list[str]:
 
 
 @pytest.fixture(scope="module")
-def rs_discovery_url(test_config) -> str:
+def rs_discovery_url(test_config, raw_discovery) -> str:
+    if not _is_node_oidc_fixture(raw_discovery):
+        pytest.skip(
+            "RS boot suite asserts node-oidc's urn:test:api audience / api "
+            "scope; remote matrix providers mint different tokens"
+        )
     return test_config["TEST_DISCO_ADDRESS"]
 
 

--- a/src/tests/integration/test_rs_boot.py
+++ b/src/tests/integration/test_rs_boot.py
@@ -1,0 +1,146 @@
+"""Real-HTTP DoD proof for TH-1.2 (#464 · epic #462).
+
+Boots the greenfield resource server (``TokenValidationMiddleware +
+require_scope``) under real uvicorn workers and drives it over httpx against a
+live node-oidc issuer. This is the acceptance proof that the RS runs the
+shipped middleware end-to-end — not an ASGI in-process shim.
+
+Run via ``make test-harness-rs`` (Docker node-oidc + ``uv run --all-packages``
+so ``fastapi_identity_model`` and ``uvicorn`` resolve). Under plain
+``make test-integration-node-oidc`` the fastapi stack is absent, so the module
+importorskips cleanly.
+"""
+
+import httpx
+import jwt
+import pytest
+
+from ..harness.rs_server import boot_rs
+
+
+pytest.importorskip("fastapi_identity_model")
+
+pytestmark = pytest.mark.integration
+
+# node-oidc issues JWT access tokens with aud=urn:test:api via
+# resourceIndicators.defaultResource (test-fixtures/node-oidc-provider).
+RS_AUDIENCE = "urn:test:api"
+GENERIC_401_DETAIL = "Invalid or unauthorized token"
+
+
+def _access_token(client_credentials_token) -> str:
+    token = client_credentials_token.token.get("access_token", "")
+    assert token, "CC fixture returned no access_token"
+    return token
+
+
+def _granted_scopes(access_token: str) -> list[str]:
+    """Scopes actually present on the minted token (unverified decode)."""
+    claims = jwt.decode(access_token, options={"verify_signature": False})
+    raw = claims.get("scope") or claims.get("scp") or ""
+    if isinstance(raw, str):
+        return raw.split()
+    return [s for s in raw if isinstance(s, str)]
+
+
+@pytest.fixture(scope="module")
+def rs_discovery_url(test_config) -> str:
+    return test_config["TEST_DISCO_ADDRESS"]
+
+
+def test_valid_token_reaches_protected_route(
+    rs_discovery_url, client_credentials_token
+):
+    """Valid CC token → 200, body echoes the validated claims."""
+    access_token = _access_token(client_credentials_token)
+    scopes = _granted_scopes(access_token)
+    assert scopes, "minted token carried no scopes to guard on"
+
+    with boot_rs(
+        discovery_url=rs_discovery_url,
+        audience=RS_AUDIENCE,
+        require_scope=scopes[0],
+    ) as base_url:
+        response = httpx.get(
+            f"{base_url}/protected",
+            headers={"Authorization": f"Bearer {access_token}"},
+            timeout=10.0,
+        )
+
+    assert response.status_code == httpx.codes.OK
+    body = response.json()
+    assert body["sub"]
+    assert scopes[0] in (body["scope"] or "")
+
+
+def test_missing_authorization_is_uniform_401(rs_discovery_url):
+    """No Authorization header → 401 with the middleware's own detail."""
+    with boot_rs(discovery_url=rs_discovery_url, audience=RS_AUDIENCE) as base_url:
+        response = httpx.get(f"{base_url}/protected", timeout=10.0)
+
+    assert response.status_code == httpx.codes.UNAUTHORIZED
+    assert response.json() == {"detail": "Missing Authorization header"}
+
+
+def test_malformed_bearer_is_uniform_401(rs_discovery_url):
+    """Garbage bearer → 401 with the generic (F-18) uniform body."""
+    with boot_rs(discovery_url=rs_discovery_url, audience=RS_AUDIENCE) as base_url:
+        response = httpx.get(
+            f"{base_url}/protected",
+            headers={"Authorization": "Bearer not-a-real-jwt"},
+            timeout=10.0,
+        )
+
+    assert response.status_code == httpx.codes.UNAUTHORIZED
+    assert response.json() == {"detail": GENERIC_401_DETAIL}
+
+
+def test_missing_required_scope_is_403(rs_discovery_url, client_credentials_token):
+    """Valid token but RS requires a scope the token lacks → 403 (require_scope)."""
+    access_token = _access_token(client_credentials_token)
+    absent_scope = "scope-the-token-does-not-carry"
+    assert absent_scope not in _granted_scopes(access_token)
+
+    with boot_rs(
+        discovery_url=rs_discovery_url,
+        audience=RS_AUDIENCE,
+        require_scope=absent_scope,
+    ) as base_url:
+        response = httpx.get(
+            f"{base_url}/protected",
+            headers={"Authorization": f"Bearer {access_token}"},
+            timeout=10.0,
+        )
+
+    assert response.status_code == httpx.codes.FORBIDDEN
+    assert absent_scope in response.json()["detail"]
+
+
+def test_health_route_is_unauthenticated(rs_discovery_url):
+    """Excluded /health answers 200 with no Authorization (readiness proof)."""
+    with boot_rs(discovery_url=rs_discovery_url, audience=RS_AUDIENCE) as base_url:
+        response = httpx.get(f"{base_url}/health", timeout=10.0)
+
+    assert response.status_code == httpx.codes.OK
+    assert response.json() == {"status": "ok"}
+
+
+def test_boots_under_multiple_workers(rs_discovery_url, client_credentials_token):
+    """uvicorn --workers 2 boots and serves a valid token → 200."""
+    access_token = _access_token(client_credentials_token)
+    scopes = _granted_scopes(access_token)
+    assert scopes, "minted token carried no scopes to guard on"
+
+    with boot_rs(
+        discovery_url=rs_discovery_url,
+        audience=RS_AUDIENCE,
+        require_scope=scopes[0],
+        workers=2,
+    ) as base_url:
+        response = httpx.get(
+            f"{base_url}/protected",
+            headers={"Authorization": f"Bearer {access_token}"},
+            timeout=10.0,
+        )
+
+    assert response.status_code == httpx.codes.OK


### PR DESCRIPTION
## Summary
Greenfield minimal FastAPI resource server booted as a **real** out-of-process uvicorn server, reachable over httpx — the TH-1.2 RS test fixture.

- `src/tests/harness/rs_app.py` — greenfield `TokenValidationMiddleware(audience, require_access_token_marker) + require_scope`-guarded app (NOT the RP login router in `conformance/app_fastapi.py`). Config via `RS_*` env so uvicorn `--workers N` forked workers re-import an identical module-level `app`. Routes: `/health` (excluded), `/protected` (guarded by `require_scope`), `/whoami`.
- `src/tests/harness/rs_server.py` — fastapi-free `boot_rs(...)` context manager: free-port bind, `subprocess` uvicorn by import-string, `/health` readiness poll over httpx, teardown terminate/kill. Kept fastapi-free so pyrefly type-checks it.
- `src/tests/integration/test_rs_boot.py` — real-HTTP DoD: valid CC token → 200; missing/malformed auth → uniform 401; missing scope → 403; `/health` unauth → 200; `workers=2` → 200. `pytest.importorskip("fastapi_identity_model")`.
- `Makefile` — `test-harness-rs` target (node-oidc Docker + `uv run --all-packages`).
- `pyproject.toml` — pyrefly-exclude only `rs_app.py` (fastapi unresolved in lint env).

Refs #464
Epic #462

## Review Findings Addressed
Independent blind + edge + acceptance review (converged in 1 iteration):
- **P0 (1, fixed):** post-kill `proc.wait()` could raise `TimeoutExpired` out of the `finally` — wrapped in `contextlib.suppress`.
- **P1 (2, fixed):** uvicorn stdout PIPE never drained → ~64KB buffer deadlock → redirected to a `tempfile.TemporaryFile` (subsumes the earlier `stdout.close` ResourceWarning fix); empty `RS_EXCLUDED_PATHS` dropped the `/health` exclusion → empty/unset now falls back to the middleware default.
- **Acceptance:** 6/6 ACs PASS, mergeable. `/whoami` + F-07 marker path untested (belong to later TH-1.3 tasks).

## Test plan
- [x] Unit tests pass (`make lint`: ruff + format + pyrefly + pytest coverage)
- [x] Integration tests pass (`make test-harness-rs` → 6/6 real-HTTP against live node-oidc)
- [x] Lint passes
- [x] Independent review agents passed
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)