### PR TITLE
test(harness): token correctness assertion matrix through booted RS (TH-1.3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,15 @@ test-harness-rs: ## Boot the RS (uvicorn) against node-oidc and run the TH-1.2 r
 		(docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml down && exit 1)
 	docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml down
 
+.PHONY: test-harness-matrix
+test-harness-matrix: ## Run the TH-1.3 token correctness matrix (mock-OP forged corpus + node-oidc leg) through the booted RS
+	@echo "Starting node-oidc-provider fixture..."
+	docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml up -d --build --wait
+	@echo "Running the correctness matrix through the booted RS (real HTTP)..."
+	uv run --all-packages pytest src/tests/integration/test_correctness_matrix.py -m integration --env-file=.env.node-oidc -v || \
+		(docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml down && exit 1)
+	docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml down
+
 .PHONY: test-benchmark
 test-benchmark: ## Run benchmarks
 	uv run pytest src/tests/benchmarks -v --benchmark-only --benchmark-sort=name

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,15 @@ test-integration-keycloak: ## Run integration tests against Keycloak
 		(docker compose -f test-fixtures/keycloak/docker-compose.yml down && exit 1)
 	docker compose -f test-fixtures/keycloak/docker-compose.yml down
 
+.PHONY: test-harness-rs
+test-harness-rs: ## Boot the RS (uvicorn) against node-oidc and run the TH-1.2 real-HTTP proof
+	@echo "Starting node-oidc-provider fixture..."
+	docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml up -d --build --wait
+	@echo "Booting fastapi-identity-model RS under uvicorn (real HTTP)..."
+	uv run --all-packages pytest src/tests/integration/test_rs_boot.py -m integration --env-file=.env.node-oidc -v || \
+		(docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml down && exit 1)
+	docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml down
+
 .PHONY: test-benchmark
 test-benchmark: ## Run benchmarks
 	uv run pytest src/tests/benchmarks -v --benchmark-only --benchmark-sort=name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,10 @@ project_excludes = [
     "examples/descope/",
     "packages/fastapi-identity-model/",
     "conformance/",
+    # Harness RS app imports the fastapi stack, unresolved in the root lint env
+    # (same rationale as packages/). Exercised via `make test-harness-rs`
+    # under `uv run --all-packages`.
+    "src/tests/harness/rs_app.py",
     # release tooling imports python-semantic-release, which the dev env
     # doesn't install; validated by the release pipeline itself
     "tools/",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,10 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "src/tests/**/*.py" = ["S101"]   # 1858 assert violations — all test assertions, 0 in production code
+"src/tests/harness/**/*.py" = [
+    "S101",    # pytest assertions
+    "PLR0913", # minter / mock-OP APIs are intentionally parameter-rich (mint, sign, mint_access_token)
+]
 "examples/**/*.py" = ["S101"]    # 73 assert violations in example integration tests
 "packages/**/tests/**/*.py" = [
     "S101",    # pytest assertions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,9 @@ project_excludes = [
     # (same rationale as packages/). Exercised via `make test-harness-rs`
     # under `uv run --all-packages`.
     "src/tests/harness/rs_app.py",
+    # Serves the mock OP under uvicorn (deferred import), unresolved in the root
+    # lint env; exercised via `make test-harness-matrix` under `--all-packages`.
+    "src/tests/harness/mock_op_server.py",
     # release tooling imports python-semantic-release, which the dev env
     # doesn't install; validated by the release pipeline itself
     "tools/",

--- a/src/tests/harness/__init__.py
+++ b/src/tests/harness/__init__.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from .corpus import CORPUS_AUDIENCE, ForgedToken, build_corpus
 from .mock_op import MockOP, MockOPControls, SigningKey
+from .mock_op_server import serve_mock_op
 from .token_source import (
     Grant,
     HarnessCapabilityError,
@@ -48,4 +49,5 @@ __all__ = [
     "TokenSource",
     "build_corpus",
     "prime_pool",
+    "serve_mock_op",
 ]

--- a/src/tests/harness/__init__.py
+++ b/src/tests/harness/__init__.py
@@ -1,0 +1,51 @@
+"""Token-blaster harness shared infrastructure (epic #462, TH-1.1..TH-1.5).
+
+A single home for the pieces T300/T301/T311 share:
+
+* :class:`TokenSource` — the unified multi-provider minter (``mint``) plus the
+  pre-minted :class:`ReplayPool`.
+* :class:`MockOP` — a controllable, framework-free ASGI OpenID Provider holding
+  a known signing key (valid tokens, forged corpus, T311 failure injection).
+* :func:`build_corpus` — the forged / negative token corpus.
+"""
+
+from __future__ import annotations
+
+from .corpus import CORPUS_AUDIENCE, ForgedToken, build_corpus
+from .mock_op import MockOP, MockOPControls, SigningKey
+from .token_source import (
+    Grant,
+    HarnessCapabilityError,
+    HarnessCredentialError,
+    HarnessError,
+    Malform,
+    MintedToken,
+    MintSpec,
+    Provider,
+    ProviderConfig,
+    ReplayPool,
+    TokenSource,
+    prime_pool,
+)
+
+
+__all__ = [
+    "CORPUS_AUDIENCE",
+    "ForgedToken",
+    "Grant",
+    "HarnessCapabilityError",
+    "HarnessCredentialError",
+    "HarnessError",
+    "Malform",
+    "MintSpec",
+    "MintedToken",
+    "MockOP",
+    "MockOPControls",
+    "Provider",
+    "ProviderConfig",
+    "ReplayPool",
+    "SigningKey",
+    "TokenSource",
+    "build_corpus",
+    "prime_pool",
+]

--- a/src/tests/harness/__init__.py
+++ b/src/tests/harness/__init__.py
@@ -1,0 +1,5 @@
+"""Token-blaster harness helpers (TH-1.x).
+
+Test-only infrastructure for booting py-identity-model as a real resource
+server and driving it over HTTP. Not part of the shipped library.
+"""

--- a/src/tests/harness/corpus.py
+++ b/src/tests/harness/corpus.py
@@ -1,0 +1,194 @@
+"""Forged / negative token corpus for the token-blaster harness (TH-1.1).
+
+Real OPs will not emit invalid tokens and node-oidc's keys are ephemeral and
+not exported, so the negative corpus is forged off the *known* signing key of
+the controllable :class:`~mock_op.MockOP` (design §3).
+
+Each :class:`ForgedToken` records ``library_rejects`` — whether
+:func:`py_identity_model.aio.validate_token` (signature + ``iss``/``aud``/``exp``
+checks) rejects it. Note the distinction from *resource-server* policy, which
+is T302's concern:
+
+* ``id_as_access`` and ``cnf_bound`` are *validly signed JWTs for the audience*
+  — the library ACCEPTS them; only the RS access-token marker / ``require_scope``
+  layer (F-07 / F-02) distinguishes them. They therefore carry
+  ``library_rejects=False`` here.
+* ``oversized`` / ``multi_aud_untrusted`` are likewise valid to the library.
+
+Real-issuer negatives that cannot be forged (a real OP signing an expired token
+with its real key) reuse the committed expired tokens + cross-provider
+``kid``-mismatch already in the integration suite.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import time
+from typing import TYPE_CHECKING, Any
+
+import jwt
+
+
+if TYPE_CHECKING:
+    from .mock_op import MockOP
+
+
+CORPUS_AUDIENCE = "mock-api"
+
+
+@dataclass(frozen=True)
+class ForgedToken:
+    """A single corpus entry.
+
+    Attributes:
+        name: Stable class name (matches a :class:`~token_source.Malform` value).
+        jwt: The compact-serialized token.
+        description: What makes it invalid (or, for accepted classes, why the
+            library accepts it despite RS-layer policy rejecting it).
+        library_rejects: Whether ``aio.validate_token`` rejects it outright.
+    """
+
+    name: str
+    jwt: str
+    description: str
+    library_rejects: bool
+
+
+def _base_claims(mock_op: MockOP, now: int, *, audience: Any = CORPUS_AUDIENCE) -> dict:
+    return {
+        "iss": mock_op.issuer,
+        "sub": "mock-subject",
+        "aud": audience,
+        "iat": now,
+        "nbf": now,
+        "exp": now + 300,
+        "client_id": "mock-client",
+        "scope": "read",
+    }
+
+
+def _tamper_signature(token: str) -> str:
+    """Flip the *first* character of the signature segment (invalid signature).
+
+    The first base64url character carries fully-significant bits, so flipping it
+    always changes the decoded signature bytes. (The *last* character of an
+    RSA-2048 signature encodes only 2 significant bits plus 4 discard bits, so
+    flipping it can decode to identical bytes and leave the signature valid.)
+    """
+    header, payload, signature = token.split(".")
+    flipped = "B" if signature[0] != "B" else "C"
+    return f"{header}.{payload}.{flipped}{signature[1:]}"
+
+
+def build_corpus(mock_op: MockOP) -> dict[str, ForgedToken]:
+    """Build the full forged corpus keyed to *mock_op*'s known signing key."""
+    now = int(time.time())
+    entries: list[ForgedToken] = []
+
+    def add(name: str, token: str, description: str, *, rejects: bool) -> None:
+        entries.append(ForgedToken(name, token, description, rejects))
+
+    # -- Accepted by the library (signature + iss + aud + exp all valid) -----
+    add(
+        "valid",
+        mock_op.sign(_base_claims(mock_op, now)),
+        "well-formed token signed by a published key",
+        rejects=False,
+    )
+    id_claims = _base_claims(mock_op, now)
+    id_claims.pop("scope")
+    id_claims.pop("client_id")
+    id_claims["nonce"] = "n-abc"
+    add(
+        "id_as_access",
+        mock_op.sign(id_claims),
+        "ID-token-shaped (no scope/client_id) presented as a bearer access "
+        "token — library accepts; RS marker (F-07) must reject",
+        rejects=False,
+    )
+    cnf_claims = _base_claims(mock_op, now)
+    cnf_claims["cnf"] = {"jkt": "0ZcOCORZNYy-DWpqq30jZyJGHTN0d2HglBV3uiguA4I"}
+    add(
+        "cnf_bound",
+        mock_op.sign(cnf_claims),
+        "DPoP/mTLS cnf-bound token presented as a plain bearer — library "
+        "accepts (F-02 accepted-today contract; do not assume rejection)",
+        rejects=False,
+    )
+    big_claims = _base_claims(mock_op, now)
+    for i in range(200):
+        big_claims[f"pad_{i}"] = "x" * 64
+    add(
+        "oversized",
+        mock_op.sign(big_claims),
+        "valid token bloated with 200 padding claims (resource-exhaustion probe)",
+        rejects=False,
+    )
+    multi_aud = _base_claims(mock_op, now, audience=[CORPUS_AUDIENCE, "urn:untrusted"])
+    add(
+        "multi_aud_untrusted",
+        mock_op.sign(multi_aud),
+        "multi-aud token whose secondary audience is untrusted — library "
+        "accepts because the trusted audience is present",
+        rejects=False,
+    )
+
+    # -- Rejected by the library --------------------------------------------
+    expired = _base_claims(mock_op, now)
+    expired["iat"] = expired["nbf"] = now - 600
+    expired["exp"] = now - 300
+    add("expired", mock_op.sign(expired), "exp in the past", rejects=True)
+
+    nbf_future = _base_claims(mock_op, now)
+    nbf_future["nbf"] = now + 3600
+    add("nbf_future", mock_op.sign(nbf_future), "nbf in the future", rejects=True)
+
+    wrong_iss = _base_claims(mock_op, now)
+    wrong_iss["iss"] = "https://evil.example.com"
+    add(
+        "wrong_iss",
+        mock_op.sign(wrong_iss),
+        "iss does not match discovery",
+        rejects=True,
+    )
+
+    wrong_aud = _base_claims(mock_op, now, audience="urn:some-other-api")
+    add(
+        "wrong_aud",
+        mock_op.sign(wrong_aud),
+        "aud does not match expected",
+        rejects=True,
+    )
+
+    add(
+        "tampered_sig",
+        _tamper_signature(mock_op.sign(_base_claims(mock_op, now))),
+        "byte-flipped signature",
+        rejects=True,
+    )
+    add(
+        "unknown_kid",
+        mock_op.sign(_base_claims(mock_op, now), key=mock_op.unpublished_key),
+        "signed by a key whose kid is absent from JWKS",
+        rejects=True,
+    )
+    add(
+        "wrong_alg",
+        jwt.encode(
+            _base_claims(mock_op, now),
+            # >= 32 bytes to avoid PyJWT's InsecureKeyLengthWarning; the exact
+            # secret is irrelevant — the point is HS256 against an RSA kid.
+            "harness-hmac-confusion-secret-key-32b",
+            algorithm="HS256",
+            headers={"kid": mock_op.primary_key.kid},
+        ),
+        "HS256 signed while claiming an RSA kid (alg-confusion)",
+        rejects=True,
+    )
+    add(
+        "alg_none",
+        jwt.encode(_base_claims(mock_op, now), "", algorithm="none"),
+        "unsigned token with alg:none",
+        rejects=True,
+    )
+    return {entry.name: entry for entry in entries}

--- a/src/tests/harness/mock_op.py
+++ b/src/tests/harness/mock_op.py
@@ -27,7 +27,7 @@ from collections.abc import Awaitable, Callable, MutableMapping
 from dataclasses import dataclass
 import json
 import time
-from typing import Any
+from typing import Any, get_args, get_type_hints
 from urllib.parse import parse_qs
 
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
@@ -110,6 +110,43 @@ class MockOPControls:
     jwks_cache_control: str | None = None
     serve_empty_jwks: bool = False
     oversized_jwks_padding: int = 0
+
+
+def _resolve_control_types() -> dict[str, tuple[type, ...]]:
+    """Resolved ``{field_name: accepted_types}`` for :class:`MockOPControls`."""
+    mapping: dict[str, tuple[type, ...]] = {}
+    for name, anno in get_type_hints(MockOPControls).items():
+        args = get_args(anno)
+        mapping[name] = tuple(a for a in (args or (anno,)) if isinstance(a, type))
+    return mapping
+
+
+# Field -> accepted types, resolved once (the dataclass is immutable in shape).
+_CONTROL_TYPES: dict[str, tuple[type, ...]] = _resolve_control_types()
+
+
+def _set_control(controls: MockOPControls, name: str, value: Any) -> bool:
+    """Type-checked control mutation; returns True if the value was applied.
+
+    A stray ``{"jwks_status": "boom"}`` or ``{"retry_after": 3}`` (JSON number,
+    not string) would otherwise poison a *later* request — an ``int`` handed to
+    an ASGI ``status`` field, or a ``.encode()`` on a non-string. Reject the
+    mismatch at the control call so the failure is local and obvious.
+    """
+    types = _CONTROL_TYPES.get(name)
+    if not types:
+        return False
+    # ``bool`` is a subclass of ``int``: accept it only for genuine bool knobs,
+    # and never let it (or a JSON int) masquerade as a status/int field's value.
+    if isinstance(value, bool):
+        accepted = bool in types
+    elif isinstance(value, int) and float in types:
+        accepted = True  # JSON ints are fine for float knobs (latency_seconds)
+    else:
+        accepted = isinstance(value, types)
+    if accepted:
+        setattr(controls, name, value)
+    return accepted
 
 
 # ASGI scope/messages are MutableMapping (matching httpx.ASGITransport's spec).
@@ -300,7 +337,12 @@ class MockOP:
         except jwt.PyJWTError:
             return {"active": False}
         now = int(time.time())
-        active = int(claims.get("exp", 0)) > now
+        try:
+            active = int(claims.get("exp", 0)) > now
+        except (TypeError, ValueError):
+            # A malformed ``exp`` (exactly the kind of token this harness feeds)
+            # must report inactive, not 500 the endpoint.
+            active = False
         return {"active": active, **claims}
 
     # -- ASGI application ---------------------------------------------------
@@ -380,7 +422,13 @@ class MockOP:
         """Out-of-process control endpoint for the uvicorn-booted case (T311).
 
         Accepts a JSON body: ``{"rotate": true, "publish": false}`` and/or any
-        subset of :class:`MockOPControls` field names to set.
+        subset of :class:`MockOPControls` field names to set. Field values are
+        type-checked against the dataclass; mismatches are reported back in the
+        ``rejected`` list rather than poisoning a later request.
+
+        Security: this route performs key rotation and failure injection with no
+        authentication. It is a *test* fixture — bind it to loopback only. Do NOT
+        expose the booted mock OP on a routable interface.
         """
         try:
             payload = json.loads((await _read_body(receive)).decode() or "{}")
@@ -388,10 +436,16 @@ class MockOP:
             payload = {}
         if payload.pop("rotate", False):
             self.rotate_keys(publish=bool(payload.pop("publish", False)))
-        for name, value in payload.items():
-            if hasattr(self.controls, name):
-                setattr(self.controls, name, value)
-        await self._send_json(send, HTTP_OK, {"ok": True})
+        else:
+            # ``publish`` is only meaningful alongside ``rotate``; drop it so it
+            # is not mistaken for a control field below.
+            payload.pop("publish", None)
+        rejected = [
+            name
+            for name, value in payload.items()
+            if not _set_control(self.controls, name, value)
+        ]
+        await self._send_json(send, HTTP_OK, {"ok": True, "rejected": rejected})
 
     # -- ASGI helpers -------------------------------------------------------
 

--- a/src/tests/harness/mock_op.py
+++ b/src/tests/harness/mock_op.py
@@ -1,0 +1,444 @@
+"""Controllable mock OpenID Provider for the token-blaster harness (TH-1.1).
+
+The mock OP holds a *known* signing key (unlike real IdPs, whose keys are
+ephemeral and not exportable), which lets the harness:
+
+1. mint genuinely valid tokens, and
+2. forge the negative corpus (:mod:`corpus`) — tampered signatures, unknown
+   ``kid``, ``alg:none``, wrong ``iss``/``aud``, etc. — that a real OP will
+   never emit.
+
+It is a framework-free ASGI application (``fastapi``/``starlette`` are not root
+test dependencies), so it is both:
+
+* unit-testable in-process via ``httpx.ASGITransport`` (no network), and
+* bootable out-of-process under ``uvicorn`` for the load/soak suite (T311).
+
+The :class:`MockOPControls` object drives T311's failure injection: injected
+latency, ``429``/``Retry-After``, ``5xx``, key-rotation-on-command,
+``Cache-Control`` directives, and empty/oversized JWKS.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from collections.abc import Awaitable, Callable, MutableMapping
+from dataclasses import dataclass
+import json
+import time
+from typing import Any
+from urllib.parse import parse_qs
+
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+import jwt
+
+
+# HTTP status codes
+HTTP_OK = 200
+HTTP_NOT_FOUND = 404
+HTTP_TOO_MANY_REQUESTS = 429
+
+DEFAULT_ISSUER = "http://mock-op.local"
+DEFAULT_TOKEN_LIFETIME = 300  # seconds — mirrors the real-IdP 300s TTL (design §3)
+
+
+def _b64url_uint(value: int) -> str:
+    """Encode an unsigned integer as base64url (JWK ``n``/``e``/``x``/``y``)."""
+    length = (value.bit_length() + 7) // 8 or 1
+    return base64.urlsafe_b64encode(value.to_bytes(length, "big")).rstrip(b"=").decode()
+
+
+@dataclass(frozen=True)
+class SigningKey:
+    """A signing key the mock OP controls end-to-end.
+
+    Holds the private key (for signing / forging) and its public JWK (for the
+    ``/jwks`` document), so the harness can both mint valid tokens and forge
+    negatives keyed to a known public key.
+    """
+
+    alg: str
+    kid: str
+    private_key: Any  # cryptography private key object
+    public_jwk: dict[str, Any]
+
+
+def _rsa_signing_key(kid: str) -> SigningKey:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    numbers = private_key.public_key().public_numbers()
+    jwk = {
+        "kty": "RSA",
+        "use": "sig",
+        "alg": "RS256",
+        "kid": kid,
+        "n": _b64url_uint(numbers.n),
+        "e": _b64url_uint(numbers.e),
+    }
+    return SigningKey(alg="RS256", kid=kid, private_key=private_key, public_jwk=jwk)
+
+
+def _ec_signing_key(kid: str) -> SigningKey:
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    numbers = private_key.public_key().public_numbers()
+    jwk = {
+        "kty": "EC",
+        "use": "sig",
+        "alg": "ES256",
+        "kid": kid,
+        "crv": "P-256",
+        "x": _b64url_uint(numbers.x),
+        "y": _b64url_uint(numbers.y),
+    }
+    return SigningKey(alg="ES256", kid=kid, private_key=private_key, public_jwk=jwk)
+
+
+@dataclass
+class MockOPControls:
+    """Mutable failure-injection knobs (design §2).
+
+    Every request consults the *live* object, so a test (or a T311 control
+    route) can flip a knob between requests and observe the effect.
+    """
+
+    latency_seconds: float = 0.0
+    discovery_status: int = HTTP_OK
+    jwks_status: int = HTTP_OK
+    token_status: int = HTTP_OK
+    retry_after: str | None = None
+    discovery_cache_control: str | None = None
+    jwks_cache_control: str | None = None
+    serve_empty_jwks: bool = False
+    oversized_jwks_padding: int = 0
+
+
+# ASGI scope/messages are MutableMapping (matching httpx.ASGITransport's spec).
+ASGIScope = MutableMapping[str, Any]
+ASGIReceive = Callable[[], Awaitable[MutableMapping[str, Any]]]
+ASGISend = Callable[[MutableMapping[str, Any]], Awaitable[None]]
+ASGIApp = Callable[[ASGIScope, ASGIReceive, ASGISend], Awaitable[None]]
+
+
+class MockOP:
+    """A controllable OIDC provider serving discovery, JWKS, token, introspect.
+
+    Args:
+        issuer: The issuer / base URL. All endpoint URLs derive from it, and
+            minted tokens carry it as ``iss``.
+        controls: Failure-injection knobs. A fresh :class:`MockOPControls` is
+            created when omitted.
+    """
+
+    def __init__(
+        self,
+        issuer: str = DEFAULT_ISSUER,
+        *,
+        controls: MockOPControls | None = None,
+    ) -> None:
+        self.issuer = issuer.rstrip("/")
+        self.controls = controls or MockOPControls()
+        # Primary RS256 signs valid tokens and is published by default.
+        self.primary_key = _rsa_signing_key("mock-rs256-1")
+        # EC key exercises the ES256 path; also published.
+        self.ec_key = _ec_signing_key("mock-es256-1")
+        # Rotation spare — NOT published until :meth:`rotate_keys` publishes it,
+        # so a token freshly signed by it presents an unknown ``kid`` (design §2
+        # key-rotation-on-command failure injection).
+        self.rotation_key = _rsa_signing_key("mock-rs256-2")
+        # A key that is never published — the source of unknown-``kid`` forgeries.
+        self.unpublished_key = _rsa_signing_key("mock-rs256-unpublished")
+        self._signing_key = self.primary_key
+        self._published: list[SigningKey] = [self.primary_key, self.ec_key]
+
+    # -- URLs ---------------------------------------------------------------
+
+    @property
+    def discovery_url(self) -> str:
+        return f"{self.issuer}/.well-known/openid-configuration"
+
+    @property
+    def jwks_uri(self) -> str:
+        return f"{self.issuer}/jwks"
+
+    @property
+    def token_endpoint(self) -> str:
+        return f"{self.issuer}/token"
+
+    @property
+    def introspection_endpoint(self) -> str:
+        return f"{self.issuer}/introspect"
+
+    @property
+    def signing_key(self) -> SigningKey:
+        """The key currently used to sign freshly minted tokens."""
+        return self._signing_key
+
+    # -- Control ------------------------------------------------------------
+
+    def rotate_keys(self, *, publish: bool = False) -> SigningKey:
+        """Rotate the active signing key to the spare.
+
+        With ``publish=False`` (the default) the new key is withheld from the
+        JWKS, so tokens minted afterwards fail validation with an unknown
+        ``kid`` until :meth:`publish_signing_key` is called — the head-of-line
+        rotation scenario the harness needs to reproduce.
+        """
+        self._signing_key = self.rotation_key
+        if publish:
+            self.publish_signing_key()
+        return self._signing_key
+
+    def publish_signing_key(self) -> None:
+        """Add the active signing key to the published JWKS (idempotent)."""
+        if self._signing_key not in self._published:
+            self._published.append(self._signing_key)
+
+    # -- Documents ----------------------------------------------------------
+
+    def discovery_document(self) -> dict[str, Any]:
+        return {
+            "issuer": self.issuer,
+            "jwks_uri": self.jwks_uri,
+            "token_endpoint": self.token_endpoint,
+            "introspection_endpoint": self.introspection_endpoint,
+            "authorization_endpoint": f"{self.issuer}/authorize",
+            "response_types_supported": ["code", "token"],
+            "grant_types_supported": [
+                "client_credentials",
+                "authorization_code",
+                "refresh_token",
+            ],
+            "id_token_signing_alg_values_supported": ["RS256", "ES256"],
+            "scopes_supported": ["openid", "profile", "email"],
+            "code_challenge_methods_supported": ["S256"],
+            "subject_types_supported": ["public"],
+            "token_endpoint_auth_methods_supported": [
+                "client_secret_basic",
+                "client_secret_post",
+                "private_key_jwt",
+            ],
+        }
+
+    def jwks(self) -> dict[str, Any]:
+        if self.controls.serve_empty_jwks:
+            return {"keys": []}
+        keys = [dict(k.public_jwk) for k in self._published]
+        for i in range(self.controls.oversized_jwks_padding):
+            pad = _rsa_signing_key(f"mock-pad-{i}")
+            keys.append(dict(pad.public_jwk))
+        return {"keys": keys}
+
+    # -- Minting ------------------------------------------------------------
+
+    def sign(
+        self,
+        claims: dict[str, Any],
+        *,
+        key: SigningKey | None = None,
+        alg: str | None = None,
+        headers: dict[str, Any] | None = None,
+    ) -> str:
+        """Sign *claims* into a compact JWS with a mock-OP key.
+
+        Used both by the token endpoint (valid tokens) and by
+        :mod:`corpus` (forged negatives keyed to a known public key).
+        """
+        signing_key = key or self._signing_key
+        merged_headers = {"kid": signing_key.kid}
+        if headers:
+            merged_headers.update(headers)
+        return jwt.encode(
+            claims,
+            signing_key.private_key,
+            algorithm=alg or signing_key.alg,
+            headers=merged_headers,
+        )
+
+    def mint_access_token(
+        self,
+        *,
+        scopes: str | None = None,
+        tenant: str | None = None,
+        audience: str = "mock-api",
+        subject: str = "mock-subject",
+        lifetime: int = DEFAULT_TOKEN_LIFETIME,
+        extra_claims: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Mint a valid access token, returning an OAuth token-response dict.
+
+        ``tenant`` shapes the Descope-style multi-tenant claims (``dct`` +
+        ``tenants``) the node-oidc offline fixture also carries (design §2/§3).
+        """
+        now = int(time.time())
+        claims: dict[str, Any] = {
+            "iss": self.issuer,
+            "sub": subject,
+            "aud": audience,
+            "iat": now,
+            "nbf": now,
+            "exp": now + lifetime,
+            "client_id": "mock-client",
+            "scope": scopes or "read",
+        }
+        if tenant is not None:
+            claims["dct"] = tenant
+            claims["tenants"] = {tenant: {"roles": ["user"]}}
+        if extra_claims:
+            claims.update(extra_claims)
+        access_token = self.sign(claims)
+        return {
+            "access_token": access_token,
+            "token_type": "Bearer",
+            "expires_in": lifetime,
+            "scope": claims["scope"],
+        }
+
+    def introspect(self, token: str) -> dict[str, Any]:
+        """Best-effort introspection: decode without verification and echo."""
+        try:
+            claims = jwt.decode(token, options={"verify_signature": False})
+        except jwt.PyJWTError:
+            return {"active": False}
+        now = int(time.time())
+        active = int(claims.get("exp", 0)) > now
+        return {"active": active, **claims}
+
+    # -- ASGI application ---------------------------------------------------
+
+    @property
+    def app(self) -> ASGIApp:
+        """The ASGI application callable (uvicorn-bootable, httpx-drivable)."""
+        return self._app
+
+    async def _app(
+        self, scope: ASGIScope, receive: ASGIReceive, send: ASGISend
+    ) -> None:
+        if scope["type"] == "lifespan":
+            await self._handle_lifespan(receive, send)
+            return
+        if scope["type"] != "http":  # pragma: no cover - defensive
+            return
+        if self.controls.latency_seconds:
+            await asyncio.sleep(self.controls.latency_seconds)
+        path = scope["path"].rstrip("/") or "/"
+        method = scope["method"]
+        handler = self._route(method, path)
+        if handler is None:
+            await self._send_json(send, HTTP_NOT_FOUND, {"error": "not_found"})
+            return
+        await handler(receive, send)
+
+    def _route(
+        self, method: str, path: str
+    ) -> Callable[[ASGIReceive, ASGISend], Awaitable[None]] | None:
+        routes: dict[tuple[str, str], Callable[..., Awaitable[None]]] = {
+            ("GET", "/.well-known/openid-configuration"): self._handle_discovery,
+            ("GET", "/jwks"): self._handle_jwks,
+            ("POST", "/token"): self._handle_token,
+            ("POST", "/introspect"): self._handle_introspect,
+            ("POST", "/_control"): self._handle_control,
+        }
+        return routes.get((method, path))
+
+    async def _handle_lifespan(self, receive: ASGIReceive, send: ASGISend) -> None:
+        while True:
+            message = await receive()
+            if message["type"] == "lifespan.startup":
+                await send({"type": "lifespan.startup.complete"})
+            elif message["type"] == "lifespan.shutdown":
+                await send({"type": "lifespan.shutdown.complete"})
+                return
+
+    async def _handle_discovery(self, _receive: ASGIReceive, send: ASGISend) -> None:
+        headers = self._cache_control_headers(self.controls.discovery_cache_control)
+        if self.controls.discovery_status != HTTP_OK:
+            await self._send_status(send, self.controls.discovery_status, headers)
+            return
+        await self._send_json(send, HTTP_OK, self.discovery_document(), headers)
+
+    async def _handle_jwks(self, _receive: ASGIReceive, send: ASGISend) -> None:
+        headers = self._cache_control_headers(self.controls.jwks_cache_control)
+        if self.controls.jwks_status != HTTP_OK:
+            await self._send_status(send, self.controls.jwks_status, headers)
+            return
+        await self._send_json(send, HTTP_OK, self.jwks(), headers)
+
+    async def _handle_token(self, receive: ASGIReceive, send: ASGISend) -> None:
+        if self.controls.token_status != HTTP_OK:
+            await self._send_status(send, self.controls.token_status)
+            return
+        form = parse_qs((await _read_body(receive)).decode())
+        scope = form.get("scope", [None])[0]
+        await self._send_json(send, HTTP_OK, self.mint_access_token(scopes=scope))
+
+    async def _handle_introspect(self, receive: ASGIReceive, send: ASGISend) -> None:
+        form = parse_qs((await _read_body(receive)).decode())
+        token = form.get("token", [""])[0]
+        await self._send_json(send, HTTP_OK, self.introspect(token))
+
+    async def _handle_control(self, receive: ASGIReceive, send: ASGISend) -> None:
+        """Out-of-process control endpoint for the uvicorn-booted case (T311).
+
+        Accepts a JSON body: ``{"rotate": true, "publish": false}`` and/or any
+        subset of :class:`MockOPControls` field names to set.
+        """
+        try:
+            payload = json.loads((await _read_body(receive)).decode() or "{}")
+        except json.JSONDecodeError:
+            payload = {}
+        if payload.pop("rotate", False):
+            self.rotate_keys(publish=bool(payload.pop("publish", False)))
+        for name, value in payload.items():
+            if hasattr(self.controls, name):
+                setattr(self.controls, name, value)
+        await self._send_json(send, HTTP_OK, {"ok": True})
+
+    # -- ASGI helpers -------------------------------------------------------
+
+    def _cache_control_headers(
+        self, cache_control: str | None
+    ) -> list[tuple[bytes, bytes]]:
+        if cache_control is None:
+            return []
+        return [(b"cache-control", cache_control.encode())]
+
+    async def _send_status(
+        self,
+        send: ASGISend,
+        status: int,
+        headers: list[tuple[bytes, bytes]] | None = None,
+    ) -> None:
+        body = {"error": "injected_failure", "status": status}
+        extra = list(headers or [])
+        if status == HTTP_TOO_MANY_REQUESTS and self.controls.retry_after is not None:
+            extra.append((b"retry-after", self.controls.retry_after.encode()))
+        await self._send_json(send, status, body, extra)
+
+    async def _send_json(
+        self,
+        send: ASGISend,
+        status: int,
+        body: dict[str, Any],
+        headers: list[tuple[bytes, bytes]] | None = None,
+    ) -> None:
+        payload = json.dumps(body).encode()
+        response_headers = [(b"content-type", b"application/json")]
+        response_headers.extend(headers or [])
+        await send(
+            {
+                "type": "http.response.start",
+                "status": status,
+                "headers": response_headers,
+            }
+        )
+        await send({"type": "http.response.body", "body": payload})
+
+
+async def _read_body(receive: ASGIReceive) -> bytes:
+    body = b""
+    while True:
+        message = await receive()
+        body += message.get("body", b"")
+        if not message.get("more_body", False):
+            break
+    return body

--- a/src/tests/harness/mock_op_server.py
+++ b/src/tests/harness/mock_op_server.py
@@ -34,6 +34,30 @@ if TYPE_CHECKING:
 
 
 _READY_POLL_INTERVAL = 0.05
+_SHUTDOWN_TIMEOUT = 10.0
+
+
+class _ServerThread(threading.Thread):
+    """Run ``uvicorn.Server.run`` and remember any startup exception.
+
+    ``server.run()`` raising inside a bare daemon thread is otherwise silently
+    swallowed: the thread just dies and the readiness poll blocks for the full
+    ``timeout`` before failing with an opaque message. Capturing the exception
+    (and exposing liveness) lets the poll fail fast with the real cause, the way
+    the sibling subprocess boot fails fast on ``proc.poll()`` (blind/edge
+    SHOULD-FIX).
+    """
+
+    def __init__(self, server: object) -> None:
+        super().__init__(daemon=True)
+        self._server = server
+        self.error: BaseException | None = None
+
+    def run(self) -> None:
+        try:
+            self._server.run()  # type: ignore[attr-defined]
+        except BaseException as exc:
+            self.error = exc
 
 
 @contextlib.contextmanager
@@ -80,20 +104,38 @@ def serve_mock_op(
         interface="asgi3",
     )
     server = uvicorn.Server(config)
-    thread = threading.Thread(target=server.run, daemon=True)
+    thread = _ServerThread(server)
     thread.start()
     try:
-        _wait_for_discovery(op.discovery_url, timeout)
+        _wait_for_discovery(thread, op.discovery_url, timeout)
         yield op
     finally:
         server.should_exit = True
-        thread.join(timeout)
+        thread.join(_SHUTDOWN_TIMEOUT)
+        if thread.is_alive():
+            # The server never honoured ``should_exit`` within the shutdown
+            # grace. The daemon thread — still bound to the loopback port —
+            # leaks past the ``with`` block and can wedge the next
+            # ``serve_mock_op`` reusing the port range (blind SHOULD-FIX).
+            raise RuntimeError(
+                f"mock OP did not shut down within {_SHUTDOWN_TIMEOUT}s; "
+                f"the uvicorn thread is still bound to {op.discovery_url}"
+            )
 
 
-def _wait_for_discovery(discovery_url: str, timeout: float) -> None:
+def _wait_for_discovery(
+    thread: _ServerThread, discovery_url: str, timeout: float
+) -> None:
     deadline = time.monotonic() + timeout
     last_error = "no attempt made"
     while time.monotonic() < deadline:
+        if not thread.is_alive():
+            # The uvicorn thread died during startup (bind refused, port TOCTOU
+            # collision, ASGI misconfig). Surface the captured cause immediately
+            # instead of polling the full timeout (edge [DEGRADED]).
+            raise RuntimeError(
+                f"mock OP uvicorn thread died during startup (last: {last_error})"
+            ) from thread.error
         try:
             response = httpx.get(discovery_url, timeout=2.0)
             if response.status_code == httpx.codes.OK:

--- a/src/tests/harness/mock_op_server.py
+++ b/src/tests/harness/mock_op_server.py
@@ -1,0 +1,107 @@
+"""Serve the framework-free :class:`~mock_op.MockOP` over real localhost HTTP.
+
+The RS boot (:func:`~rs_server.boot_rs`) launches uvicorn as a *subprocess*, so
+it cannot reach an in-process ASGI mock OP — it fetches discovery + JWKS over
+real HTTP. This helper runs the mock OP on a real loopback port so the booted RS
+can validate against it.
+
+The mock OP must run **in-process** (a uvicorn thread, not a subprocess): the
+forged corpus (:func:`~corpus.build_corpus`) is keyed to the *same* ``MockOP``
+instance's signing key, and a subprocess mock OP would re-import a fresh random
+key, breaking every forgery.
+
+``import uvicorn`` is deferred into the function so that plain unit-env
+collection of importers does not fail (uvicorn is not a root test dependency).
+This module is excluded from the root pyrefly lint env for the same reason
+(see ``[tool.pyrefly] project_excludes`` in ``pyproject.toml``).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+import time
+from typing import TYPE_CHECKING
+
+import httpx
+
+from .mock_op import MockOP, MockOPControls
+from .rs_server import _free_port
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+_READY_POLL_INTERVAL = 0.05
+
+
+@contextlib.contextmanager
+def serve_mock_op(
+    *,
+    controls: MockOPControls | None = None,
+    timeout: float = 30.0,
+) -> Iterator[MockOP]:
+    """Serve a :class:`MockOP` over real localhost HTTP for the duration of the
+    ``with`` block.
+
+    Binds an ephemeral loopback port, builds a ``MockOP`` whose ``issuer`` is the
+    bound ``http://127.0.0.1:<port>`` (so its discovery ``issuer`` and the RS
+    ``iss`` check both match the URL the RS actually fetches), runs it under
+    ``uvicorn`` in a daemon thread, and polls its discovery endpoint until it
+    answers ``200``.
+
+    Args:
+        controls: Failure-injection knobs handed to the ``MockOP``.
+        timeout: Seconds to wait for the first successful discovery response.
+
+    Yields:
+        The live :class:`MockOP` instance (use ``op.discovery_url`` for the RS,
+        ``op.sign`` / :func:`~corpus.build_corpus` for forged tokens).
+    """
+    # Deferred so importing this module in the root env (where uvicorn is not
+    # installed) does not ImportError — only calling serve_mock_op needs it, and
+    # that path is only taken under `uv run --all-packages`.
+    import uvicorn  # noqa: PLC0415 — intentional in-function import, see above
+
+    port = _free_port()
+    op = MockOP(issuer=f"http://127.0.0.1:{port}", controls=controls)
+    # ``lifespan="off"``: the framework-free app needs no startup, and skipping
+    # lifespan avoids driving ``MockOP._handle_lifespan`` through uvicorn.
+    # ``interface="asgi3"``: ``op.app`` is a bare 3-arg ASGI callable (not a
+    # class), which uvicorn's auto-detection otherwise mistakes for the legacy
+    # 2-arg ASGI-2 factory and calls with a single ``scope`` argument.
+    config = uvicorn.Config(
+        op.app,
+        host="127.0.0.1",
+        port=port,
+        log_level="warning",
+        lifespan="off",
+        interface="asgi3",
+    )
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    try:
+        _wait_for_discovery(op.discovery_url, timeout)
+        yield op
+    finally:
+        server.should_exit = True
+        thread.join(timeout)
+
+
+def _wait_for_discovery(discovery_url: str, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    last_error = "no attempt made"
+    while time.monotonic() < deadline:
+        try:
+            response = httpx.get(discovery_url, timeout=2.0)
+            if response.status_code == httpx.codes.OK:
+                return
+            last_error = f"HTTP {response.status_code}"
+        except httpx.HTTPError as exc:
+            last_error = str(exc)
+        time.sleep(_READY_POLL_INTERVAL)
+    raise RuntimeError(
+        f"mock OP did not serve discovery within {timeout}s (last: {last_error})"
+    )

--- a/src/tests/harness/mock_op_server.py
+++ b/src/tests/harness/mock_op_server.py
@@ -19,6 +19,7 @@ This module is excluded from the root pyrefly lint env for the same reason
 from __future__ import annotations
 
 import contextlib
+import sys
 import threading
 import time
 from typing import TYPE_CHECKING
@@ -112,11 +113,15 @@ def serve_mock_op(
     finally:
         server.should_exit = True
         thread.join(_SHUTDOWN_TIMEOUT)
-        if thread.is_alive():
+        if thread.is_alive() and sys.exc_info()[0] is None:
             # The server never honoured ``should_exit`` within the shutdown
             # grace. The daemon thread — still bound to the loopback port —
             # leaks past the ``with`` block and can wedge the next
             # ``serve_mock_op`` reusing the port range (blind SHOULD-FIX).
+            # Only raise when the body did not already fail: a raise here would
+            # otherwise supersede the real test failure, demoting it to a
+            # chained ``__context__`` and misreporting a body assertion as a
+            # shutdown bug (delta SHOULD-FIX).
             raise RuntimeError(
                 f"mock OP did not shut down within {_SHUTDOWN_TIMEOUT}s; "
                 f"the uvicorn thread is still bound to {op.discovery_url}"
@@ -130,11 +135,13 @@ def _wait_for_discovery(
     last_error = "no attempt made"
     while time.monotonic() < deadline:
         if not thread.is_alive():
-            # The uvicorn thread died during startup (bind refused, port TOCTOU
-            # collision, ASGI misconfig). Surface the captured cause immediately
-            # instead of polling the full timeout (edge [DEGRADED]).
+            # The uvicorn thread exited before discovery answered — a crash
+            # (bind refused, port TOCTOU collision, ASGI misconfig) or an
+            # unexpected clean exit. Surface it immediately instead of polling
+            # the full timeout (edge [DEGRADED]); ``thread.error`` chains the
+            # captured cause when there was one, else is ``None`` (clean exit).
             raise RuntimeError(
-                f"mock OP uvicorn thread died during startup (last: {last_error})"
+                f"mock OP uvicorn thread exited during startup (last: {last_error})"
             ) from thread.error
         try:
             response = httpx.get(discovery_url, timeout=2.0)

--- a/src/tests/harness/rs_app.py
+++ b/src/tests/harness/rs_app.py
@@ -33,11 +33,16 @@ def _truthy(value: str | None) -> bool:
 
 def _excluded_paths() -> list[str] | None:
     """Parse ``RS_EXCLUDED_PATHS`` (comma-separated) or return ``None`` so the
-    middleware falls back to its own defaults (which include ``/health``)."""
+    middleware falls back to its own defaults (which include ``/health``).
+
+    An unset OR empty ``RS_EXCLUDED_PATHS`` both fall back to the middleware
+    defaults. An empty string (which is what ``boot_rs(excluded_paths=[])``
+    serializes to) must NOT be read as an explicit "exclude nothing" list —
+    that would drop the ``/health`` exclusion and break the readiness poll."""
     raw = os.environ.get("RS_EXCLUDED_PATHS")
-    if raw is None:
+    if not raw:
         return None
-    return [p for p in raw.split(",") if p]
+    return [p for p in raw.split(",") if p] or None
 
 
 def create_app() -> FastAPI:

--- a/src/tests/harness/rs_app.py
+++ b/src/tests/harness/rs_app.py
@@ -1,0 +1,90 @@
+"""Greenfield FastAPI resource server for the token-blaster harness (TH-1.2).
+
+A minimal RS that mounts ``TokenValidationMiddleware`` and guards routes with
+``require_scope``. All configuration comes from ``RS_*`` environment variables
+so uvicorn ``--workers N`` forked workers each re-import this module and rebuild
+an identical app (the workers are forked *after* import-string resolution, so
+they cannot share a closure — only the env).
+
+This is the ONLY harness module that imports FastAPI / fastapi-identity-model.
+It is excluded from the root pyrefly lint env (see ``[tool.pyrefly]
+project_excludes`` in ``pyproject.toml``) because that env installs only
+py-identity-model and cannot resolve the fastapi stack; it is exercised via
+``make test-harness-rs`` under ``uv run --all-packages``.
+"""
+
+from __future__ import annotations
+
+import os
+
+from fastapi import Depends, FastAPI
+
+from fastapi_identity_model import (
+    Claims,
+    CurrentUser,
+    TokenValidationMiddleware,
+    require_scope,
+)
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _excluded_paths() -> list[str] | None:
+    """Parse ``RS_EXCLUDED_PATHS`` (comma-separated) or return ``None`` so the
+    middleware falls back to its own defaults (which include ``/health``)."""
+    raw = os.environ.get("RS_EXCLUDED_PATHS")
+    if raw is None:
+        return None
+    return [p for p in raw.split(",") if p]
+
+
+def create_app() -> FastAPI:
+    """Build the resource-server app from ``RS_*`` env config.
+
+    Required env: ``RS_DISCOVERY_URL``, ``RS_AUDIENCE``.
+    Optional env: ``RS_REQUIRE_SCOPE`` (default ``api``),
+    ``RS_REQUIRE_ACCESS_TOKEN_MARKER`` (bool, F-07 opt-in),
+    ``RS_EXCLUDED_PATHS`` (comma-separated).
+    """
+    discovery_url = os.environ["RS_DISCOVERY_URL"]
+    audience = os.environ["RS_AUDIENCE"]
+    required_scope = os.environ.get("RS_REQUIRE_SCOPE", "api")
+
+    app = FastAPI(title="token-harness-rs")
+    app.add_middleware(
+        TokenValidationMiddleware,
+        discovery_url=discovery_url,
+        audience=audience,
+        excluded_paths=_excluded_paths(),
+        require_access_token_marker=_truthy(
+            os.environ.get("RS_REQUIRE_ACCESS_TOKEN_MARKER")
+        ),
+    )
+
+    @app.get("/health")
+    def health() -> dict:
+        # Excluded from auth (middleware default) — the readiness probe target.
+        return {"status": "ok"}
+
+    @app.get("/protected", dependencies=[Depends(require_scope(required_scope))])
+    def protected(claims: Claims) -> dict:
+        # Reached only after the middleware validated the token AND the token
+        # carries ``required_scope`` (else require_scope raises 403).
+        return {
+            "sub": claims.get("sub"),
+            "scope": claims.get("scope") or claims.get("scp"),
+        }
+
+    @app.get("/whoami")
+    def whoami(user: CurrentUser) -> dict:
+        identity = user.identity
+        return {"name": identity.name if identity is not None else None}
+
+    return app
+
+
+# Module-level app so uvicorn can boot it by import string
+# (``src.tests.harness.rs_app:app``) and forked workers re-import identically.
+app = create_app()

--- a/src/tests/harness/rs_server.py
+++ b/src/tests/harness/rs_server.py
@@ -87,7 +87,7 @@ def _wait_for_health(
 
 
 @contextlib.contextmanager
-def boot_rs(  # noqa: PLR0913 — each RS knob (issuer/audience/scope/workers/...) is an explicit keyword
+def boot_rs(
     *,
     discovery_url: str,
     audience: str,

--- a/src/tests/harness/rs_server.py
+++ b/src/tests/harness/rs_server.py
@@ -15,8 +15,9 @@ from pathlib import Path
 import socket
 import subprocess
 import sys
+import tempfile
 import time
-from typing import TYPE_CHECKING
+from typing import IO, TYPE_CHECKING
 
 import httpx
 
@@ -43,12 +44,23 @@ def _free_port() -> int:
         return int(sock.getsockname()[1])
 
 
-def _drain(proc: subprocess.Popen[str]) -> str:
-    return proc.stdout.read() if proc.stdout is not None else ""
+def _drain(log: IO[str]) -> str:
+    """Return everything uvicorn has written to its capture file so far.
+
+    Reading from a seekable temp file (not a live PIPE) never blocks: the child
+    writes to its own inherited fd and we snapshot from position 0. This also
+    means the child can emit an arbitrarily large traceback without filling an
+    OS pipe buffer and deadlocking on ``write()`` (blind/edge SHOULD-FIX).
+    """
+    try:
+        log.seek(0)
+        return log.read()
+    except (OSError, ValueError):  # pragma: no cover - defensive, file closed
+        return ""
 
 
 def _wait_for_health(
-    proc: subprocess.Popen[str], base_url: str, timeout: float
+    proc: subprocess.Popen[str], log: IO[str], base_url: str, timeout: float
 ) -> None:
     deadline = time.monotonic() + timeout
     last_error = "no attempt made"
@@ -56,7 +68,7 @@ def _wait_for_health(
         if proc.poll() is not None:
             raise RuntimeError(
                 f"uvicorn exited before becoming healthy "
-                f"(code {proc.returncode}):\n{_drain(proc)}"
+                f"(code {proc.returncode}):\n{_drain(log)}"
             )
         try:
             response = httpx.get(f"{base_url}/health", timeout=2.0)
@@ -70,7 +82,7 @@ def _wait_for_health(
     proc.terminate()
     raise RuntimeError(
         f"resource server did not become healthy within {timeout}s "
-        f"(last: {last_error}):\n{_drain(proc)}"
+        f"(last: {last_error}):\n{_drain(log)}"
     )
 
 
@@ -117,40 +129,46 @@ def boot_rs(  # noqa: PLR0913 — each RS knob (issuer/audience/scope/workers/..
     if extra_env:
         env.update(extra_env)
 
-    proc = subprocess.Popen(  # noqa: S603 — fixed argv, no shell, test-only
-        [
-            sys.executable,
-            "-m",
-            "uvicorn",
-            "src.tests.harness.rs_app:app",
-            "--host",
-            "127.0.0.1",
-            "--port",
-            str(port),
-            "--workers",
-            str(workers),
-            "--log-level",
-            "warning",
-        ],
-        cwd=str(_REPO_ROOT),
-        env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-    )
-    try:
-        _wait_for_health(proc, base_url, timeout)
-        yield base_url
-    finally:
-        proc.terminate()
+    # Capture uvicorn output to a seekable temp file rather than a PIPE. A PIPE
+    # is only drained on the failure path, so a healthy-but-chatty worker could
+    # fill the ~64KB OS pipe buffer and block on ``write()``, hanging the server
+    # (blind/edge SHOULD-FIX). A temp file has no such backpressure and reading
+    # it back on failure never blocks. ``TemporaryFile`` also unlinks itself on
+    # close, so there is no lingering fd for the GC to ResourceWarning over.
+    with tempfile.TemporaryFile(mode="w+") as log:
+        proc = subprocess.Popen(  # noqa: S603 — fixed argv, no shell, test-only
+            [
+                sys.executable,
+                "-m",
+                "uvicorn",
+                "src.tests.harness.rs_app:app",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(port),
+                "--workers",
+                str(workers),
+                "--log-level",
+                "warning",
+            ],
+            cwd=str(_REPO_ROOT),
+            env=env,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
         try:
-            proc.wait(timeout=_TERMINATE_GRACE)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            proc.wait(timeout=_TERMINATE_GRACE)
+            _wait_for_health(proc, log, base_url, timeout)
+            yield base_url
         finally:
-            # Close the inherited stdout pipe explicitly. Leaving it to the GC
-            # raises ResourceWarning, which pytest's ``filterwarnings=error``
-            # promotes to an unraisable-exception failure in a later test.
-            if proc.stdout is not None:
-                proc.stdout.close()
+            proc.terminate()
+            try:
+                proc.wait(timeout=_TERMINATE_GRACE)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                # A SIGKILL'd process stuck in uninterruptible I/O may still not
+                # reap within the grace window. Swallow the second timeout so
+                # teardown never raises out of ``finally`` and masks the real
+                # test result (edge [CRASH]).
+                with contextlib.suppress(subprocess.TimeoutExpired):
+                    proc.wait(timeout=_TERMINATE_GRACE)

--- a/src/tests/harness/rs_server.py
+++ b/src/tests/harness/rs_server.py
@@ -1,0 +1,150 @@
+"""Boot the harness resource server (:mod:`rs_app`) under real uvicorn workers.
+
+``boot_rs`` is deliberately free of any FastAPI / fastapi-identity-model import
+so it stays inside the root pyrefly lint env. It launches uvicorn as a
+subprocess by import-string (``src.tests.harness.rs_app:app``), passes RS
+configuration through inherited ``RS_*`` environment variables, waits for the
+``/health`` endpoint to answer over real HTTP, then tears the process down.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from pathlib import Path
+import socket
+import subprocess
+import sys
+import time
+from typing import TYPE_CHECKING
+
+import httpx
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Mapping
+
+
+# src/tests/harness/rs_server.py -> parents[3] is the repo root (holds ``src/``).
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_HEALTH_POLL_INTERVAL = 0.25
+_TERMINATE_GRACE = 10.0
+
+
+def _free_port() -> int:
+    """Bind to an ephemeral port, then release it for uvicorn to reuse.
+
+    A TOCTOU window exists between close and re-bind; the ``/health`` readiness
+    poll (which fails loudly if uvicorn never binds) is the real guard.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _drain(proc: subprocess.Popen[str]) -> str:
+    return proc.stdout.read() if proc.stdout is not None else ""
+
+
+def _wait_for_health(
+    proc: subprocess.Popen[str], base_url: str, timeout: float
+) -> None:
+    deadline = time.monotonic() + timeout
+    last_error = "no attempt made"
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(
+                f"uvicorn exited before becoming healthy "
+                f"(code {proc.returncode}):\n{_drain(proc)}"
+            )
+        try:
+            response = httpx.get(f"{base_url}/health", timeout=2.0)
+            if response.status_code == httpx.codes.OK:
+                return
+            last_error = f"HTTP {response.status_code}"
+        except httpx.HTTPError as exc:
+            last_error = str(exc)
+        time.sleep(_HEALTH_POLL_INTERVAL)
+
+    proc.terminate()
+    raise RuntimeError(
+        f"resource server did not become healthy within {timeout}s "
+        f"(last: {last_error}):\n{_drain(proc)}"
+    )
+
+
+@contextlib.contextmanager
+def boot_rs(  # noqa: PLR0913 — each RS knob (issuer/audience/scope/workers/...) is an explicit keyword
+    *,
+    discovery_url: str,
+    audience: str,
+    require_scope: str = "api",
+    workers: int = 1,
+    require_access_token_marker: bool = False,
+    excluded_paths: list[str] | None = None,
+    extra_env: Mapping[str, str] | None = None,
+    timeout: float = 30.0,
+) -> Iterator[str]:
+    """Boot a single-issuer resource server and yield its base URL.
+
+    Args:
+        discovery_url: OIDC discovery URL the middleware binds to.
+        audience: Expected ``aud`` claim (middleware requires non-empty).
+        require_scope: Scope enforced on ``/protected`` (403 if absent).
+        workers: uvicorn ``--workers`` count (>=2 proves multi-worker boot).
+        require_access_token_marker: F-07 ID-token-substitution defence opt-in.
+        excluded_paths: Override middleware excluded paths (must keep
+            ``/health`` for the readiness poll to pass).
+        extra_env: Additional environment for the uvicorn subprocess.
+        timeout: Seconds to wait for the first healthy ``/health`` response.
+
+    Yields:
+        The ``http://127.0.0.1:<port>`` base URL of the running server.
+    """
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+
+    env = dict(os.environ)
+    env["RS_DISCOVERY_URL"] = discovery_url
+    env["RS_AUDIENCE"] = audience
+    env["RS_REQUIRE_SCOPE"] = require_scope
+    env["RS_REQUIRE_ACCESS_TOKEN_MARKER"] = (
+        "true" if require_access_token_marker else "false"
+    )
+    if excluded_paths is not None:
+        env["RS_EXCLUDED_PATHS"] = ",".join(excluded_paths)
+    if extra_env:
+        env.update(extra_env)
+
+    proc = subprocess.Popen(  # noqa: S603 — fixed argv, no shell, test-only
+        [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            "src.tests.harness.rs_app:app",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--workers",
+            str(workers),
+            "--log-level",
+            "warning",
+        ],
+        cwd=str(_REPO_ROOT),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        _wait_for_health(proc, base_url, timeout)
+        yield base_url
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=_TERMINATE_GRACE)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=_TERMINATE_GRACE)

--- a/src/tests/harness/rs_server.py
+++ b/src/tests/harness/rs_server.py
@@ -148,3 +148,9 @@ def boot_rs(  # noqa: PLR0913 — each RS knob (issuer/audience/scope/workers/..
         except subprocess.TimeoutExpired:
             proc.kill()
             proc.wait(timeout=_TERMINATE_GRACE)
+        finally:
+            # Close the inherited stdout pipe explicitly. Leaving it to the GC
+            # raises ResourceWarning, which pytest's ``filterwarnings=error``
+            # promotes to an unraisable-exception failure in a later test.
+            if proc.stdout is not None:
+                proc.stdout.close()

--- a/src/tests/harness/token_source.py
+++ b/src/tests/harness/token_source.py
@@ -1,0 +1,462 @@
+"""Unified multi-provider ``TokenSource`` minter for the harness (TH-1.1, #463).
+
+One :meth:`TokenSource.mint` call unifies what the integration ``conftest``
+previously spread across ``client_credentials_token``, ``jwt_access_token``,
+``opaque_access_token`` and the ``auth_code_result`` helpers, plus the
+Descope-shaped multi-tenant minter — capability/credential-gated exactly like
+``provider_matrix.detect_capabilities``.
+
+* Real providers (node-oidc, Keycloak, Ory, Descope) mint through the library's
+  own token logic (``request_client_credentials_token`` / an injected auth-code
+  minter) — never reimplemented.
+* The ``MOCK`` provider mints valid tokens and, via ``malform=``, the forged
+  corpus (:mod:`corpus`) off the controllable mock OP (:mod:`mock_op`).
+
+Gating raises typed errors (:class:`HarnessCapabilityError` /
+:class:`HarnessCredentialError`) that the ``conftest`` fixture translates to
+``pytest.skip`` — so Ory/Descope skip cleanly when secret-gated, while ``MOCK``
+is always available.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import StrEnum
+import json
+import time
+from typing import TYPE_CHECKING, Any
+
+from py_identity_model import (
+    ClientCredentialsTokenRequest,
+    request_client_credentials_token,
+)
+
+from ..integration.provider_matrix import detect_capabilities
+from .corpus import build_corpus
+from .mock_op import MockOP
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+JWT_SEGMENT_SEPARATOR_COUNT = 2
+
+
+class Provider(StrEnum):
+    """Identity providers the harness can mint against."""
+
+    NODE_OIDC = "node-oidc"
+    KEYCLOAK = "keycloak"
+    ORY = "ory"
+    DESCOPE = "descope"
+    MOCK = "mock"
+
+
+class Grant(StrEnum):
+    """OAuth grant types the minter understands."""
+
+    CLIENT_CREDENTIALS = "client_credentials"
+    AUTHORIZATION_CODE = "authorization_code"
+    REFRESH_TOKEN = "refresh_token"
+    DEVICE_CODE = "device_code"
+
+
+class Malform(StrEnum):
+    """Forged-token classes (MOCK provider only)."""
+
+    VALID = "valid"
+    EXPIRED = "expired"
+    NBF_FUTURE = "nbf_future"
+    WRONG_ISS = "wrong_iss"
+    WRONG_AUD = "wrong_aud"
+    TAMPERED_SIG = "tampered_sig"
+    UNKNOWN_KID = "unknown_kid"
+    WRONG_ALG = "wrong_alg"
+    ALG_NONE = "alg_none"
+    ID_AS_ACCESS = "id_as_access"
+    CNF_BOUND = "cnf_bound"
+    OVERSIZED = "oversized"
+    MULTI_AUD_UNTRUSTED = "multi_aud_untrusted"
+
+
+# Grant -> provider_matrix capability key.
+_GRANT_CAPABILITY: dict[Grant, str] = {
+    Grant.CLIENT_CREDENTIALS: "client_credentials",
+    Grant.AUTHORIZATION_CODE: "authorization_code",
+    Grant.REFRESH_TOKEN: "refresh_token",
+    Grant.DEVICE_CODE: "device_authorization",
+}
+
+
+class HarnessError(Exception):
+    """Base class for token-harness errors."""
+
+
+class HarnessCapabilityError(HarnessError):
+    """The provider does not advertise the requested grant/capability."""
+
+
+class HarnessCredentialError(HarnessError):
+    """The provider supports the grant but the required credentials are absent."""
+
+
+@dataclass(frozen=True)
+class MintedToken:
+    """The result of a mint — a replayable token plus its provenance."""
+
+    access_token: str
+    provider: Provider
+    grant: Grant
+    token_type: str = "Bearer"
+    id_token: str | None = None
+    expires_at: float | None = None
+    tenant: str | None = None
+    alg: str | None = None
+    kid: str | None = None
+    malform: Malform | None = None
+
+    def is_expired(self, *, now: float | None = None, leeway: float = 0.0) -> bool:
+        """Whether the token is past its expiry (for T311 re-mint cadence)."""
+        if self.expires_at is None:
+            return False
+        return (now if now is not None else time.time()) >= self.expires_at - leeway
+
+
+# An auth-code minter returns an OAuth token-response dict (``access_token`` …),
+# letting the conftest inject ``perform_auth_code_flow`` without this module
+# importing pytest.
+AuthCodeMinter = Callable[[str | None, str | None], dict[str, Any]]
+
+
+@dataclass
+class ProviderConfig:
+    """Per-provider configuration and capabilities for the minter."""
+
+    provider: Provider
+    capabilities: set[str] = field(default_factory=set)
+    token_endpoint: str | None = None
+    client_id: str | None = None
+    client_secret: str | None = None
+    scope: str | None = None
+    mock_op: MockOP | None = None
+    auth_code_minter: AuthCodeMinter | None = None
+
+    @classmethod
+    def from_discovery(
+        cls,
+        provider: Provider,
+        raw_discovery: dict[str, Any],
+        *,
+        token_endpoint: str | None = None,
+        client_id: str | None = None,
+        client_secret: str | None = None,
+        scope: str | None = None,
+        auth_code_minter: AuthCodeMinter | None = None,
+    ) -> ProviderConfig:
+        """Build a real-provider config, deriving capabilities from discovery.
+
+        Reuses ``provider_matrix.detect_capabilities`` so the harness and the
+        capability matrix never drift.
+        """
+        caps = {name for name, ok in detect_capabilities(raw_discovery).items() if ok}
+        return cls(
+            provider=provider,
+            capabilities=caps,
+            token_endpoint=token_endpoint or raw_discovery.get("token_endpoint"),
+            client_id=client_id,
+            client_secret=client_secret,
+            scope=scope,
+            auth_code_minter=auth_code_minter,
+        )
+
+
+class TokenSource:
+    """The unified minter. One :meth:`mint` for every provider/grant/forgery."""
+
+    def __init__(self, configs: Iterable[ProviderConfig]) -> None:
+        self._configs: dict[Provider, ProviderConfig] = {
+            cfg.provider: cfg for cfg in configs
+        }
+
+    @classmethod
+    def with_mock(
+        cls, mock_op: MockOP | None = None, *, extra: Iterable[ProviderConfig] = ()
+    ) -> TokenSource:
+        """Convenience builder wiring a ``MOCK`` provider (always mintable)."""
+        mock = mock_op or MockOP()
+        mock_cfg = ProviderConfig(
+            provider=Provider.MOCK,
+            capabilities={_GRANT_CAPABILITY[g] for g in Grant},
+            mock_op=mock,
+        )
+        return cls([mock_cfg, *extra])
+
+    @property
+    def providers(self) -> list[Provider]:
+        return list(self._configs)
+
+    def config(self, provider: Provider) -> ProviderConfig:
+        try:
+            return self._configs[provider]
+        except KeyError:
+            raise HarnessCapabilityError(
+                f"provider {provider.value} is not configured in this TokenSource"
+            ) from None
+
+    def mint(
+        self,
+        provider: Provider,
+        grant: Grant = Grant.CLIENT_CREDENTIALS,
+        *,
+        tenant: str | None = None,
+        scopes: str | None = None,
+        malform: Malform | None = None,
+    ) -> MintedToken:
+        """Mint a token.
+
+        Args:
+            provider: The provider to mint against.
+            grant: The grant type (``client_credentials`` by default).
+            tenant: Optional tenant, shaping Descope-style multi-tenant claims.
+            scopes: Space-delimited scopes.
+            malform: A forged class — MOCK-only; raises
+                :class:`HarnessCapabilityError` for any real provider.
+
+        Raises:
+            HarnessCapabilityError: provider/grant/forgery unsupported.
+            HarnessCredentialError: grant supported but credentials absent.
+        """
+        cfg = self.config(provider)
+        if malform is not None:
+            return self._mint_forged(cfg, grant, tenant, malform)
+        if provider is Provider.MOCK:
+            return self._mint_mock_valid(cfg, grant, tenant, scopes)
+        self._check_capability(cfg, grant)
+        self._check_credentials(cfg, grant)
+        if grant is Grant.CLIENT_CREDENTIALS:
+            return self._mint_client_credentials(cfg, tenant, scopes)
+        if grant is Grant.AUTHORIZATION_CODE:
+            return self._mint_auth_code(cfg, tenant, scopes)
+        raise HarnessCapabilityError(
+            f"grant {grant.value} is not implemented for provider {provider.value}"
+        )
+
+    # -- Gating -------------------------------------------------------------
+
+    def _check_capability(self, cfg: ProviderConfig, grant: Grant) -> None:
+        capability = _GRANT_CAPABILITY[grant]
+        if capability not in cfg.capabilities:
+            raise HarnessCapabilityError(
+                f"{cfg.provider.value} does not advertise {capability} "
+                f"(grant {grant.value})"
+            )
+
+    def _check_credentials(self, cfg: ProviderConfig, grant: Grant) -> None:
+        if grant is Grant.CLIENT_CREDENTIALS:
+            if not (cfg.client_id and cfg.client_secret and cfg.token_endpoint):
+                raise HarnessCredentialError(
+                    f"{cfg.provider.value}: client_credentials requires "
+                    f"client_id, client_secret and a token endpoint"
+                )
+        elif grant is Grant.AUTHORIZATION_CODE and cfg.auth_code_minter is None:
+            raise HarnessCredentialError(
+                f"{cfg.provider.value}: no auth-code minter configured"
+            )
+
+    # -- Real-provider mints ------------------------------------------------
+
+    def _mint_client_credentials(
+        self, cfg: ProviderConfig, tenant: str | None, scopes: str | None
+    ) -> MintedToken:
+        assert cfg.token_endpoint
+        assert cfg.client_id
+        assert cfg.client_secret
+        response = request_client_credentials_token(
+            ClientCredentialsTokenRequest(
+                client_id=cfg.client_id,
+                client_secret=cfg.client_secret,
+                address=cfg.token_endpoint,
+                scope=scopes or cfg.scope,
+            )
+        )
+        if not response.is_successful:
+            raise HarnessError(
+                f"{cfg.provider.value}: client_credentials mint failed: "
+                f"{response.error}"
+            )
+        assert response.token is not None
+        return self._from_token_response(
+            cfg.provider, Grant.CLIENT_CREDENTIALS, response.token, tenant
+        )
+
+    def _mint_auth_code(
+        self, cfg: ProviderConfig, tenant: str | None, scopes: str | None
+    ) -> MintedToken:
+        assert cfg.auth_code_minter is not None
+        token = cfg.auth_code_minter(tenant, scopes)
+        return self._from_token_response(
+            cfg.provider, Grant.AUTHORIZATION_CODE, token, tenant
+        )
+
+    def _from_token_response(
+        self,
+        provider: Provider,
+        grant: Grant,
+        token: dict[str, Any],
+        tenant: str | None,
+    ) -> MintedToken:
+        access_token = token["access_token"]
+        expires_in = token.get("expires_in")
+        expires_at = time.time() + expires_in if expires_in else None
+        alg, kid = _peek_jwt_header(access_token)
+        return MintedToken(
+            access_token=access_token,
+            provider=provider,
+            grant=grant,
+            token_type=token.get("token_type", "Bearer"),
+            id_token=token.get("id_token"),
+            expires_at=expires_at,
+            tenant=tenant,
+            alg=alg,
+            kid=kid,
+        )
+
+    # -- MOCK mints ---------------------------------------------------------
+
+    def _mint_mock_valid(
+        self,
+        cfg: ProviderConfig,
+        grant: Grant,
+        tenant: str | None,
+        scopes: str | None,
+    ) -> MintedToken:
+        mock = self._require_mock(cfg)
+        token = mock.mint_access_token(scopes=scopes, tenant=tenant)
+        return MintedToken(
+            access_token=token["access_token"],
+            provider=Provider.MOCK,
+            grant=grant,
+            token_type=token["token_type"],
+            expires_at=time.time() + token["expires_in"],
+            tenant=tenant,
+            alg=mock.signing_key.alg,
+            kid=mock.signing_key.kid,
+            malform=Malform.VALID,
+        )
+
+    def _mint_forged(
+        self,
+        cfg: ProviderConfig,
+        grant: Grant,
+        tenant: str | None,
+        malform: Malform,
+    ) -> MintedToken:
+        if cfg.provider is not Provider.MOCK:
+            raise HarnessCapabilityError(
+                "forged tokens are only available from the MOCK provider "
+                "(real OPs will not emit invalid tokens)"
+            )
+        mock = self._require_mock(cfg)
+        forged = build_corpus(mock)[malform.value]
+        return MintedToken(
+            access_token=forged.jwt,
+            provider=Provider.MOCK,
+            grant=grant,
+            tenant=tenant,
+            malform=malform,
+        )
+
+    def _require_mock(self, cfg: ProviderConfig) -> MockOP:
+        if cfg.mock_op is None:
+            raise HarnessCapabilityError("MOCK provider has no mock OP configured")
+        return cfg.mock_op
+
+
+def _peek_jwt_header(token: str) -> tuple[str | None, str | None]:
+    """Best-effort ``(alg, kid)`` from a compact JWT header; ``(None, None)``
+    for opaque tokens."""
+    if token.count(".") != JWT_SEGMENT_SEPARATOR_COUNT:
+        return None, None
+    header_segment = token.split(".", 1)[0]
+    padding = "=" * (-len(header_segment) % 4)
+    try:
+        header = json.loads(base64.urlsafe_b64decode(header_segment + padding))
+    except (ValueError, json.JSONDecodeError):
+        return None, None
+    return header.get("alg"), header.get("kid")
+
+
+# -- Replay pool ------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MintSpec:
+    """A single mint request for :func:`prime_pool`."""
+
+    provider: Provider
+    grant: Grant = Grant.CLIENT_CREDENTIALS
+    tenant: str | None = None
+    scopes: str | None = None
+    malform: Malform | None = None
+
+    def key(self) -> str:
+        parts = [
+            self.provider.value,
+            self.grant.value,
+            self.tenant or "-",
+            self.scopes or "-",
+            self.malform.value if self.malform else "-",
+        ]
+        return "|".join(parts)
+
+
+class ReplayPool:
+    """Pre-mint once, replay many (design §3).
+
+    Real IdPs rate-limit and validation is stateless, so the harness mints each
+    distinct spec a single time and replays the token. ``expires_at`` is tracked
+    so T311 can re-mint across the 300s TTL / classify post-expiry 401s as
+    expected rather than error-budget.
+    """
+
+    def __init__(self) -> None:
+        self._by_key: dict[str, MintedToken] = {}
+
+    def add(self, spec: MintSpec, token: MintedToken) -> None:
+        self._by_key[spec.key()] = token
+
+    def get(self, spec: MintSpec) -> MintedToken:
+        return self._by_key[spec.key()]
+
+    def all(self) -> list[MintedToken]:
+        return list(self._by_key.values())
+
+    def __len__(self) -> int:
+        return len(self._by_key)
+
+    def __iter__(self):
+        return iter(self._by_key.values())
+
+
+def prime_pool(source: TokenSource, specs: Iterable[MintSpec]) -> ReplayPool:
+    """Mint each spec once into a :class:`ReplayPool` (skips duplicate specs)."""
+    pool = ReplayPool()
+    seen: set[str] = set()
+    for spec in specs:
+        if spec.key() in seen:
+            continue
+        seen.add(spec.key())
+        pool.add(
+            spec,
+            source.mint(
+                spec.provider,
+                spec.grant,
+                tenant=spec.tenant,
+                scopes=spec.scopes,
+                malform=spec.malform,
+            ),
+        )
+    return pool

--- a/src/tests/harness/token_source.py
+++ b/src/tests/harness/token_source.py
@@ -462,11 +462,13 @@ def _descope_accesskey_exchange(
         data = created.json()
         key_id = data.get("key", {}).get("id", "")
         cleartext = data.get("cleartext", "")
+    # Once a key exists, the finally must delete it — even if ``cleartext`` is
+    # absent — so the raise lives inside the try, not before it.
+    try:
         if not cleartext:
             raise HarnessError(
                 f"descope access-key create returned no cleartext: {data}"
             )
-    try:
         with httpx.Client(timeout=_DESCOPE_HTTP_TIMEOUT) as client:
             exchanged = client.post(
                 f"{base}/v1/auth/accesskey/exchange",
@@ -482,15 +484,16 @@ def _descope_accesskey_exchange(
                 )
             return session_jwt
     finally:
-        with (
-            contextlib.suppress(Exception),
-            httpx.Client(timeout=_DESCOPE_HTTP_TIMEOUT) as client,
-        ):
-            client.post(
-                f"{base}/v1/mgmt/accesskey/delete",
-                headers=mgmt_headers,
-                json={"id": key_id},
-            )
+        if key_id:
+            with (
+                contextlib.suppress(Exception),
+                httpx.Client(timeout=_DESCOPE_HTTP_TIMEOUT) as client,
+            ):
+                client.post(
+                    f"{base}/v1/mgmt/accesskey/delete",
+                    headers=mgmt_headers,
+                    json={"id": key_id},
+                )
 
 
 def _peek_jwt_header(token: str) -> tuple[str | None, str | None]:

--- a/src/tests/harness/token_source.py
+++ b/src/tests/harness/token_source.py
@@ -22,11 +22,15 @@ from __future__ import annotations
 
 import base64
 from collections.abc import Callable
+import contextlib
 from dataclasses import dataclass, field
 from enum import StrEnum
 import json
 import time
 from typing import TYPE_CHECKING, Any
+import uuid
+
+import httpx
 
 from py_identity_model import (
     ClientCredentialsTokenRequest,
@@ -143,6 +147,12 @@ class ProviderConfig:
     scope: str | None = None
     mock_op: MockOP | None = None
     auth_code_minter: AuthCodeMinter | None = None
+    # Descope multi-tenant (access-key -> /v1/auth/accesskey/exchange) config.
+    # When present, ``mint(DESCOPE, tenant=…)`` produces a session JWT carrying
+    # distinct ``dct``/``tenants`` claims (AC-3); absent -> credential skip.
+    descope_project_id: str | None = None
+    descope_management_key: str | None = None
+    descope_base_url: str | None = None
 
     @classmethod
     def from_discovery(
@@ -155,6 +165,9 @@ class ProviderConfig:
         client_secret: str | None = None,
         scope: str | None = None,
         auth_code_minter: AuthCodeMinter | None = None,
+        descope_project_id: str | None = None,
+        descope_management_key: str | None = None,
+        descope_base_url: str | None = None,
     ) -> ProviderConfig:
         """Build a real-provider config, deriving capabilities from discovery.
 
@@ -170,6 +183,9 @@ class ProviderConfig:
             client_secret=client_secret,
             scope=scope,
             auth_code_minter=auth_code_minter,
+            descope_project_id=descope_project_id,
+            descope_management_key=descope_management_key,
+            descope_base_url=descope_base_url,
         )
 
 
@@ -234,6 +250,14 @@ class TokenSource:
             return self._mint_forged(cfg, grant, tenant, malform)
         if provider is Provider.MOCK:
             return self._mint_mock_valid(cfg, grant, tenant, scopes)
+        if (
+            provider is Provider.DESCOPE
+            and grant is Grant.CLIENT_CREDENTIALS
+            and tenant is not None
+        ):
+            # AC-3: the Descope multi-tenant path is the access-key -> session-JWT
+            # exchange (distinct dct/tenants), NOT the plain OIDC token endpoint.
+            return self._mint_descope_tenant(cfg, tenant)
         self._check_capability(cfg, grant)
         self._check_credentials(cfg, grant)
         if grant is Grant.CLIENT_CREDENTIALS:
@@ -299,6 +323,37 @@ class TokenSource:
         token = cfg.auth_code_minter(tenant, scopes)
         return self._from_token_response(
             cfg.provider, Grant.AUTHORIZATION_CODE, token, tenant
+        )
+
+    def _mint_descope_tenant(self, cfg: ProviderConfig, tenant: str) -> MintedToken:
+        """Reuse the identity-stack access-key -> session-JWT exchange (AC-3).
+
+        Creates a temporary tenant-scoped access key, exchanges it via
+        ``/v1/auth/accesskey/exchange`` for a Descope *session JWT* carrying
+        distinct ``dct``/``tenants`` claims, then deletes the key. Credential-
+        gated: absent Descope management config raises
+        :class:`HarnessCredentialError` (translated to ``pytest.skip``).
+        """
+        if not (
+            cfg.descope_project_id
+            and cfg.descope_management_key
+            and cfg.descope_base_url
+        ):
+            raise HarnessCredentialError(
+                "descope: multi-tenant mint requires descope_project_id, "
+                "descope_management_key and descope_base_url"
+            )
+        session_jwt = _descope_accesskey_exchange(
+            base_url=cfg.descope_base_url,
+            project_id=cfg.descope_project_id,
+            management_key=cfg.descope_management_key,
+            tenant=tenant,
+        )
+        return self._from_token_response(
+            Provider.DESCOPE,
+            Grant.CLIENT_CREDENTIALS,
+            {"access_token": session_jwt, "token_type": "Bearer"},
+            tenant,
         )
 
     def _from_token_response(
@@ -375,6 +430,69 @@ class TokenSource:
         return cfg.mock_op
 
 
+_DESCOPE_HTTP_TIMEOUT = 30.0
+
+
+def _descope_accesskey_exchange(
+    *,
+    base_url: str,
+    project_id: str,
+    management_key: str,
+    tenant: str,
+    roles: Iterable[str] = ("owner", "admin"),
+) -> str:
+    """Access-key create -> exchange -> delete, returning the session JWT.
+
+    Mirrors the identity-stack e2e minter: a ``keyTenants`` (array) access key
+    is required so the exchanged session JWT includes ``dct``/``tenants`` claims
+    (a top-level ``tenantId`` does not). The temporary key is deleted best-effort.
+    """
+    base = base_url.rstrip("/")
+    mgmt_headers = {"Authorization": f"Bearer {project_id}:{management_key}"}
+    with httpx.Client(timeout=_DESCOPE_HTTP_TIMEOUT) as client:
+        created = client.post(
+            f"{base}/v1/mgmt/accesskey/create",
+            headers=mgmt_headers,
+            json={
+                "name": f"harness-{uuid.uuid4().hex[:8]}",
+                "keyTenants": [{"tenantId": tenant, "roleNames": list(roles)}],
+            },
+        )
+        created.raise_for_status()
+        data = created.json()
+        key_id = data.get("key", {}).get("id", "")
+        cleartext = data.get("cleartext", "")
+        if not cleartext:
+            raise HarnessError(
+                f"descope access-key create returned no cleartext: {data}"
+            )
+    try:
+        with httpx.Client(timeout=_DESCOPE_HTTP_TIMEOUT) as client:
+            exchanged = client.post(
+                f"{base}/v1/auth/accesskey/exchange",
+                headers={"Authorization": f"Bearer {project_id}:{cleartext}"},
+                json={},
+            )
+            exchanged.raise_for_status()
+            session_jwt = exchanged.json().get("sessionJwt", "")
+            if not session_jwt:
+                raise HarnessError(
+                    f"descope access-key exchange returned no sessionJwt: "
+                    f"{exchanged.json()}"
+                )
+            return session_jwt
+    finally:
+        with (
+            contextlib.suppress(Exception),
+            httpx.Client(timeout=_DESCOPE_HTTP_TIMEOUT) as client,
+        ):
+            client.post(
+                f"{base}/v1/mgmt/accesskey/delete",
+                headers=mgmt_headers,
+                json={"id": key_id},
+            )
+
+
 def _peek_jwt_header(token: str) -> tuple[str | None, str | None]:
     """Best-effort ``(alg, kid)`` from a compact JWT header; ``(None, None)``
     for opaque tokens."""
@@ -385,6 +503,8 @@ def _peek_jwt_header(token: str) -> tuple[str | None, str | None]:
     try:
         header = json.loads(base64.urlsafe_b64decode(header_segment + padding))
     except (ValueError, json.JSONDecodeError):
+        return None, None
+    if not isinstance(header, dict):
         return None, None
     return header.get("alg"), header.get("kid")
 

--- a/src/tests/integration/.env.descope.example
+++ b/src/tests/integration/.env.descope.example
@@ -29,3 +29,12 @@ TEST_AUDIENCE=
 
 # Expired token for testing (generate a token and let it expire, or use an invalid token)
 TEST_EXPIRED_TOKEN=
+
+# Multi-tenant access-key exchange (TH-1.1 AC-3). When all four are set, the
+# harness TokenSource.mint(Provider.DESCOPE, tenant=…) reuses the identity-stack
+# access-key -> /v1/auth/accesskey/exchange flow to produce a session JWT
+# carrying distinct dct/tenants claims. Absent -> the multi-tenant test skips.
+DESCOPE_BASE_URL=https://api.descope.com
+DESCOPE_PROJECT_ID=
+DESCOPE_MANAGEMENT_KEY=
+DESCOPE_TEST_TENANT_ID=

--- a/src/tests/integration/README.md
+++ b/src/tests/integration/README.md
@@ -80,6 +80,15 @@ TEST_AUDIENCE=YOUR_PROJECT_ID
 
 # Optional: Generate an expired token for expiration tests
 TEST_EXPIRED_TOKEN=
+
+# Optional: Multi-tenant access-key exchange (harness TokenSource).
+# When all four are set, `TokenSource.mint(Provider.DESCOPE, tenant=…)` reuses
+# the access-key -> /v1/auth/accesskey/exchange flow to produce a session JWT
+# carrying distinct dct/tenants claims; absent, the multi-tenant test skips.
+DESCOPE_BASE_URL=https://api.descope.com
+DESCOPE_PROJECT_ID=
+DESCOPE_MANAGEMENT_KEY=
+DESCOPE_TEST_TENANT_ID=
 ```
 
 3. Load the environment variables:

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -705,6 +705,10 @@ def token_source(
         client_secret=test_config.get("TEST_CLIENT_SECRET"),
         scope=test_config.get("TEST_SCOPE"),
         auth_code_minter=auth_code_minter,
+        # Descope multi-tenant access-key exchange (AC-3); absent -> skip.
+        descope_project_id=test_config.get("DESCOPE_PROJECT_ID"),
+        descope_management_key=test_config.get("DESCOPE_MANAGEMENT_KEY"),
+        descope_base_url=test_config.get("DESCOPE_BASE_URL"),
     )
     return TokenSource.with_mock(extra=[real_cfg])
 

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -57,6 +57,12 @@ from py_identity_model.core.pkce import generate_pkce_pair
 from py_identity_model.exceptions import TokenValidationException
 from py_identity_model.sync.http_client import close_http_client
 
+from ..harness import (
+    HarnessError,
+    Provider,
+    ProviderConfig,
+    TokenSource,
+)
 from .test_utils import get_config
 
 
@@ -610,6 +616,97 @@ def opaque_access_token(
         access_token = response.token["access_token"]
         cache_file.write_text(json.dumps({"access_token": access_token}))
         return access_token
+
+
+# ============================================================================
+# Unified token-source harness (TH-1.1, #463)
+# ============================================================================
+
+# The provider slug (derived from the ``.env.<slug>`` file) maps onto the
+# harness ``Provider`` enum. An unrecognised slug (e.g. ``.env.local``) leaves
+# the real provider unwired, so only the always-available MOCK provider is
+# offered and the real-IdP tests skip cleanly.
+_SLUG_TO_PROVIDER: dict[str, Provider] = {
+    "node-oidc": Provider.NODE_OIDC,
+    "keycloak": Provider.KEYCLOAK,
+    "ory": Provider.ORY,
+    "descope": Provider.DESCOPE,
+}
+
+
+@pytest.fixture(scope="session")
+def harness_provider(provider_slug) -> Provider | None:
+    """The real :class:`Provider` under test, or ``None`` for an unknown slug."""
+    return _SLUG_TO_PROVIDER.get(provider_slug)
+
+
+@pytest.fixture(scope="session")
+def token_source(
+    harness_provider,
+    raw_discovery,
+    discovery_document,
+    provider_capabilities,
+    test_config,
+) -> TokenSource:
+    """Session-scoped unified minter (:class:`TokenSource`) for the harness.
+
+    Wires the real provider under test — capabilities derived from live
+    discovery via ``provider_matrix.detect_capabilities`` (so the harness and
+    the capability matrix never drift), credentials from the env file — plus
+    the always-available MOCK provider. When the provider supports automated
+    auth-code flows (devInteractions) and the auth-code client is configured,
+    an ``auth_code_minter`` wrapping :func:`perform_auth_code_flow` is injected
+    so ``Grant.AUTHORIZATION_CODE`` mints end-to-end.
+
+    Tests translate the typed gating errors
+    (:class:`HarnessCapabilityError` / :class:`HarnessCredentialError`) to
+    ``pytest.skip`` so secret-gated providers (Ory/Descope) skip cleanly while
+    MOCK is always mintable.
+    """
+    if harness_provider is None:
+        return TokenSource.with_mock()
+
+    auth_code_minter = None
+    if "dev_interactions" in provider_capabilities:
+        client_id = test_config.get("TEST_AUTH_CODE_CLIENT_ID")
+        redirect_uri = test_config.get("TEST_AUTH_CODE_REDIRECT_URI")
+        client_secret = test_config.get("TEST_AUTH_CODE_CLIENT_SECRET")
+        if client_id and redirect_uri:
+
+            def auth_code_minter(
+                tenant: str | None,
+                scopes: str | None,
+                *,
+                _client_id: str = client_id,
+                _redirect_uri: str = redirect_uri,
+                _client_secret: str | None = client_secret,
+            ) -> dict[str, Any]:
+                del tenant  # single-tenant local fixtures ignore tenant shaping
+                result = perform_auth_code_flow(
+                    discovery=discovery_document,
+                    client_id=_client_id,
+                    redirect_uri=_redirect_uri,
+                    config=AuthCodeFlowConfig(
+                        client_secret=_client_secret,
+                        scope=scopes or "openid profile email offline_access",
+                        resource="urn:test:api",
+                    ),
+                )
+                token_response = result["token_response"]
+                if not token_response.is_successful or token_response.token is None:
+                    raise HarnessError(f"auth-code mint failed: {token_response.error}")
+                return dict(token_response.token)
+
+    real_cfg = ProviderConfig.from_discovery(
+        harness_provider,
+        raw_discovery,
+        token_endpoint=discovery_document.token_endpoint,
+        client_id=test_config.get("TEST_CLIENT_ID"),
+        client_secret=test_config.get("TEST_CLIENT_SECRET"),
+        scope=test_config.get("TEST_SCOPE"),
+        auth_code_minter=auth_code_minter,
+    )
+    return TokenSource.with_mock(extra=[real_cfg])
 
 
 @pytest.fixture(autouse=True)

--- a/src/tests/integration/test_correctness_matrix.py
+++ b/src/tests/integration/test_correctness_matrix.py
@@ -249,9 +249,9 @@ def _granted_scopes(access_token: str) -> list[str]:
     raw = claims.get("scope") or claims.get("scp") or ""
     if isinstance(raw, str):
         return raw.split()
-    if isinstance(raw, (list, tuple)):
+    if isinstance(raw, (list, tuple, set, frozenset)):
         return [s for s in raw if isinstance(s, str)]
-    # A non-str, non-sequence scope claim (e.g. a JSON int) is not iterable —
+    # A non-str, non-collection scope claim (e.g. a JSON int) is not iterable —
     # treat it as no granted scopes rather than crashing on ``for`` (edge guard).
     return []
 

--- a/src/tests/integration/test_correctness_matrix.py
+++ b/src/tests/integration/test_correctness_matrix.py
@@ -1,0 +1,302 @@
+"""Token correctness assertion matrix — TH-1.3 (#465 · epic #462, design §4 S8).
+
+Sends ONE token per class through the **booted resource server**
+(:func:`~harness.rs_server.boot_rs` — real uvicorn, real HTTP) and asserts the
+contract: ``200`` for valid tokens, ``401`` with the uniform (F-18) body for
+every validation-failure class, ``403``/``401`` for the RS-policy classes, and
+that **nothing is silently accepted**.
+
+Two groups:
+
+* **Group A — forged-corpus matrix.** The controllable :class:`~harness.MockOP`
+  (served over real localhost HTTP by :func:`~harness.serve_mock_op` so the
+  out-of-process RS can fetch its discovery + JWKS) supplies the full forged
+  corpus keyed to its known signing key. This is self-contained: no Docker, runs
+  under ``uv run --all-packages``.
+* **Group B — real-issuer leg.** A live node-oidc token proves the same contract
+  against a REAL IdP over real HTTP. Gated to node-oidc (the remote matrix
+  providers mint different aud/scope), mirroring ``test_rs_boot``.
+
+Run via ``make test-harness-matrix`` (Docker node-oidc + ``--all-packages`` so
+``fastapi_identity_model`` and ``uvicorn`` resolve). Under a plain env the module
+importorskips cleanly.
+"""
+
+from collections import namedtuple
+import time
+from urllib.parse import urlparse
+
+import httpx
+import jwt
+import pytest
+
+from ..harness import CORPUS_AUDIENCE, build_corpus, serve_mock_op
+from ..harness.rs_server import boot_rs
+
+
+pytest.importorskip("fastapi_identity_model")
+pytest.importorskip("uvicorn")
+
+pytestmark = pytest.mark.integration
+
+GENERIC_401_BODY = {"detail": "Invalid or unauthorized token"}
+
+# The 8 classes a validating library rejects outright (sig / iss / aud / exp /
+# nbf / kid / alg). Every one must collapse to the SAME generic 401 body (F-18).
+VALIDATION_FAIL_CLASSES = [
+    "expired",
+    "nbf_future",
+    "wrong_iss",
+    "wrong_aud",
+    "tampered_sig",
+    "unknown_kid",
+    "wrong_alg",
+    "alg_none",
+]
+
+# Validly signed, correct-audience tokens carrying the ``read`` scope — the
+# library AND the RS scope guard accept them (200). ``cnf_bound`` is here on
+# purpose: the cnf-bound-as-bearer token is ACCEPTED today (F-02, #478); this
+# suite asserts the *current* contract, it does not assume rejection.
+ACCEPTED_200_CLASSES = ["valid", "cnf_bound", "oversized", "multi_aud_untrusted"]
+
+# The middleware's always-on negative ID-token defense (F-07): a token carrying
+# an ID-token-only claim (``nonce``/``at_hash``/``c_hash``) is rejected before
+# ``require_scope`` runs, regardless of the ``require_access_token_marker`` opt-in.
+ID_TOKEN_DETAIL = "ID token cannot be used as an access token"
+
+# What the module fixture exposes: the live mock OP (to mint bespoke tokens), the
+# booted RS base URL, the forged corpus, and the mock OP discovery URL (so a
+# second RS can be booted against the same issuer for the F-07 marker case).
+MockMatrix = namedtuple("MockMatrix", "op base_url corpus discovery_url")
+
+
+def _get_protected(base_url: str, token: str) -> httpx.Response:
+    return httpx.get(
+        f"{base_url}/protected",
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=10.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Group A — forged-corpus matrix through the mock-OP-backed RS
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def mock_matrix():
+    """One mock OP + one booted RS (audience=mock-api, require_scope=read).
+
+    Yields a :class:`MockMatrix`; the RS is a single uvicorn subprocess reused
+    across all parametrized cases (a boot is ~1-2s, so we batch, not re-boot).
+    """
+    with (
+        serve_mock_op() as op,
+        boot_rs(
+            discovery_url=op.discovery_url,
+            audience=CORPUS_AUDIENCE,
+            require_scope="read",
+        ) as base_url,
+    ):
+        yield MockMatrix(op, base_url, build_corpus(op), op.discovery_url)
+
+
+@pytest.mark.parametrize("name", ACCEPTED_200_CLASSES)
+def test_accepted_classes_reach_protected(mock_matrix, name):
+    """Validly signed, correctly scoped tokens → 200 (F-02 contract included)."""
+    response = _get_protected(mock_matrix.base_url, mock_matrix.corpus[name].jwt)
+    assert response.status_code == httpx.codes.OK
+
+
+def test_valid_token_body_echoes_claims(mock_matrix):
+    """The canonical valid token → 200 with the validated sub + scope echoed."""
+    response = _get_protected(mock_matrix.base_url, mock_matrix.corpus["valid"].jwt)
+    assert response.status_code == httpx.codes.OK
+    body = response.json()
+    assert body["sub"] == "mock-subject"
+    assert body["scope"] == "read"
+
+
+@pytest.mark.parametrize("name", VALIDATION_FAIL_CLASSES)
+def test_validation_failures_are_uniform_401(mock_matrix, name):
+    """Each validation-failure class → 401 with the generic (F-18) body."""
+    response = _get_protected(mock_matrix.base_url, mock_matrix.corpus[name].jwt)
+    assert response.status_code == httpx.codes.UNAUTHORIZED
+    assert response.json() == GENERIC_401_BODY
+
+
+def test_f18_body_uniform_across_all_failure_stages(mock_matrix):
+    """F-18: every validation stage returns the *same* 401 body (no leakage).
+
+    A single divergent body (e.g. an ``exp``-specific message) would let a
+    caller distinguish rejection reasons — the vulnerability F-18 closed.
+    """
+    bodies = [
+        _get_protected(mock_matrix.base_url, mock_matrix.corpus[name].jwt).json()
+        for name in VALIDATION_FAIL_CLASSES
+    ]
+    assert bodies == [GENERIC_401_BODY] * len(VALIDATION_FAIL_CLASSES)
+
+
+def test_id_as_access_rejected_by_negative_defense(mock_matrix):
+    """F-07 negative (always on): an ID-token presented as a bearer → 401.
+
+    The corpus ID-token carries ``nonce`` (an ID-token-only claim), so the
+    middleware rejects it as the wrong token type BEFORE ``require_scope`` runs
+    — on the default RS, with no marker opt-in required. This is the passive
+    token-type-confusion defense; the opt-in *positive* marker path is proven in
+    :func:`test_scopeless_access_token_marker_gate`.
+    """
+    response = _get_protected(
+        mock_matrix.base_url, mock_matrix.corpus["id_as_access"].jwt
+    )
+    assert response.status_code == httpx.codes.UNAUTHORIZED
+    assert response.json() == {"detail": ID_TOKEN_DETAIL}
+
+
+def test_f02_cnf_bound_accepted_today(mock_matrix):
+    """F-02: a cnf-bound token presented as a plain bearer → 200 TODAY.
+
+    This asserts the *current* accepted-today contract, NOT desired behaviour;
+    #478 tracks rejecting sender-constrained tokens at the RS. When #478 lands
+    this expectation flips to 401 — that is intended, not a regression here.
+    """
+    response = _get_protected(mock_matrix.base_url, mock_matrix.corpus["cnf_bound"].jwt)
+    assert response.status_code == httpx.codes.OK
+
+
+def test_nothing_silently_accepted(mock_matrix):
+    """Every class outside the accepted set is rejected (never a silent 200)."""
+    for name, forged in mock_matrix.corpus.items():
+        if name in ACCEPTED_200_CLASSES:
+            continue
+        response = _get_protected(mock_matrix.base_url, forged.jwt)
+        assert response.status_code != httpx.codes.OK, (
+            f"class {name!r} was silently accepted (200)"
+        )
+
+
+def _mint_scopeless_access_token(op) -> str:
+    """A validly signed token with NO ``scope``/``scp`` and NO ID-token-only
+    claim — passes signature/aud/type validation but carries no access-token
+    marker (the exact shape the positive F-07 marker gate exists to catch)."""
+    now = int(time.time())
+    return op.sign(
+        {
+            "iss": op.issuer,
+            "sub": "marker-subject",
+            "aud": CORPUS_AUDIENCE,
+            "iat": now,
+            "nbf": now,
+            "exp": now + 300,
+            "client_id": "mock-client",
+        }
+    )
+
+
+def test_scopeless_access_token_marker_gate(mock_matrix):
+    """F-07 positive (opt-in ``require_access_token_marker``).
+
+    A scope-less token with no ID-token-only claim slips past the negative
+    defense. On the default RS it validates and is handed to
+    ``require_scope("read")`` → 403 (missing scope). On a marker-enabled RS the
+    access-token marker gate rejects it FIRST → 401 — proving the opt-in marker
+    is what distinguishes the two, not the always-on negative check.
+    """
+    token = _mint_scopeless_access_token(mock_matrix.op)
+
+    default = _get_protected(mock_matrix.base_url, token)
+    assert default.status_code == httpx.codes.FORBIDDEN
+
+    with boot_rs(
+        discovery_url=mock_matrix.discovery_url,
+        audience=CORPUS_AUDIENCE,
+        require_scope="read",
+        require_access_token_marker=True,
+    ) as marker_base:
+        marked = _get_protected(marker_base, token)
+    assert marked.status_code == httpx.codes.UNAUTHORIZED
+
+
+# ---------------------------------------------------------------------------
+# Group B — real-issuer leg (node-oidc), gated like test_rs_boot
+# ---------------------------------------------------------------------------
+
+NODE_OIDC_AUDIENCE = "urn:test:api"
+
+
+def _is_node_oidc_fixture(raw_discovery: dict) -> bool:
+    """Whether the active provider is the bundled node-oidc-provider fixture.
+
+    The fixed ``urn:test:api`` audience this leg asserts on only exists in the
+    local node-oidc-provider; the remote matrix providers (Keycloak/Ory/Descope)
+    mint a different audience, so they must skip. node-oidc serves discovery at
+    the localhost host root — the check that distinguishes it from Keycloak,
+    which also runs on localhost but under ``/realms/<realm>`` (mirrors
+    ``test_rs_boot._is_node_oidc_fixture``).
+    """
+    parsed = urlparse(raw_discovery.get("issuer", ""))
+    is_local = parsed.hostname in ("localhost", "127.0.0.1")
+    at_host_root = parsed.path in ("", "/")
+    return is_local and at_host_root
+
+
+def _granted_scopes(access_token: str) -> list[str]:
+    claims = jwt.decode(access_token, options={"verify_signature": False})
+    raw = claims.get("scope") or claims.get("scp") or ""
+    if isinstance(raw, str):
+        return raw.split()
+    return [s for s in raw if isinstance(s, str)]
+
+
+@pytest.fixture(scope="module")
+def node_oidc_discovery_url(test_config, raw_discovery) -> str:
+    if not _is_node_oidc_fixture(raw_discovery):
+        pytest.skip(
+            "correctness-matrix real-issuer leg asserts node-oidc's "
+            "urn:test:api audience; remote matrix providers mint different tokens"
+        )
+    return test_config["TEST_DISCO_ADDRESS"]
+
+
+def test_real_issuer_valid_token_accepted(
+    node_oidc_discovery_url, client_credentials_token
+):
+    """A REAL node-oidc CC token → 200 through the booted RS (real HTTP DoD)."""
+    access_token = client_credentials_token.token.get("access_token", "")
+    assert access_token, "CC fixture returned no access_token"
+    scopes = _granted_scopes(access_token)
+    assert scopes, "minted token carried no scopes to guard on"
+
+    with boot_rs(
+        discovery_url=node_oidc_discovery_url,
+        audience=NODE_OIDC_AUDIENCE,
+        require_scope=scopes[0],
+    ) as base_url:
+        response = _get_protected(base_url, access_token)
+
+    assert response.status_code == httpx.codes.OK
+    assert response.json()["sub"]
+
+
+def test_real_issuer_wrong_aud_rejected(
+    node_oidc_discovery_url, client_credentials_token
+):
+    """A REAL node-oidc token against an RS expecting a different aud → 401.
+
+    A real-issuer negative the corpus cannot forge: a genuinely signed token
+    whose ``aud`` does not match the RS's configured audience. Proves the
+    uniform 401 contract end-to-end against a live IdP.
+    """
+    access_token = client_credentials_token.token.get("access_token", "")
+    assert access_token, "CC fixture returned no access_token"
+
+    with boot_rs(
+        discovery_url=node_oidc_discovery_url,
+        audience="urn:does-not-match-any-real-token",
+    ) as base_url:
+        response = _get_protected(base_url, access_token)
+
+    assert response.status_code == httpx.codes.UNAUTHORIZED
+    assert response.json() == GENERIC_401_BODY

--- a/src/tests/integration/test_correctness_matrix.py
+++ b/src/tests/integration/test_correctness_matrix.py
@@ -88,8 +88,10 @@ def _get_protected(base_url: str, token: str) -> httpx.Response:
 def mock_matrix():
     """One mock OP + one booted RS (audience=mock-api, require_scope=read).
 
-    Yields a :class:`MockMatrix`; the RS is a single uvicorn subprocess reused
-    across all parametrized cases (a boot is ~1-2s, so we batch, not re-boot).
+    Yields a :class:`MockMatrix`. The mock OP runs in-process (a uvicorn daemon
+    thread inside ``serve_mock_op``); the RS is a separate uvicorn subprocess
+    (``boot_rs``). Both are reused across all parametrized cases — a boot is
+    ~1-2s, so we batch rather than re-boot per case.
     """
     with (
         serve_mock_op() as op,
@@ -247,7 +249,11 @@ def _granted_scopes(access_token: str) -> list[str]:
     raw = claims.get("scope") or claims.get("scp") or ""
     if isinstance(raw, str):
         return raw.split()
-    return [s for s in raw if isinstance(s, str)]
+    if isinstance(raw, (list, tuple)):
+        return [s for s in raw if isinstance(s, str)]
+    # A non-str, non-sequence scope claim (e.g. a JSON int) is not iterable —
+    # treat it as no granted scopes rather than crashing on ``for`` (edge guard).
+    return []
 
 
 @pytest.fixture(scope="module")

--- a/src/tests/integration/test_rs_boot.py
+++ b/src/tests/integration/test_rs_boot.py
@@ -11,6 +11,8 @@ so ``fastapi_identity_model`` and ``uvicorn`` resolve). Under plain
 importorskips cleanly.
 """
 
+from urllib.parse import urlparse
+
 import httpx
 import jwt
 import pytest
@@ -26,6 +28,22 @@ pytestmark = pytest.mark.integration
 # resourceIndicators.defaultResource (test-fixtures/node-oidc-provider).
 RS_AUDIENCE = "urn:test:api"
 GENERIC_401_DETAIL = "Invalid or unauthorized token"
+
+
+def _is_node_oidc_fixture(raw_discovery: dict) -> bool:
+    """Whether the active provider is the bundled node-oidc-provider fixture.
+
+    The fixed ``urn:test:api`` audience and ``api`` scope this suite asserts on
+    only exist in the local node-oidc-provider (``resourceIndicators``); the
+    remote CI-matrix providers (Keycloak/Ory/Descope) mint tokens with a
+    different audience/scope, so they must skip. node-oidc serves discovery at
+    the localhost host root — the check that distinguishes it from Keycloak,
+    which also runs on localhost but under ``/realms/<realm>``.
+    """
+    parsed = urlparse(raw_discovery.get("issuer", ""))
+    is_local = parsed.hostname in ("localhost", "127.0.0.1")
+    at_host_root = parsed.path in ("", "/")
+    return is_local and at_host_root
 
 
 def _access_token(client_credentials_token) -> str:
@@ -44,7 +62,12 @@ def _granted_scopes(access_token: str) -> list[str]:
 
 
 @pytest.fixture(scope="module")
-def rs_discovery_url(test_config) -> str:
+def rs_discovery_url(test_config, raw_discovery) -> str:
+    if not _is_node_oidc_fixture(raw_discovery):
+        pytest.skip(
+            "RS boot suite asserts node-oidc's urn:test:api audience / api "
+            "scope; remote matrix providers mint different tokens"
+        )
     return test_config["TEST_DISCO_ADDRESS"]
 
 

--- a/src/tests/integration/test_rs_boot.py
+++ b/src/tests/integration/test_rs_boot.py
@@ -1,0 +1,146 @@
+"""Real-HTTP DoD proof for TH-1.2 (#464 · epic #462).
+
+Boots the greenfield resource server (``TokenValidationMiddleware +
+require_scope``) under real uvicorn workers and drives it over httpx against a
+live node-oidc issuer. This is the acceptance proof that the RS runs the
+shipped middleware end-to-end — not an ASGI in-process shim.
+
+Run via ``make test-harness-rs`` (Docker node-oidc + ``uv run --all-packages``
+so ``fastapi_identity_model`` and ``uvicorn`` resolve). Under plain
+``make test-integration-node-oidc`` the fastapi stack is absent, so the module
+importorskips cleanly.
+"""
+
+import httpx
+import jwt
+import pytest
+
+from ..harness.rs_server import boot_rs
+
+
+pytest.importorskip("fastapi_identity_model")
+
+pytestmark = pytest.mark.integration
+
+# node-oidc issues JWT access tokens with aud=urn:test:api via
+# resourceIndicators.defaultResource (test-fixtures/node-oidc-provider).
+RS_AUDIENCE = "urn:test:api"
+GENERIC_401_DETAIL = "Invalid or unauthorized token"
+
+
+def _access_token(client_credentials_token) -> str:
+    token = client_credentials_token.token.get("access_token", "")
+    assert token, "CC fixture returned no access_token"
+    return token
+
+
+def _granted_scopes(access_token: str) -> list[str]:
+    """Scopes actually present on the minted token (unverified decode)."""
+    claims = jwt.decode(access_token, options={"verify_signature": False})
+    raw = claims.get("scope") or claims.get("scp") or ""
+    if isinstance(raw, str):
+        return raw.split()
+    return [s for s in raw if isinstance(s, str)]
+
+
+@pytest.fixture(scope="module")
+def rs_discovery_url(test_config) -> str:
+    return test_config["TEST_DISCO_ADDRESS"]
+
+
+def test_valid_token_reaches_protected_route(
+    rs_discovery_url, client_credentials_token
+):
+    """Valid CC token → 200, body echoes the validated claims."""
+    access_token = _access_token(client_credentials_token)
+    scopes = _granted_scopes(access_token)
+    assert scopes, "minted token carried no scopes to guard on"
+
+    with boot_rs(
+        discovery_url=rs_discovery_url,
+        audience=RS_AUDIENCE,
+        require_scope=scopes[0],
+    ) as base_url:
+        response = httpx.get(
+            f"{base_url}/protected",
+            headers={"Authorization": f"Bearer {access_token}"},
+            timeout=10.0,
+        )
+
+    assert response.status_code == httpx.codes.OK
+    body = response.json()
+    assert body["sub"]
+    assert scopes[0] in (body["scope"] or "")
+
+
+def test_missing_authorization_is_uniform_401(rs_discovery_url):
+    """No Authorization header → 401 with the middleware's own detail."""
+    with boot_rs(discovery_url=rs_discovery_url, audience=RS_AUDIENCE) as base_url:
+        response = httpx.get(f"{base_url}/protected", timeout=10.0)
+
+    assert response.status_code == httpx.codes.UNAUTHORIZED
+    assert response.json() == {"detail": "Missing Authorization header"}
+
+
+def test_malformed_bearer_is_uniform_401(rs_discovery_url):
+    """Garbage bearer → 401 with the generic (F-18) uniform body."""
+    with boot_rs(discovery_url=rs_discovery_url, audience=RS_AUDIENCE) as base_url:
+        response = httpx.get(
+            f"{base_url}/protected",
+            headers={"Authorization": "Bearer not-a-real-jwt"},
+            timeout=10.0,
+        )
+
+    assert response.status_code == httpx.codes.UNAUTHORIZED
+    assert response.json() == {"detail": GENERIC_401_DETAIL}
+
+
+def test_missing_required_scope_is_403(rs_discovery_url, client_credentials_token):
+    """Valid token but RS requires a scope the token lacks → 403 (require_scope)."""
+    access_token = _access_token(client_credentials_token)
+    absent_scope = "scope-the-token-does-not-carry"
+    assert absent_scope not in _granted_scopes(access_token)
+
+    with boot_rs(
+        discovery_url=rs_discovery_url,
+        audience=RS_AUDIENCE,
+        require_scope=absent_scope,
+    ) as base_url:
+        response = httpx.get(
+            f"{base_url}/protected",
+            headers={"Authorization": f"Bearer {access_token}"},
+            timeout=10.0,
+        )
+
+    assert response.status_code == httpx.codes.FORBIDDEN
+    assert absent_scope in response.json()["detail"]
+
+
+def test_health_route_is_unauthenticated(rs_discovery_url):
+    """Excluded /health answers 200 with no Authorization (readiness proof)."""
+    with boot_rs(discovery_url=rs_discovery_url, audience=RS_AUDIENCE) as base_url:
+        response = httpx.get(f"{base_url}/health", timeout=10.0)
+
+    assert response.status_code == httpx.codes.OK
+    assert response.json() == {"status": "ok"}
+
+
+def test_boots_under_multiple_workers(rs_discovery_url, client_credentials_token):
+    """uvicorn --workers 2 boots and serves a valid token → 200."""
+    access_token = _access_token(client_credentials_token)
+    scopes = _granted_scopes(access_token)
+    assert scopes, "minted token carried no scopes to guard on"
+
+    with boot_rs(
+        discovery_url=rs_discovery_url,
+        audience=RS_AUDIENCE,
+        require_scope=scopes[0],
+        workers=2,
+    ) as base_url:
+        response = httpx.get(
+            f"{base_url}/protected",
+            headers={"Authorization": f"Bearer {access_token}"},
+            timeout=10.0,
+        )
+
+    assert response.status_code == httpx.codes.OK

--- a/src/tests/integration/test_token_source.py
+++ b/src/tests/integration/test_token_source.py
@@ -15,6 +15,9 @@ signature-valid token the library accepts.
 
 from __future__ import annotations
 
+import base64
+import json
+
 import pytest
 
 from py_identity_model import (
@@ -144,6 +147,34 @@ def test_forged_tokens_require_mock_provider(token_source, harness_provider):
             Grant.CLIENT_CREDENTIALS,
             malform=Malform.TAMPERED_SIG,
         )
+
+
+def test_descope_multitenant_mint_carries_dct_tenants(
+    token_source, harness_provider, test_config
+):
+    """AC-3: the Descope multi-tenant path yields distinct ``dct``/``tenants``.
+
+    Reuses the identity-stack access-key -> ``/v1/auth/accesskey/exchange`` flow
+    (credential-gated on ``DESCOPE_PROJECT_ID``/``DESCOPE_MANAGEMENT_KEY``/
+    ``DESCOPE_BASE_URL`` + a tenant id) so it skips cleanly off Descope.
+    """
+    if harness_provider is not Provider.DESCOPE:
+        pytest.skip("Descope-only: multi-tenant access-key exchange")
+    tenant = test_config.get("DESCOPE_TEST_TENANT_ID")
+    if not tenant:
+        pytest.skip("DESCOPE_TEST_TENANT_ID not configured")
+
+    minted = _mint_or_skip(
+        token_source, Provider.DESCOPE, Grant.CLIENT_CREDENTIALS, tenant=tenant
+    )
+    assert minted.tenant == tenant
+    # Session JWT must carry the Descope multi-tenant claims (dct/tenants).
+    payload_segment = minted.access_token.split(".")[1]
+    payload = json.loads(
+        base64.urlsafe_b64decode(payload_segment + "=" * (-len(payload_segment) % 4))
+    )
+    assert payload.get("dct") == tenant
+    assert tenant in payload.get("tenants", {})
 
 
 def test_mock_provider_always_mintable(token_source):

--- a/src/tests/integration/test_token_source.py
+++ b/src/tests/integration/test_token_source.py
@@ -1,0 +1,170 @@
+"""DoD: real-IdP proof for the unified ``TokenSource`` minter (TH-1.1, #463).
+
+This is the Definition-of-Done evidence for the minter: it mints tokens through
+a **live** identity provider (node-oidc / Keycloak under ``make
+test-integration-node-oidc`` / ``-keycloak``; Ory / Descope when secret-gated)
+and validates them end-to-end with the real library
+(:func:`py_identity_model.validate_token`) against the provider's live JWKS.
+
+The deterministic, network-free proofs (forged corpus, mock-OP failure
+injection, capability/credential gating) live in the unit suite
+(``test_mock_op.py`` / ``test_token_source_gating.py``); here we prove the one
+thing only a real IdP can: that a ``TokenSource.mint`` result is a genuine,
+signature-valid token the library accepts.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from py_identity_model import (
+    TokenValidationConfig,
+    validate_token,
+)
+
+from ..harness import (
+    Grant,
+    HarnessCapabilityError,
+    HarnessCredentialError,
+    Malform,
+    MintSpec,
+    Provider,
+    ProviderConfig,
+    TokenSource,
+    prime_pool,
+)
+from .conftest import DEFAULT_VALIDATION_OPTIONS
+
+
+pytestmark = pytest.mark.integration
+
+# JWT format: three dot-separated segments (two separators).
+JWT_SEGMENT_SEPARATOR_COUNT = 2
+
+
+def _mint_or_skip(source: TokenSource, provider: Provider, grant: Grant, **kwargs):
+    """Mint, translating the typed gating errors to ``pytest.skip``.
+
+    This is the contract the harness relies on: secret-gated providers
+    (Ory/Descope) and unsupported grants skip cleanly rather than failing.
+    """
+    try:
+        return source.mint(provider, grant, **kwargs)
+    except HarnessCapabilityError as exc:
+        pytest.skip(f"capability-gated: {exc}")
+    except HarnessCredentialError as exc:
+        pytest.skip(f"credential-gated: {exc}")
+
+
+def _validate(token: str, test_config, require_https) -> dict:
+    """Validate a token against the live provider's discovery + JWKS."""
+    config = TokenValidationConfig(
+        perform_disco=True,
+        audience=test_config["TEST_AUDIENCE"],
+        options=DEFAULT_VALIDATION_OPTIONS,
+        require_https=require_https,
+    )
+    return validate_token(
+        jwt=token,
+        disco_doc_address=test_config["TEST_DISCO_ADDRESS"],
+        token_validation_config=config,
+    )
+
+
+def test_client_credentials_mint_validates_end_to_end(
+    token_source, harness_provider, test_config, require_https
+):
+    """DoD: a client-credentials mint validates against the live JWKS."""
+    if harness_provider is None:
+        pytest.skip("no real provider wired for this env file")
+
+    minted = _mint_or_skip(token_source, harness_provider, Grant.CLIENT_CREDENTIALS)
+    assert minted.access_token
+    assert minted.provider is harness_provider
+    assert minted.grant is Grant.CLIENT_CREDENTIALS
+
+    claims = _validate(minted.access_token, test_config, require_https)
+    assert claims["iss"]
+    assert claims["exp"]
+
+
+def test_auth_code_mint_validates_when_capable(
+    token_source, harness_provider, test_config, require_https
+):
+    """Auth-code mint validates end-to-end where the provider supports it.
+
+    Skips (capability/credential-gated) on providers without devInteractions
+    or an auth-code client — the same gating the correctness matrix relies on.
+    """
+    if harness_provider is None:
+        pytest.skip("no real provider wired for this env file")
+
+    minted = _mint_or_skip(token_source, harness_provider, Grant.AUTHORIZATION_CODE)
+    assert minted.access_token
+    assert minted.grant is Grant.AUTHORIZATION_CODE
+
+    # Only JWT-format access tokens are library-validatable; opaque tokens are
+    # a legitimate outcome for some providers (introspection territory).
+    if minted.access_token.count(".") == JWT_SEGMENT_SEPARATOR_COUNT:
+        claims = _validate(minted.access_token, test_config, require_https)
+        assert claims["iss"]
+
+
+def test_replay_pool_mints_once_and_replays(token_source, harness_provider):
+    """The pre-minted pool mints each spec once and replays the same token."""
+    if harness_provider is None:
+        pytest.skip("no real provider wired for this env file")
+
+    spec = MintSpec(provider=harness_provider, grant=Grant.CLIENT_CREDENTIALS)
+    try:
+        pool = prime_pool(token_source, [spec, spec])
+    except (HarnessCapabilityError, HarnessCredentialError) as exc:
+        pytest.skip(f"gated: {exc}")
+
+    # Duplicate specs collapse to a single mint (rate-limit friendly).
+    assert len(pool) == 1
+    minted = pool.get(spec)
+    assert minted.access_token
+    # expires_at is tracked so T311 can re-mint across the 300s TTL.
+    assert minted.expires_at is None or minted.expires_at > 0
+
+
+def test_forged_tokens_require_mock_provider(token_source, harness_provider):
+    """A real provider refuses to emit forged tokens (deterministic gating).
+
+    Real OPs will not mint invalid tokens; the harness enforces that forgery
+    is MOCK-only, so the forged corpus stays in one controllable place.
+    """
+    if harness_provider is None:
+        pytest.skip("no real provider wired for this env file")
+
+    with pytest.raises(HarnessCapabilityError):
+        token_source.mint(
+            harness_provider,
+            Grant.CLIENT_CREDENTIALS,
+            malform=Malform.TAMPERED_SIG,
+        )
+
+
+def test_mock_provider_always_mintable(token_source):
+    """MOCK is always available regardless of which real provider is wired."""
+    minted = token_source.mint(Provider.MOCK, Grant.CLIENT_CREDENTIALS)
+    assert minted.provider is Provider.MOCK
+    assert minted.malform is Malform.VALID
+    assert minted.access_token.count(".") == JWT_SEGMENT_SEPARATOR_COUNT
+
+
+def test_credential_gating_raises_typed_error():
+    """A real provider without credentials raises ``HarnessCredentialError``.
+
+    Proves the contract the ``token_source`` fixture leans on to turn
+    secret-gated providers (Ory/Descope) into clean ``pytest.skip``.
+    """
+    credentialless = ProviderConfig(
+        provider=Provider.ORY,
+        capabilities={"client_credentials"},
+        token_endpoint="https://example.test/oauth2/token",
+    )
+    source = TokenSource.with_mock(extra=[credentialless])
+    with pytest.raises(HarnessCredentialError):
+        source.mint(Provider.ORY, Grant.CLIENT_CREDENTIALS)

--- a/src/tests/unit/test_mock_op.py
+++ b/src/tests/unit/test_mock_op.py
@@ -1,0 +1,228 @@
+"""Unit tests for the controllable mock OP and forged corpus (TH-1.1, #463).
+
+Deterministic and network-free: the framework-free ASGI app is driven in-process
+via ``httpx.ASGITransport``, and the *real* library
+(:func:`py_identity_model.aio.validate_token`) validates minted / forged tokens
+through the mock OP's discovery + JWKS documents.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from py_identity_model.aio.managed_client import AsyncHTTPClient
+from py_identity_model.aio.token_validation import validate_token
+from py_identity_model.core.models import TokenValidationConfig
+from py_identity_model.exceptions import PyIdentityModelException
+
+from ..harness import CORPUS_AUDIENCE, MockOP, build_corpus
+from ..harness import mock_op as mock_op_mod
+
+
+HTTP_OK = 200
+HTTP_TOO_MANY_REQUESTS = 429
+HTTP_SERVICE_UNAVAILABLE = 503
+PUBLISHED_KEY_COUNT = 2
+OVERSIZED_PADDING = 50
+
+
+def _client(mock: MockOP) -> AsyncHTTPClient:
+    """An AsyncHTTPClient routed at the in-process mock OP (no network)."""
+    transport = httpx.ASGITransport(app=mock.app)
+    return AsyncHTTPClient(
+        client=httpx.AsyncClient(
+            transport=transport, base_url=mock.issuer, follow_redirects=False
+        )
+    )
+
+
+def _validation_config() -> TokenValidationConfig:
+    return TokenValidationConfig(
+        perform_disco=True,
+        audience=CORPUS_AUDIENCE,
+        algorithms=["RS256", "ES256"],
+        require_https=False,
+    )
+
+
+async def _validate(mock: MockOP, token: str) -> dict:
+    client = _client(mock)
+    try:
+        return await validate_token(
+            token,
+            _validation_config(),
+            disco_doc_address=mock.discovery_url,
+            http_client=client,
+        )
+    finally:
+        await client.close()
+
+
+# -- Documents served over ASGI --------------------------------------------
+
+
+async def test_discovery_document_served() -> None:
+    mock = MockOP()
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        resp = await client.get(mock.discovery_url)
+    assert resp.status_code == HTTP_OK
+    doc = resp.json()
+    assert doc["issuer"] == mock.issuer
+    assert doc["jwks_uri"] == mock.jwks_uri
+    assert doc["token_endpoint"] == mock.token_endpoint
+
+
+async def test_jwks_served_with_published_keys() -> None:
+    mock = MockOP()
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        resp = await client.get(mock.jwks_uri)
+    kids = {k["kid"] for k in resp.json()["keys"]}
+    assert mock.primary_key.kid in kids
+    assert mock.ec_key.kid in kids
+    assert mock.unpublished_key.kid not in kids
+
+
+async def test_token_endpoint_mints_valid_token() -> None:
+    mock = MockOP()
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        resp = await client.post(
+            mock.token_endpoint,
+            data={"grant_type": "client_credentials", "scope": "read"},
+        )
+    body = resp.json()
+    assert body["token_type"] == "Bearer"
+    claims = await _validate(mock, body["access_token"])
+    assert claims["iss"] == mock.issuer
+
+
+# -- End-to-end validation of the corpus -----------------------------------
+
+
+async def test_valid_token_validates_end_to_end() -> None:
+    mock = MockOP()
+    corpus = build_corpus(mock)
+    claims = await _validate(mock, corpus["valid"].jwt)
+    assert claims["scope"] == "read"
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "expired",
+        "nbf_future",
+        "wrong_iss",
+        "wrong_aud",
+        "tampered_sig",
+        "unknown_kid",
+        "wrong_alg",
+        "alg_none",
+    ],
+)
+async def test_forged_tokens_are_rejected(name: str) -> None:
+    mock = MockOP()
+    forged = build_corpus(mock)[name]
+    assert forged.library_rejects is True
+    with pytest.raises(PyIdentityModelException):
+        await _validate(mock, forged.jwt)
+
+
+@pytest.mark.parametrize("name", ["id_as_access", "cnf_bound", "oversized"])
+async def test_library_accepted_classes_are_signature_valid(name: str) -> None:
+    # These are validly signed for the audience — the library ACCEPTS them.
+    # Only the RS access-token marker / require_scope layer (F-07/F-02) rejects
+    # them; that distinction is proven in T302, not here.
+    mock = MockOP()
+    forged = build_corpus(mock)[name]
+    assert forged.library_rejects is False
+    claims = await _validate(mock, forged.jwt)
+    assert claims["iss"] == mock.issuer
+
+
+# -- Failure injection (design §2) -----------------------------------------
+
+
+async def test_key_rotation_then_republish() -> None:
+    mock = MockOP()
+    # Rotate to the spare WITHOUT publishing -> tokens present an unknown kid.
+    mock.rotate_keys(publish=False)
+    token = mock.mint_access_token()["access_token"]
+    with pytest.raises(PyIdentityModelException):
+        await _validate(mock, token)
+    # Publishing the rotated key lets the same token validate on refetch.
+    mock.publish_signing_key()
+    claims = await _validate(mock, token)
+    assert claims["iss"] == mock.issuer
+
+
+async def test_empty_jwks_control() -> None:
+    mock = MockOP()
+    mock.controls.serve_empty_jwks = True
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        resp = await client.get(mock.jwks_uri)
+    assert resp.json()["keys"] == []
+
+
+async def test_oversized_jwks_control() -> None:
+    mock = MockOP()
+    mock.controls.oversized_jwks_padding = OVERSIZED_PADDING
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        resp = await client.get(mock.jwks_uri)
+    assert len(resp.json()["keys"]) == PUBLISHED_KEY_COUNT + OVERSIZED_PADDING
+
+
+async def test_rate_limit_control_sets_retry_after() -> None:
+    mock = MockOP()
+    mock.controls.discovery_status = HTTP_TOO_MANY_REQUESTS
+    mock.controls.retry_after = "3"
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        resp = await client.get(mock.discovery_url)
+    assert resp.status_code == HTTP_TOO_MANY_REQUESTS
+    assert resp.headers["retry-after"] == "3"
+
+
+async def test_no_store_cache_control_on_jwks() -> None:
+    mock = MockOP()
+    mock.controls.jwks_cache_control = "no-store"
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        resp = await client.get(mock.jwks_uri)
+    assert resp.headers["cache-control"] == "no-store"
+
+
+async def test_injected_latency(monkeypatch: pytest.MonkeyPatch) -> None:
+    mock = MockOP()
+    slept: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        slept.append(seconds)
+
+    monkeypatch.setattr(mock_op_mod.asyncio, "sleep", fake_sleep)
+    mock.controls.latency_seconds = 0.25
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        await client.get(mock.discovery_url)
+    assert slept == [0.25]
+
+
+async def test_control_route_rotates_and_sets_knobs() -> None:
+    mock = MockOP()
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        resp = await client.post(
+            f"{mock.issuer}/_control",
+            json={
+                "rotate": True,
+                "publish": True,
+                "jwks_status": HTTP_SERVICE_UNAVAILABLE,
+            },
+        )
+    assert resp.json() == {"ok": True}
+    assert mock.controls.jwks_status == HTTP_SERVICE_UNAVAILABLE
+    assert mock.signing_key is mock.rotation_key

--- a/src/tests/unit/test_mock_op.py
+++ b/src/tests/unit/test_mock_op.py
@@ -9,6 +9,7 @@ through the mock OP's discovery + JWKS documents.
 from __future__ import annotations
 
 import httpx
+import jwt
 import pytest
 
 from py_identity_model.aio.managed_client import AsyncHTTPClient
@@ -223,6 +224,59 @@ async def test_control_route_rotates_and_sets_knobs() -> None:
                 "jwks_status": HTTP_SERVICE_UNAVAILABLE,
             },
         )
-    assert resp.json() == {"ok": True}
+    assert resp.json() == {"ok": True, "rejected": []}
     assert mock.controls.jwks_status == HTTP_SERVICE_UNAVAILABLE
     assert mock.signing_key is mock.rotation_key
+
+
+async def test_control_route_rejects_type_mismatched_values() -> None:
+    """A stray JSON type must be rejected at the control call, not crash a later
+    request (design: fail local, not downstream)."""
+    mock = MockOP()
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        resp = await client.post(
+            f"{mock.issuer}/_control",
+            json={
+                "jwks_status": "boom",  # str for an int field -> reject
+                "retry_after": 3,  # int for a str|None field -> reject
+                "oversized_jwks_padding": "big",  # str for an int field -> reject
+                "discovery_status": HTTP_SERVICE_UNAVAILABLE,  # valid int -> apply
+            },
+        )
+        body = resp.json()
+        # The valid knob applied; the mismatches were reported, not applied.
+        assert body["ok"] is True
+        assert set(body["rejected"]) == {
+            "jwks_status",
+            "retry_after",
+            "oversized_jwks_padding",
+        }
+        assert mock.controls.jwks_status == HTTP_OK
+        assert mock.controls.retry_after is None
+        assert mock.controls.oversized_jwks_padding == 0
+        assert mock.controls.discovery_status == HTTP_SERVICE_UNAVAILABLE
+        # The next /jwks request must still succeed (no poisoned state).
+        mock.controls.jwks_status = HTTP_OK
+        jwks = await client.get(mock.jwks_uri)
+        assert jwks.status_code == HTTP_OK
+
+
+def test_introspect_reports_active_for_valid_token() -> None:
+    mock = MockOP()
+    minted = mock.mint_access_token()
+    result = mock.introspect(minted["access_token"])
+    assert result["active"] is True
+
+
+def test_introspect_survives_malformed_exp() -> None:
+    """A token with a non-numeric ``exp`` (exactly what this harness forges)
+    must report inactive, not 500 the introspect endpoint."""
+    token = jwt.encode({"exp": "not-a-number"}, "x" * 32, algorithm="HS256")
+    result = MockOP().introspect(token)
+    assert result["active"] is False
+
+
+def test_introspect_reports_inactive_for_non_jwt() -> None:
+    result = MockOP().introspect("not.a.jwt")
+    assert result["active"] is False

--- a/src/tests/unit/test_token_source_gating.py
+++ b/src/tests/unit/test_token_source_gating.py
@@ -8,7 +8,12 @@ is always mintable (valid + forged).
 
 from __future__ import annotations
 
+import base64
+import json
+
+import jwt
 import pytest
+import respx
 
 from ..harness import (
     Grant,
@@ -21,6 +26,7 @@ from ..harness import (
     TokenSource,
     prime_pool,
 )
+from ..harness.token_source import _peek_jwt_header
 
 
 JWT_SEGMENT_COUNT = 2
@@ -135,6 +141,72 @@ def test_auth_code_minter_is_invoked() -> None:
     )
     assert token.access_token == "opaque-token"
     assert calls == [("t1", "openid")]
+
+
+def test_descope_multitenant_requires_management_creds() -> None:
+    # Plain CC creds present, but the multi-tenant (tenant=…) path needs the
+    # access-key exchange config; absent -> credential error (drives skip).
+    descope = ProviderConfig(
+        provider=Provider.DESCOPE,
+        capabilities={"client_credentials"},
+        token_endpoint="https://api.descope.com/oauth2/v1/token",
+        client_id="cid",
+        client_secret="secret",
+    )
+    source = TokenSource([descope])
+    with pytest.raises(HarnessCredentialError, match="multi-tenant"):
+        source.mint(Provider.DESCOPE, Grant.CLIENT_CREDENTIALS, tenant="t1")
+
+
+@respx.mock
+def test_descope_multitenant_exchange_produces_dct_tenants() -> None:
+    # AC-3: the multi-tenant path reuses access-key create -> exchange -> delete
+    # and returns the session JWT carrying distinct dct/tenants claims.
+    base = "https://api.descope.com"
+    session_jwt = jwt.encode(
+        {"sub": "u1", "dct": "t1", "tenants": {"t1": {"roles": ["admin"]}}},
+        "x" * 32,
+        algorithm="HS256",
+    )
+    create = respx.post(f"{base}/v1/mgmt/accesskey/create").respond(
+        json={"key": {"id": "k1"}, "cleartext": "ck"}
+    )
+    exchange = respx.post(f"{base}/v1/auth/accesskey/exchange").respond(
+        json={"sessionJwt": session_jwt}
+    )
+    delete = respx.post(f"{base}/v1/mgmt/accesskey/delete").respond(json={})
+
+    cfg = ProviderConfig(
+        provider=Provider.DESCOPE,
+        capabilities={"client_credentials"},
+        descope_project_id="P1",
+        descope_management_key="MK",
+        descope_base_url=base,
+    )
+    token = TokenSource([cfg]).mint(
+        Provider.DESCOPE, Grant.CLIENT_CREDENTIALS, tenant="t1"
+    )
+
+    assert token.access_token == session_jwt
+    assert token.tenant == "t1"
+    # keyTenants array shaping (not top-level tenantId) is what yields dct/tenants.
+    body = json.loads(create.calls.last.request.content)
+    assert body["keyTenants"] == [{"tenantId": "t1", "roleNames": ["owner", "admin"]}]
+    payload = json.loads(
+        base64.urlsafe_b64decode(token.access_token.split(".")[1] + "==").decode()
+    )
+    assert payload["dct"] == "t1"
+    assert "t1" in payload["tenants"]
+    assert exchange.called
+    assert delete.called  # temporary key cleaned up
+
+
+def test_peek_jwt_header_guards_non_object_header() -> None:
+    """A JWT whose header segment decodes to a non-object (e.g. ``5``) must not
+    crash header inspection — return ``(None, None)`` like an opaque token."""
+    non_object_header = base64.urlsafe_b64encode(b"5").rstrip(b"=").decode()
+    token = f"{non_object_header}.{non_object_header}.sig"
+    assert _peek_jwt_header(token) == (None, None)
 
 
 def test_replay_pool_mints_once() -> None:

--- a/src/tests/unit/test_token_source_gating.py
+++ b/src/tests/unit/test_token_source_gating.py
@@ -1,0 +1,150 @@
+"""Unit tests for TokenSource capability/credential gating (TH-1.1, #463).
+
+The gating mirrors ``provider_matrix.detect_capabilities``: an unsupported
+grant raises :class:`HarnessCapabilityError`, a supported grant with absent
+credentials raises :class:`HarnessCredentialError`, and the ``MOCK`` provider
+is always mintable (valid + forged).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ..harness import (
+    Grant,
+    HarnessCapabilityError,
+    HarnessCredentialError,
+    Malform,
+    MintSpec,
+    Provider,
+    ProviderConfig,
+    TokenSource,
+    prime_pool,
+)
+
+
+JWT_SEGMENT_COUNT = 2
+DEDUPED_POOL_SIZE = 2
+
+
+def test_mock_provider_is_always_mintable() -> None:
+    source = TokenSource.with_mock()
+    token = source.mint(Provider.MOCK, Grant.CLIENT_CREDENTIALS)
+    assert token.provider is Provider.MOCK
+    assert token.malform is Malform.VALID
+    assert token.access_token.count(".") == JWT_SEGMENT_COUNT  # a real JWT
+    assert token.expires_at is not None
+    assert token.alg == "RS256"
+
+
+def test_mock_provider_mints_every_forged_class() -> None:
+    source = TokenSource.with_mock()
+    for malform in Malform:
+        token = source.mint(Provider.MOCK, malform=malform)
+        assert token.malform is malform
+        assert token.access_token  # non-empty
+
+
+def test_forged_tokens_are_mock_only() -> None:
+    node = ProviderConfig(
+        provider=Provider.NODE_OIDC,
+        capabilities={"client_credentials"},
+        token_endpoint="https://issuer.example/token",
+        client_id="cid",
+        client_secret="secret",
+    )
+    source = TokenSource([node])
+    with pytest.raises(HarnessCapabilityError, match="MOCK provider"):
+        source.mint(Provider.NODE_OIDC, malform=Malform.ALG_NONE)
+
+
+def test_capability_gating_rejects_unsupported_grant() -> None:
+    # Advertises only client_credentials — auth_code must be capability-gated.
+    node = ProviderConfig(
+        provider=Provider.NODE_OIDC,
+        capabilities={"client_credentials"},
+        token_endpoint="https://issuer.example/token",
+        client_id="cid",
+        client_secret="secret",
+    )
+    source = TokenSource([node])
+    with pytest.raises(HarnessCapabilityError, match="authorization_code"):
+        source.mint(Provider.NODE_OIDC, Grant.AUTHORIZATION_CODE)
+
+
+def test_credential_gating_when_secret_absent() -> None:
+    # Capability present, credentials missing -> credential error (drives skip).
+    ory = ProviderConfig(
+        provider=Provider.ORY,
+        capabilities={"client_credentials"},
+        token_endpoint="https://issuer.example/token",
+        client_id=None,
+        client_secret=None,
+    )
+    source = TokenSource([ory])
+    with pytest.raises(HarnessCredentialError):
+        source.mint(Provider.ORY, Grant.CLIENT_CREDENTIALS)
+
+
+def test_auth_code_requires_injected_minter() -> None:
+    keycloak = ProviderConfig(
+        provider=Provider.KEYCLOAK,
+        capabilities={"authorization_code"},
+    )
+    source = TokenSource([keycloak])
+    with pytest.raises(HarnessCredentialError, match="auth-code minter"):
+        source.mint(Provider.KEYCLOAK, Grant.AUTHORIZATION_CODE)
+
+
+def test_unconfigured_provider_raises_capability_error() -> None:
+    source = TokenSource.with_mock()
+    with pytest.raises(HarnessCapabilityError, match="not configured"):
+        source.mint(Provider.DESCOPE, Grant.CLIENT_CREDENTIALS)
+
+
+def test_from_discovery_derives_capabilities() -> None:
+    disco = {
+        "issuer": "http://localhost:9000",
+        "token_endpoint": "http://localhost:9000/token",
+        "authorization_endpoint": "http://localhost:9000/auth",
+        "grant_types_supported": ["client_credentials", "authorization_code"],
+    }
+    cfg = ProviderConfig.from_discovery(
+        Provider.NODE_OIDC, disco, client_id="cid", client_secret="secret"
+    )
+    assert "client_credentials" in cfg.capabilities
+    assert "authorization_code" in cfg.capabilities
+    assert cfg.token_endpoint == "http://localhost:9000/token"
+
+
+def test_auth_code_minter_is_invoked() -> None:
+    calls: list[tuple[str | None, str | None]] = []
+
+    def minter(tenant: str | None, scopes: str | None) -> dict:
+        calls.append((tenant, scopes))
+        return {"access_token": "opaque-token", "token_type": "Bearer"}
+
+    cfg = ProviderConfig(
+        provider=Provider.KEYCLOAK,
+        capabilities={"authorization_code"},
+        auth_code_minter=minter,
+    )
+    source = TokenSource([cfg])
+    token = source.mint(
+        Provider.KEYCLOAK, Grant.AUTHORIZATION_CODE, tenant="t1", scopes="openid"
+    )
+    assert token.access_token == "opaque-token"
+    assert calls == [("t1", "openid")]
+
+
+def test_replay_pool_mints_once() -> None:
+    source = TokenSource.with_mock()
+    specs = [
+        MintSpec(Provider.MOCK, Grant.CLIENT_CREDENTIALS),
+        MintSpec(Provider.MOCK, Grant.CLIENT_CREDENTIALS),  # duplicate -> deduped
+        MintSpec(Provider.MOCK, malform=Malform.EXPIRED),
+    ]
+    pool = prime_pool(source, specs)
+    assert len(pool) == DEDUPED_POOL_SIZE
+    valid = pool.get(MintSpec(Provider.MOCK, Grant.CLIENT_CREDENTIALS))
+    assert valid.malform is Malform.VALID


### PR DESCRIPTION
## Summary

Adds the **token correctness assertion matrix** (TH-1.3, #465): send one token per class through the **booted resource server** (T301 `boot_rs`) and assert 200 for valid, **401 with the uniform F-18 body** per invalid class, and that **nothing is silently accepted**.

- `src/tests/harness/mock_op_server.py` (NEW, pyrefly-excluded) — `serve_mock_op()` context manager serves the framework-free `MockOP` over **real localhost HTTP** (in-process uvicorn daemon thread, `interface="asgi3"`, `lifespan="off"`) so the out-of-process booted RS can fetch discovery + JWKS, while the forged corpus is minted off the same in-process signing key.
- `src/tests/integration/test_correctness_matrix.py` (NEW):
  - **Group A — mock-OP forged-corpus matrix (self-contained, no Docker):** valid→200; the 8 validation-failure classes (expired, nbf-future, wrong-iss, wrong-aud, tampered-sig, unknown-kid, wrong-alg, alg:none) → **uniform 401** (F-18); `id_as_access` → 401 via the always-on negative defense (F-07) and 403/401 via the opt-in marker gate; `cnf_bound` → **200** (F-02 accepted-today contract, tracked by #478); `nothing_silently_accepted` guard.
  - **Group B — real-issuer node-oidc leg (real-HTTP DoD, gated to node-oidc like `test_rs_boot`):** real client-credentials token → 200; wrong-audience RS → 401 generic. Proves the contract against a **real IdP over real HTTP** through the booted RS.
- `Makefile` — `test-harness-matrix` target (node-oidc Docker + `uv run --all-packages … --env-file=.env.node-oidc`).

Refs #465
Epic #462

> **Stacked PR.** This branch builds on the T300 minter (#521) and T301 RS-boot (#522) foundations, neither yet merged to `main`. The diff therefore includes those files until #521 and #522 merge first; once they do, this PR collapses to the T302-only changes (`mock_op_server.py`, `test_correctness_matrix.py`, the `test-harness-matrix` target). No production `core/` code is touched.

## Review Findings Addressed

Three fresh-context review agents (blind + edge-case + acceptance): **0 MUST-FIX / 0 FAIL**. Applied SHOULD-FIX items across two review-fix rounds (`fe012df`, `5fced0d`):
- `serve_mock_op`: `_ServerThread` captures uvicorn startup exceptions; `_wait_for_discovery` fast-fails on thread death instead of polling the full 30s (blind+edge convergent).
- Bounded shutdown with a leaked-thread / port-wedge guard, gated on `sys.exc_info()[0] is None` so a failing test body keeps its own exception as the headline (delta-review regression fix).
- `_granted_scopes`: return `[]` for non-str / non-sequence scope claims (edge CRASH guard).
- Docstring/import nitpicks.

Acceptance: 5 PASS / 1 PARTIAL (AC-2 "from each provider" satisfied via the mock-OP full matrix + node-oidc valid/wrong-aud; Keycloak/Ory/Descope real legs gated per the design's forge-off-mock-OP strategy).

## Test plan
- [x] Unit tests pass (`make lint` — ruff/format/pyrefly/pytest 80% cov, green after every commit)
- [x] Integration tests pass — `make test-harness-matrix`: **20 passed** (Group A forged-corpus matrix + Group B real node-oidc leg through the booted RS over real HTTP), `MAKE_EXIT=0`
- [x] Lint passes
- [x] Independent review agents passed (0 MUST-FIX / 0 FAIL)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)