### PR TITLE
test(load): Locust load/soak suite S1-S12 vs booted RS + mock OP (TH-1.5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,9 +368,36 @@ jobs:
           BASE_REF: ${{ github.base_ref || 'main' }}
         run: BASE="origin/$BASE_REF" make security-gate
 
+  load-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: 3.13
+
+      - name: Cache uv dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: make ci-setup
+
+      - name: Load smoke (CI-short profile — real Locust vs the booted RS)
+        run: make test-harness-load
+
   ci-complete:
     if: always()
-    needs: [lint, unit-tests, fastapi-tests, integration-tests-ory, integration-tests-descope, integration-tests-node-oidc, integration-tests-keycloak, example-tests, build, security-gate]
+    needs: [lint, unit-tests, fastapi-tests, integration-tests-ory, integration-tests-descope, integration-tests-node-oidc, integration-tests-keycloak, example-tests, build, security-gate, load-smoke]
     runs-on: ubuntu-latest
     steps:
       - name: Check CI results
@@ -386,6 +413,7 @@ jobs:
             "${{ needs.example-tests.result }}" \
             "${{ needs.build.result }}" \
             "${{ needs.security-gate.result }}" \
+            "${{ needs.load-smoke.result }}" \
           )
           for result in "${results[@]}"; do
             if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,59 @@
+name: Nightly
+
+# Scheduled coverage that does not belong on the per-PR path:
+#  * full-ci   — re-runs the whole reusable CI matrix (all integration providers)
+#                on a schedule, so upstream provider / dependency drift is caught
+#                even on days with no commits.
+#  * load-soak — the long-window load/soak profile (S4 TTL-rollover + S7/S11/S12
+#                LRU-thrash / RSS-FD soak) that is too slow for the PR gate.
+
+on:
+  schedule:
+    - cron: '0 7 * * *'   # 07:00 UTC daily
+  workflow_dispatch:       # allow manual runs
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  full-ci:
+    name: Full CI (all integrations)
+    uses: ./.github/workflows/ci.yml
+    with:
+      run-descope-integration: true
+      run-example-tests: true
+      run-build: true
+      run-ory-integration: true
+    secrets: inherit
+
+  load-soak:
+    name: Load soak (NIGHTLY profile)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: 3.13
+
+      - name: Cache uv dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: make ci-setup
+
+      - name: Load soak (S4/S7/S11/S12 — real Locust vs the booted RS)
+        run: make test-harness-load-nightly

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,9 @@ make test-integration-local # Requires .env.local file
 # Run example integration tests (spins up Docker containers)
 make test-examples
 
+# Run the TH-1.5 CI-short load profile (real Locust vs the booted RS + mock OP)
+make test-harness-load       # Opt-in `load` group (locust); Locust runs out-of-process
+
 # Run all tests including examples
 make test-all
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,8 +100,9 @@ src/py_identity_model/
    - Core functions are pure (no I/O) and return result objects or raise exceptions
 
 3. **Caching Strategy**
-   - Discovery documents: Cached per-process with `functools.lru_cache` (sync) and `async_lru.alru_cache` (async)
-   - JWKS keys: Cached to avoid repeated fetches during token validation
+   - Discovery documents and JWKS are cached per-process with an explicit **TTL + LRU** cache (an `OrderedDict` bounded to `DEFAULT_MAX_CACHE_ENTRIES` = 64), **not** `functools.lru_cache`/`async_lru.alru_cache`. Cache *policy* lives in `core/jwks_cache.py`; the sync/async cache stacks live in `sync/token_validation.py` and `aio/token_validation.py`.
+   - Entries expire on a TTL resolved from `Cache-Control: max-age` → env override (`DISCO_CACHE_TTL` / `JWKS_CACHE_TTL`) → built-in default, clamped to `[60s, 86400s]`. Concurrent misses are coalesced into a single upstream fetch via per-URI striped locks.
+   - Per-process cache hit/miss/refresh counters are exposed via `core/cache_metrics.py` (`get_cache_counters()`, re-exported at the top level); the async cache paths are instrumented. Clear caches with `clear_discovery_cache()` / `clear_jwks_cache()` (async variants must be `await`ed).
    - All caches are per-process, not shared across processes
 
 4. **Error Handling**

--- a/Makefile
+++ b/Makefile
@@ -87,12 +87,10 @@ test-harness-load: ## Run the TH-1.5 CI-short load profile (real Locust vs the b
 		-m integration -p no:benchmark -v
 
 .PHONY: test-harness-load-nightly
-test-harness-load-nightly: ## (nightly, NOT CI-gated) Long LRU-thrash / RSS-FD soak profile (S7/S11/S12)
-	@echo "Nightly soak profile (design §4 S7/S11/S12) — a documented, not-scheduled"
-	@echo "hook (#271). Run on demand once the SLO baseline is calibrated:"
-	@echo "  uv run --group load --all-packages python -c \\"
-	@echo "    'from src.tests.load.runner import run_profile; from src.tests.load.scenarios import Profile;\\"
-	@echo "     [print(r) for r in run_profile(Profile.NIGHTLY)]'"
+test-harness-load-nightly: ## (nightly) Long TTL-rollover / LRU-thrash / RSS-FD soak profile (S4/S7/S11/S12)
+	@echo "Driving the NIGHTLY soak profile (design §4 S4/S7/S11/S12) through the booted RS..."
+	uv run --group load --all-packages pytest src/tests/load/test_load_nightly.py \
+		-m integration -p no:benchmark -v
 
 .PHONY: test-benchmark
 test-benchmark: ## Run benchmarks

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,15 @@ test-harness-rs: ## Boot the RS (uvicorn) against node-oidc and run the TH-1.2 r
 		(docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml down && exit 1)
 	docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml down
 
+.PHONY: test-harness-matrix
+test-harness-matrix: ## Run the TH-1.3 token correctness matrix (mock-OP forged corpus + node-oidc leg) through the booted RS
+	@echo "Starting node-oidc-provider fixture..."
+	docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml up -d --build --wait
+	@echo "Running the correctness matrix through the booted RS (real HTTP)..."
+	uv run --all-packages pytest src/tests/integration/test_correctness_matrix.py -m integration --env-file=.env.node-oidc -v || \
+		(docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml down && exit 1)
+	docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml down
+
 .PHONY: test-benchmark
 test-benchmark: ## Run benchmarks
 	uv run pytest src/tests/benchmarks -v --benchmark-only --benchmark-sort=name

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,20 @@ test-harness-matrix: ## Run the TH-1.3 token correctness matrix (mock-OP forged 
 		(docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml down && exit 1)
 	docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml down
 
+.PHONY: test-harness-load
+test-harness-load: ## Run the TH-1.5 CI-short load profile (real Locust vs the booted RS + mock OP)
+	@echo "Driving the CI-short Locust profile through the booted RS (real HTTP)..."
+	uv run --group load --all-packages pytest src/tests/load/test_load_ci_short.py \
+		-m integration -p no:benchmark -v
+
+.PHONY: test-harness-load-nightly
+test-harness-load-nightly: ## (nightly, NOT CI-gated) Long LRU-thrash / RSS-FD soak profile (S7/S11/S12)
+	@echo "Nightly soak profile (design §4 S7/S11/S12) — a documented, not-scheduled"
+	@echo "hook (#271). Run on demand once the SLO baseline is calibrated:"
+	@echo "  uv run --group load --all-packages python -c \\"
+	@echo "    'from src.tests.load.runner import run_profile; from src.tests.load.scenarios import Profile;\\"
+	@echo "     [print(r) for r in run_profile(Profile.NIGHTLY)]'"
+
 .PHONY: test-benchmark
 test-benchmark: ## Run benchmarks
 	uv run pytest src/tests/benchmarks -v --benchmark-only --benchmark-sort=name

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,15 @@ test-integration-keycloak: ## Run integration tests against Keycloak
 		(docker compose -f test-fixtures/keycloak/docker-compose.yml down && exit 1)
 	docker compose -f test-fixtures/keycloak/docker-compose.yml down
 
+.PHONY: test-harness-rs
+test-harness-rs: ## Boot the RS (uvicorn) against node-oidc and run the TH-1.2 real-HTTP proof
+	@echo "Starting node-oidc-provider fixture..."
+	docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml up -d --build --wait
+	@echo "Booting fastapi-identity-model RS under uvicorn (real HTTP)..."
+	uv run --all-packages pytest src/tests/integration/test_rs_boot.py -m integration --env-file=.env.node-oidc -v || \
+		(docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml down && exit 1)
+	docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml down
+
 .PHONY: test-benchmark
 test-benchmark: ## Run benchmarks
 	uv run pytest src/tests/benchmarks -v --benchmark-only --benchmark-sort=name

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -10,112 +10,108 @@ py-identity-model is designed for high performance with built-in caching and sup
 
 ### Discovery Document Caching
 
-Discovery documents are cached automatically to avoid repeated HTTP requests:
+Discovery documents and JWKS are cached in-process to keep the steady-state
+request path off the network. The cache is **not** `functools.lru_cache` /
+`async_lru.alru_cache` — those were replaced (v3.0.0) with an explicit
+**TTL + LRU** cache so entries expire on a schedule, key rotation is handled
+automatically, and concurrent misses are coalesced into a single upstream
+fetch. The cache *policy* lives in `core/jwks_cache.py`; the sync and async
+cache stacks live in `sync/token_validation.py` and `aio/token_validation.py`.
 
-**Sync Implementation:**
-```python
-from functools import lru_cache
+### What is cached
 
-@lru_cache(maxsize=128)
-def _get_disco_response(disco_doc_address: str) -> DiscoveryDocumentResponse:
-    """Cached discovery document fetching"""
-    request = DiscoveryDocumentRequest(address=disco_doc_address)
-    return get_discovery_document(request)
-```
+| Cache | Cache key | Backing store | Default TTL | Env override |
+|-------|-----------|---------------|-------------|--------------|
+| Discovery document | `(address, require_https)` | `OrderedDict` | 3600s (1 hour) | `DISCO_CACHE_TTL` |
+| JWKS | `jwks_uri` | `OrderedDict` | 86400s (24 hours) | `JWKS_CACHE_TTL` |
 
-**Async Implementation:**
-```python
-from async_lru import alru_cache
+Both caches share the same policy machinery:
 
-@alru_cache(maxsize=128)
-async def _get_disco_response(disco_doc_address: str) -> DiscoveryDocumentResponse:
-    """Cached async discovery document fetching"""
-    request = DiscoveryDocumentRequest(address=disco_doc_address)
-    return await get_discovery_document(request)
-```
+- **LRU eviction, 64 entries** (`DEFAULT_MAX_CACHE_ENTRIES`). The store is an
+  `OrderedDict`, not a plain dict, so a *read hit* refreshes recency
+  (`touch_cache_entry`) and eviction targets the least-recently-**used** entry.
+- **TTL resolution order.** For each entry the TTL is the first available of:
+  (1) the response's `Cache-Control: max-age`, (2) the environment override,
+  (3) the built-in default. The resolved value is clamped to
+  **[60s, 86400s]** (`MIN_CACHE_TTL_SECONDS` … `MAX_CACHE_TTL_SECONDS`); a bad
+  or out-of-range env value is clamped and logged, never crashes the request.
+- **Single-flight fetch.** Per-URI striped locks (32 stripes) ensure a cache
+  miss issues exactly one upstream fetch; concurrent requests for the same URI
+  wait on the stripe and then read the freshly-cached entry (a
+  *double-checked* hit) rather than each hitting the network.
+- **Kid-miss cooldown.** If a JWT's `kid` is absent from the cached JWKS the
+  cache is treated as stale and a refresh is forced (OP key rotation). This is
+  rate-limited per-URI — default 5s (`DEFAULT_KID_MISS_REFRESH_COOLDOWN_SECONDS`,
+  override `KID_MISS_REFRESH_COOLDOWN`) — so an attacker forging tokens with
+  random unknown kids cannot amplify inbound traffic into upstream JWKS fetches.
+- **Per-event-loop locks (async).** The async write/fetch locks are keyed on
+  the running event loop via `WeakKeyDictionary` (#399), so a test runner or
+  embed that creates a new loop per scope does not hit
+  `RuntimeError: <Lock> is bound to a different event loop`.
 
-### JWKS Caching
-
-JSON Web Key Sets are also cached:
-
-- **Cache Size**: 128 entries (both sync and async)
-- **Cache Key**: JWKS URL (from discovery document)
-- **Cache Duration**: Lifetime of the process
-- **Thread Safety**: Both implementations are thread-safe
-
-### Cache Behavior Differences
-
-| Aspect | Synchronous | Asynchronous |
-|--------|-------------|--------------|
-| Library | `functools.lru_cache` | `async_lru.alru_cache` |
-| Max Entries | 128 | 128 |
-| Thread Safety | ✅ Yes | ✅ Yes |
-| Cache Sharing | Sync calls only | Async calls only |
-| Cache Clearing | `function.cache_clear()` | `function.cache_clear()` |
-| Performance | Fast | Fast |
-
-**Important:** Sync and async caches are **separate**. They do not share cached data.
-
-#### Example: Cache Separation
-
-```python
-from py_identity_model import get_discovery_document as sync_disco
-from py_identity_model.aio import get_discovery_document as async_disco
-from py_identity_model import DiscoveryDocumentRequest
-
-# First call - fetches from network (sync cache)
-disco = sync_disco(DiscoveryDocumentRequest(address="https://..."))
-
-# Second call - uses sync cache (fast)
-disco = sync_disco(DiscoveryDocumentRequest(address="https://..."))
-
-# Async call - fetches from network again (separate cache!)
-disco = await async_disco(DiscoveryDocumentRequest(address="https://..."))
-
-# Second async call - uses async cache (fast)
-disco = await async_disco(DiscoveryDocumentRequest(address="https://..."))
-```
+**Important:** the sync and async caches are **separate** process-global
+`OrderedDict`s. They do not share cached data.
 
 ### Clearing Caches
 
-You can manually clear caches if needed:
+Use the public cache-clear helpers. **Breaking change (v3.0.0):** the async
+helpers are now `async def` — they acquire the cache write lock before
+clearing so a fetch in flight can't write its result back into a "cleared"
+cache — so callers must `await` them.
 
 ```python
-from py_identity_model.sync.token_validation import _get_disco_response, _get_jwks_response
+# Sync
+from py_identity_model import clear_discovery_cache, clear_jwks_cache
 
-# Clear discovery document cache
-_get_disco_response.cache_clear()
-
-# Clear JWKS cache
-_get_jwks_response.cache_clear()
+clear_discovery_cache()
+clear_jwks_cache()
 ```
-
-For async:
-```python
-from py_identity_model.aio.token_validation import _get_disco_response, _get_jwks_response
-
-# Clear async discovery document cache
-_get_disco_response.cache_clear()
-
-# Clear async JWKS cache
-_get_jwks_response.cache_clear()
-```
-
-### Cache Statistics
-
-You can inspect cache performance:
 
 ```python
-from py_identity_model.sync.token_validation import _get_disco_response
+# Async — must be awaited
+from py_identity_model.aio import clear_discovery_cache, clear_jwks_cache
 
-# Get cache statistics
-info = _get_disco_response.cache_info()
-print(f"Hits: {info.hits}")
-print(f"Misses: {info.misses}")
-print(f"Size: {info.currsize}")
-print(f"Max Size: {info.maxsize}")
-print(f"Hit Rate: {info.hits / (info.hits + info.misses) * 100:.2f}%")
+await clear_discovery_cache()
+await clear_jwks_cache()
 ```
+
+There is no `_get_disco_response.cache_clear()` / `.cache_info()` — those are
+`functools.lru_cache` APIs and the cache no longer uses `lru_cache`.
+
+### Observing Cache Hit Rate
+
+The cache exposes lightweight per-process counters via
+`core/cache_metrics.py`, re-exported at the top level. Read a `snapshot()` and
+compute whatever rate you need:
+
+```python
+from py_identity_model import get_cache_counters
+
+snap = get_cache_counters().snapshot()
+# {'disco_hits': ..., 'disco_misses': ..., 'jwks_hits': ...,
+#  'jwks_misses': ..., 'jwks_refreshes': ...}
+
+jwks_total = snap["jwks_hits"] + snap["jwks_misses"]
+jwks_hit_rate = snap["jwks_hits"] / jwks_total if jwks_total else 0.0
+```
+
+Semantics:
+
+- **hit** — request served from a fresh cached entry (no upstream call);
+  **miss** — request that had to fetch from upstream;
+  **refresh** — a *forced* upstream JWKS re-fetch (kid-miss or
+  signature-failure key-rotation recovery). A refresh that coalesces onto
+  another coroutine's in-flight fetch does no upstream work and is not counted.
+- Counters currently cover the **async** cache paths
+  (`_get_disco_response` / `_get_cached_jwks` / `_refresh_jwks`). The sync
+  stack uses the same TTL/LRU structure but is not yet instrumented.
+- Counters are **per-process**. Under `uvicorn --workers N` each worker keeps
+  its own tally — aggregate snapshots across workers for a fleet-wide rate.
+- The injected-`http_client` path bypasses the caches entirely and is
+  deliberately **not** counted (it performs no caching, so a hit rate over it
+  would be meaningless).
+- `get_cache_counters().reset()` zeros every counter — useful for per-run
+  baselines and tests.
 
 ## Performance Benchmarks
 
@@ -518,25 +514,28 @@ Monitor cache performance in production:
 
 ```python
 import logging
-from py_identity_model.sync.token_validation import _get_disco_response
+from py_identity_model import get_cache_counters
 
 logger = logging.getLogger(__name__)
 
 def log_cache_stats():
     """Log cache statistics periodically."""
-    disco_info = _get_disco_response.cache_info()
+    snap = get_cache_counters().snapshot()
 
-    total = disco_info.hits + disco_info.misses
-    hit_rate = (disco_info.hits / total * 100) if total > 0 else 0
+    disco_total = snap["disco_hits"] + snap["disco_misses"]
+    disco_rate = (snap["disco_hits"] / disco_total * 100) if disco_total else 0
+    jwks_total = snap["jwks_hits"] + snap["jwks_misses"]
+    jwks_rate = (snap["jwks_hits"] / jwks_total * 100) if jwks_total else 0
 
     logger.info(
-        f"Discovery cache: {disco_info.hits} hits, "
-        f"{disco_info.misses} misses, "
-        f"{hit_rate:.1f}% hit rate, "
-        f"{disco_info.currsize}/{disco_info.maxsize} entries"
+        f"Discovery cache: {snap['disco_hits']} hits, "
+        f"{snap['disco_misses']} misses, {disco_rate:.1f}% hit rate | "
+        f"JWKS cache: {snap['jwks_hits']} hits, {snap['jwks_misses']} misses, "
+        f"{snap['jwks_refreshes']} refreshes, {jwks_rate:.1f}% hit rate"
     )
 
-# Log every 1000 requests or periodically
+# Log every 1000 requests or periodically. Counters are per-process — aggregate
+# across workers for a fleet-wide rate.
 ```
 
 ### Performance Metrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,10 @@ project_excludes = [
     "examples/descope/",
     "packages/fastapi-identity-model/",
     "conformance/",
+    # Harness RS app imports the fastapi stack, unresolved in the root lint env
+    # (same rationale as packages/). Exercised via `make test-harness-rs`
+    # under `uv run --all-packages`.
+    "src/tests/harness/rs_app.py",
     # release tooling imports python-semantic-release, which the dev env
     # doesn't install; validated by the release pipeline itself
     "tools/",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,10 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "src/tests/**/*.py" = ["S101"]   # 1858 assert violations — all test assertions, 0 in production code
+"src/tests/harness/**/*.py" = [
+    "S101",    # pytest assertions
+    "PLR0913", # minter / mock-OP APIs are intentionally parameter-rich (mint, sign, mint_access_token)
+]
 "examples/**/*.py" = ["S101"]    # 73 assert violations in example integration tests
 "packages/**/tests/**/*.py" = [
     "S101",    # pytest assertions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,13 @@ docs = [
     "mkdocs-material>=9.6.0,<10",
     "mkdocstrings[python]>=0.29.0,<2",
 ]
+# Load/soak harness (TH-1.5). NOT a root test dependency — locust pulls in gevent
+# and monkey-patches the stdlib, so it is opt-in via `uv run --group load`
+# (see `make test-harness-load`). src/tests/load/{locustfile,runner}.py defer
+# their locust/gevent imports and are pyrefly-excluded in the root lint env.
+load = [
+    "locust>=2.31,<3",
+]
 
 [build-system]
 requires = ["uv_build>=0.6,<0.12"]
@@ -123,6 +130,10 @@ project_excludes = [
     # Serves the mock OP under uvicorn (deferred import), unresolved in the root
     # lint env; exercised via `make test-harness-matrix` under `--all-packages`.
     "src/tests/harness/mock_op_server.py",
+    # Load/soak driver: deferred locust/gevent imports (the `load` group), which
+    # the root lint env does not install. Exercised via `make test-harness-load`.
+    "src/tests/load/locustfile.py",
+    "src/tests/load/runner.py",
     # release tooling imports python-semantic-release, which the dev env
     # doesn't install; validated by the release pipeline itself
     "tools/",
@@ -179,6 +190,10 @@ ignore = [
 "src/tests/harness/**/*.py" = [
     "S101",    # pytest assertions
     "PLR0913", # minter / mock-OP APIs are intentionally parameter-rich (mint, sign, mint_access_token)
+]
+"src/tests/load/**/*.py" = [
+    "S101",    # pytest assertions
+    "PLR2004", # magic values — HTTP status codes in expected-status comparisons
 ]
 "examples/**/*.py" = ["S101"]    # 73 assert violations in example integration tests
 "packages/**/tests/**/*.py" = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,9 @@ project_excludes = [
     # (same rationale as packages/). Exercised via `make test-harness-rs`
     # under `uv run --all-packages`.
     "src/tests/harness/rs_app.py",
+    # Serves the mock OP under uvicorn (deferred import), unresolved in the root
+    # lint env; exercised via `make test-harness-matrix` under `--all-packages`.
+    "src/tests/harness/mock_op_server.py",
     # release tooling imports python-semantic-release, which the dev env
     # doesn't install; validated by the release pipeline itself
     "tools/",

--- a/src/py_identity_model/__init__.py
+++ b/src/py_identity_model/__init__.py
@@ -5,6 +5,7 @@ Provides both synchronous and asynchronous APIs for OpenID Connect operations.
 
 # Initialize SSL compatibility for backward compatibility with requests library
 from . import ssl_config  # noqa: F401
+from .core.cache_metrics import CacheCounters, get_cache_counters
 
 # Backward compatible sync exports (default)
 from .exceptions import (
@@ -150,6 +151,7 @@ __all__ = [
     # Base Classes
     "BaseRequest",
     "BaseResponse",
+    "CacheCounters",
     # mTLS (RFC 8705)
     "CertificateBindingError",
     # Identity models
@@ -245,6 +247,7 @@ __all__ = [
     "generate_code_verifier",
     "generate_dpop_key",
     "generate_pkce_pair",
+    "get_cache_counters",
     # Sync API (default)
     "get_discovery_document",
     "get_jwks",

--- a/src/py_identity_model/aio/token_validation.py
+++ b/src/py_identity_model/aio/token_validation.py
@@ -11,6 +11,7 @@ import threading
 import time
 from weakref import WeakKeyDictionary
 
+from ..core.cache_metrics import get_cache_counters
 from ..core.discovery_policy import DiscoveryPolicy
 from ..core.jwks_cache import (
     DiscoCacheEntry,
@@ -134,16 +135,23 @@ async def _get_disco_response(
         # against an eviction on another loop sharing this module-global cache;
         # the process-wide lock inside touch_cache_entry does (#397).
         touch_cache_entry(_disco_cache, cache_key)
+        get_cache_counters().record_disco_hit()
         return entry.response
 
     fetch_lock = _get_disco_fetch_lock(cache_key)
     async with fetch_lock:
         entry = _disco_cache.get(cache_key)
         if entry is not None and not is_cache_expired(entry):
+            # Double-checked hit: another coroutine populated the entry while we
+            # waited on the fetch lock. This is a genuine cache hit, not a miss —
+            # counting it as a miss would inflate the miss rate under concurrent
+            # warmup.
             touch_cache_entry(_disco_cache, cache_key)
+            get_cache_counters().record_disco_hit()
             return entry.response
 
         policy = DiscoveryPolicy(require_https=require_https)
+        get_cache_counters().record_disco_miss()
         response = await get_discovery_document(
             DiscoveryDocumentRequest(address=disco_doc_address, policy=policy),
         )
@@ -219,19 +227,24 @@ async def _get_cached_jwks(jwks_uri: str, require_https: bool = True) -> JwksRes
         # Refresh LRU recency (see _get_disco_response) — self-serializing via
         # the process-wide structure lock, no per-loop write lock needed.
         touch_cache_entry(_jwks_cache, jwks_uri)
+        get_cache_counters().record_jwks_hit()
         return entry.response
 
     fetch_lock = _get_jwks_fetch_lock(jwks_uri)
     async with fetch_lock:
         entry = _jwks_cache.get(jwks_uri)
         if entry is not None and not is_cache_expired(entry):
+            # Double-checked hit populated by a concurrent fetch (see
+            # _get_disco_response) — count as a hit, not a miss.
             touch_cache_entry(_jwks_cache, jwks_uri)
+            get_cache_counters().record_jwks_hit()
             return entry.response
 
         # The jwks_uri was already vetted against this policy when the
         # discovery document was processed; thread it through so the
         # pre-flight scheme check inside get_jwks() does not double-reject.
         policy = DiscoveryPolicy(require_https=require_https)
+        get_cache_counters().record_jwks_miss()
         response = await get_jwks(JwksRequest(address=jwks_uri, policy=policy))
         async with _get_jwks_cache_write_lock():
             apply_jwks_cache_outcome(
@@ -272,6 +285,10 @@ async def _refresh_jwks(
             return entry.response, False
 
         logger.info("Forcing JWKS refresh for %s (possible key rotation)", jwks_uri)
+        # Count only the branch that issues the upstream GET. The coalesced
+        # early return above returns another coroutine's just-fetched result
+        # and does no upstream work, so it is not a refresh fetch.
+        get_cache_counters().record_jwks_refresh()
         policy = DiscoveryPolicy(require_https=require_https)
         response = await get_jwks(JwksRequest(address=jwks_uri, policy=policy))
         async with _get_jwks_cache_write_lock():

--- a/src/py_identity_model/aio/token_validation.py
+++ b/src/py_identity_model/aio/token_validation.py
@@ -151,10 +151,17 @@ async def _get_disco_response(
             return entry.response
 
         policy = DiscoveryPolicy(require_https=require_https)
-        get_cache_counters().record_disco_miss()
         response = await get_discovery_document(
             DiscoveryDocumentRequest(address=disco_doc_address, policy=policy),
         )
+        # Count the miss only when an upstream fetch actually succeeded.
+        # get_discovery_document runs a pre-flight scheme check that returns an
+        # unsuccessful response *before any network I/O* for a disallowed URI;
+        # such a request does zero upstream work and must not inflate the
+        # miss/fetch-volume counter (else forged non-https addresses skew the
+        # very hit-rate this counter exists to report).
+        if response.is_successful:
+            get_cache_counters().record_disco_miss()
         async with _get_disco_cache_write_lock():
             apply_disco_cache_outcome(
                 _disco_cache, cache_key, response, time.monotonic()
@@ -244,8 +251,14 @@ async def _get_cached_jwks(jwks_uri: str, require_https: bool = True) -> JwksRes
         # discovery document was processed; thread it through so the
         # pre-flight scheme check inside get_jwks() does not double-reject.
         policy = DiscoveryPolicy(require_https=require_https)
-        get_cache_counters().record_jwks_miss()
         response = await get_jwks(JwksRequest(address=jwks_uri, policy=policy))
+        # Count the miss only when an upstream fetch actually succeeded. get_jwks
+        # returns an unsuccessful response for a disallowed scheme (e.g. plaintext
+        # http://) via a pre-flight check *before any network I/O*; a rejected
+        # request does zero upstream work and must not inflate the
+        # miss/fetch-volume counter.
+        if response.is_successful:
+            get_cache_counters().record_jwks_miss()
         async with _get_jwks_cache_write_lock():
             apply_jwks_cache_outcome(
                 _jwks_cache,
@@ -285,12 +298,15 @@ async def _refresh_jwks(
             return entry.response, False
 
         logger.info("Forcing JWKS refresh for %s (possible key rotation)", jwks_uri)
-        # Count only the branch that issues the upstream GET. The coalesced
-        # early return above returns another coroutine's just-fetched result
-        # and does no upstream work, so it is not a refresh fetch.
-        get_cache_counters().record_jwks_refresh()
         policy = DiscoveryPolicy(require_https=require_https)
         response = await get_jwks(JwksRequest(address=jwks_uri, policy=policy))
+        # Count only the branch that issues the upstream GET, and only when it
+        # actually succeeded. The coalesced early return above returns another
+        # coroutine's just-fetched result and does no upstream work; a scheme-
+        # rejected refresh returns an unsuccessful response before any network
+        # I/O. Neither is an upstream re-fetch, so neither is counted.
+        if response.is_successful:
+            get_cache_counters().record_jwks_refresh()
         async with _get_jwks_cache_write_lock():
             apply_jwks_cache_outcome(
                 _jwks_cache,

--- a/src/py_identity_model/aio/token_validation.py
+++ b/src/py_identity_model/aio/token_validation.py
@@ -12,7 +12,7 @@ import time
 from weakref import WeakKeyDictionary
 
 from ..core.cache_metrics import get_cache_counters
-from ..core.discovery_policy import DiscoveryPolicy
+from ..core.discovery_policy import DiscoveryPolicy, validate_url_scheme
 from ..core.jwks_cache import (
     DiscoCacheEntry,
     JwksCacheEntry,
@@ -51,6 +51,37 @@ from ..logging_config import logger
 from .discovery import get_discovery_document
 from .jwks import get_jwks
 from .managed_client import AsyncHTTPClient
+
+
+# ============================================================================
+# Upstream-fetch accounting
+# ============================================================================
+
+
+def _upstream_fetch_attempted(address: str, policy: DiscoveryPolicy) -> bool:
+    """Return ``True`` when an upstream fetch was actually attempted for *address*.
+
+    ``get_discovery_document`` / ``get_jwks`` short-circuit to an *unsuccessful*
+    response **before any network I/O** only when the pre-flight scheme check
+    (:func:`validate_url_scheme`) rejects the address. Every other unsuccessful
+    outcome — a ``429``/``5xx`` upstream response, a connection error/timeout —
+    followed a real network round trip.
+
+    The fetch-volume counters must count those round trips *including the failed
+    ones*: a ``429``/``5xx`` during an upstream outage is exactly the signal an
+    operator watches this metric for, and gating on ``response.is_successful``
+    silently drops it (the outage reads as zero upstream fetches). So gate the
+    miss/refresh increment on "did we get past the scheme check" — which is a
+    pure, side-effect-free re-parse of the same policy the fetch itself applied —
+    rather than on the response status. A scheme-rejected request (zero upstream
+    work, e.g. a forged plaintext ``http://`` URI) is the only excluded case, so
+    it still cannot inflate the tally.
+    """
+    try:
+        validate_url_scheme(address, policy)
+    except ConfigurationException:
+        return False
+    return True
 
 
 # ============================================================================
@@ -154,13 +185,14 @@ async def _get_disco_response(
         response = await get_discovery_document(
             DiscoveryDocumentRequest(address=disco_doc_address, policy=policy),
         )
-        # Count the miss only when an upstream fetch actually succeeded.
-        # get_discovery_document runs a pre-flight scheme check that returns an
-        # unsuccessful response *before any network I/O* for a disallowed URI;
-        # such a request does zero upstream work and must not inflate the
-        # miss/fetch-volume counter (else forged non-https addresses skew the
-        # very hit-rate this counter exists to report).
-        if response.is_successful:
+        # Count the miss whenever an upstream fetch was actually attempted —
+        # including a 429/5xx or a connection error (a real round trip whose
+        # volume this counter exists to surface during an outage). Only a
+        # scheme-rejected address does zero network work and is excluded; see
+        # _upstream_fetch_attempted. Gating on response.is_successful instead
+        # would silently drop failed fetches and make an upstream outage read as
+        # zero upstream volume.
+        if _upstream_fetch_attempted(disco_doc_address, policy):
             get_cache_counters().record_disco_miss()
         async with _get_disco_cache_write_lock():
             apply_disco_cache_outcome(
@@ -252,12 +284,11 @@ async def _get_cached_jwks(jwks_uri: str, require_https: bool = True) -> JwksRes
         # pre-flight scheme check inside get_jwks() does not double-reject.
         policy = DiscoveryPolicy(require_https=require_https)
         response = await get_jwks(JwksRequest(address=jwks_uri, policy=policy))
-        # Count the miss only when an upstream fetch actually succeeded. get_jwks
-        # returns an unsuccessful response for a disallowed scheme (e.g. plaintext
-        # http://) via a pre-flight check *before any network I/O*; a rejected
-        # request does zero upstream work and must not inflate the
-        # miss/fetch-volume counter.
-        if response.is_successful:
+        # Count the miss whenever an upstream fetch was attempted, including a
+        # 429/5xx round trip (fetch volume during an outage is the signal). Only
+        # a scheme-rejected URI (e.g. plaintext http:// under the default policy)
+        # does zero network work and is excluded; see _upstream_fetch_attempted.
+        if _upstream_fetch_attempted(jwks_uri, policy):
             get_cache_counters().record_jwks_miss()
         async with _get_jwks_cache_write_lock():
             apply_jwks_cache_outcome(
@@ -300,12 +331,12 @@ async def _refresh_jwks(
         logger.info("Forcing JWKS refresh for %s (possible key rotation)", jwks_uri)
         policy = DiscoveryPolicy(require_https=require_https)
         response = await get_jwks(JwksRequest(address=jwks_uri, policy=policy))
-        # Count only the branch that issues the upstream GET, and only when it
-        # actually succeeded. The coalesced early return above returns another
-        # coroutine's just-fetched result and does no upstream work; a scheme-
-        # rejected refresh returns an unsuccessful response before any network
-        # I/O. Neither is an upstream re-fetch, so neither is counted.
-        if response.is_successful:
+        # Count only the branch that issues the upstream GET, whenever that GET
+        # was actually attempted (a 429/5xx re-fetch is still an upstream round
+        # trip). The coalesced early return above returns another coroutine's
+        # just-fetched result and never reaches here; a scheme-rejected refresh
+        # does zero network work and is excluded via _upstream_fetch_attempted.
+        if _upstream_fetch_attempted(jwks_uri, policy):
             get_cache_counters().record_jwks_refresh()
         async with _get_jwks_cache_write_lock():
             apply_jwks_cache_outcome(

--- a/src/py_identity_model/core/cache_metrics.py
+++ b/src/py_identity_model/core/cache_metrics.py
@@ -33,11 +33,18 @@ class CacheCounters:
     """Thread-safe hit/miss/refresh tallies for the discovery and JWKS caches.
 
     A *hit* is a request served from a fresh cached entry (no upstream call).
-    A *miss* is a request that had to fetch the document/keys from upstream.
-    A *refresh* is a forced upstream JWKS re-fetch triggered by a kid miss or
-    a signature-verification failure (key-rotation recovery); a refresh that
-    coalesces onto another coroutine's in-flight fetch does no upstream work
-    and is not counted.
+    A *miss* is a request that fetched the document/keys from upstream and
+    succeeded. A *refresh* is a forced upstream JWKS re-fetch triggered by a
+    kid miss or a signature-verification failure (key-rotation recovery) that
+    succeeded.
+
+    Only upstream fetches that actually reached the network and returned a
+    successful response are counted. A request rejected by the pre-flight URL
+    scheme check (e.g. a plaintext ``http://`` address under the default
+    HTTPS-required policy) does zero upstream work and is *not* counted — so a
+    forged non-https discovery/JWKS URI cannot inflate the miss/fetch-volume
+    tally. Likewise a refresh that coalesces onto another coroutine's in-flight
+    fetch does no upstream work and is not counted.
     """
 
     disco_hits: int = 0

--- a/src/py_identity_model/core/cache_metrics.py
+++ b/src/py_identity_model/core/cache_metrics.py
@@ -1,0 +1,116 @@
+"""Per-process cache observability counters.
+
+Lightweight, dependency-free hit/miss/refresh counters for the discovery
+and JWKS caches. These make the cache-hit rate and upstream-fetch volume
+observable without pulling in a metrics runtime (Prometheus, statsd, …);
+a caller that wants those can read :func:`get_cache_counters` snapshots and
+export them however it likes.
+
+**Scope:** counters are *per-process*. Each worker (uvicorn ``--workers N``,
+gunicorn fork, …) keeps its own :data:`CACHE_COUNTERS`; aggregate across
+workers externally when a fleet-wide rate is needed (the load/soak harness
+sums per-worker snapshots).
+
+**Cost:** every ``record_*`` is an O(1) integer increment under a dedicated
+leaf :class:`threading.Lock`. The lock guards only the counter fields — it
+never wraps I/O or a cache-structure critical section, so instrumenting the
+cache fast path adds no contention against the cache itself.
+
+**What is counted:** only the module-level singleton cache paths in
+:mod:`py_identity_model.aio.token_validation`
+(``_get_disco_response`` / ``_get_cached_jwks`` / ``_refresh_jwks``). The
+injected-``http_client`` path bypasses those caches entirely and is
+deliberately *not* counted — it performs no caching, so a "hit rate" over it
+would be meaningless.
+"""
+
+from dataclasses import dataclass, field
+import threading
+
+
+@dataclass
+class CacheCounters:
+    """Thread-safe hit/miss/refresh tallies for the discovery and JWKS caches.
+
+    A *hit* is a request served from a fresh cached entry (no upstream call).
+    A *miss* is a request that had to fetch the document/keys from upstream.
+    A *refresh* is a forced upstream JWKS re-fetch triggered by a kid miss or
+    a signature-verification failure (key-rotation recovery); a refresh that
+    coalesces onto another coroutine's in-flight fetch does no upstream work
+    and is not counted.
+    """
+
+    disco_hits: int = 0
+    disco_misses: int = 0
+    jwks_hits: int = 0
+    jwks_misses: int = 0
+    jwks_refreshes: int = 0
+    _lock: threading.Lock = field(
+        default_factory=threading.Lock, repr=False, compare=False
+    )
+
+    def record_disco_hit(self) -> None:
+        """Count a discovery request served from a fresh cache entry."""
+        with self._lock:
+            self.disco_hits += 1
+
+    def record_disco_miss(self) -> None:
+        """Count a discovery request that fetched from upstream."""
+        with self._lock:
+            self.disco_misses += 1
+
+    def record_jwks_hit(self) -> None:
+        """Count a JWKS request served from a fresh cache entry."""
+        with self._lock:
+            self.jwks_hits += 1
+
+    def record_jwks_miss(self) -> None:
+        """Count a JWKS request that fetched from upstream."""
+        with self._lock:
+            self.jwks_misses += 1
+
+    def record_jwks_refresh(self) -> None:
+        """Count a forced upstream JWKS re-fetch (key-rotation recovery)."""
+        with self._lock:
+            self.jwks_refreshes += 1
+
+    def snapshot(self) -> dict[str, int]:
+        """Return a point-in-time copy of every counter.
+
+        The returned dict is a detached copy — mutating it does not affect the
+        live counters, and the counters can advance freely afterwards.
+        """
+        with self._lock:
+            return {
+                "disco_hits": self.disco_hits,
+                "disco_misses": self.disco_misses,
+                "jwks_hits": self.jwks_hits,
+                "jwks_misses": self.jwks_misses,
+                "jwks_refreshes": self.jwks_refreshes,
+            }
+
+    def reset(self) -> None:
+        """Zero every counter. Primarily for tests and per-run baselines."""
+        with self._lock:
+            self.disco_hits = 0
+            self.disco_misses = 0
+            self.jwks_hits = 0
+            self.jwks_misses = 0
+            self.jwks_refreshes = 0
+
+
+# Process-wide singleton. The async cache paths increment this directly; a
+# caller reads it via ``get_cache_counters().snapshot()``.
+CACHE_COUNTERS = CacheCounters()
+
+
+def get_cache_counters() -> CacheCounters:
+    """Return the process-wide :data:`CACHE_COUNTERS` singleton."""
+    return CACHE_COUNTERS
+
+
+__all__ = [
+    "CACHE_COUNTERS",
+    "CacheCounters",
+    "get_cache_counters",
+]

--- a/src/py_identity_model/core/cache_metrics.py
+++ b/src/py_identity_model/core/cache_metrics.py
@@ -33,18 +33,22 @@ class CacheCounters:
     """Thread-safe hit/miss/refresh tallies for the discovery and JWKS caches.
 
     A *hit* is a request served from a fresh cached entry (no upstream call).
-    A *miss* is a request that fetched the document/keys from upstream and
-    succeeded. A *refresh* is a forced upstream JWKS re-fetch triggered by a
-    kid miss or a signature-verification failure (key-rotation recovery) that
-    succeeded.
+    A *miss* is a request that fetched the document/keys from upstream. A
+    *refresh* is a forced upstream JWKS re-fetch triggered by a kid miss or a
+    signature-verification failure (key-rotation recovery).
 
-    Only upstream fetches that actually reached the network and returned a
-    successful response are counted. A request rejected by the pre-flight URL
-    scheme check (e.g. a plaintext ``http://`` address under the default
-    HTTPS-required policy) does zero upstream work and is *not* counted — so a
-    forged non-https discovery/JWKS URI cannot inflate the miss/fetch-volume
-    tally. Likewise a refresh that coalesces onto another coroutine's in-flight
-    fetch does no upstream work and is not counted.
+    A miss/refresh counts every request that actually reached the network —
+    **including a failed round trip** (a ``429``/``5xx`` upstream response or a
+    connection error). Counting failed fetches is deliberate: fetch volume
+    during an upstream outage is exactly the signal this metric exists to
+    surface, and dropping it would make an outage read as zero upstream work.
+    This matches ``docs/performance.md`` ("a request that had to fetch from
+    upstream"). Only a request rejected by the pre-flight URL scheme check (e.g.
+    a plaintext ``http://`` address under the default HTTPS-required policy) does
+    zero upstream work and is *not* counted — so a forged non-https
+    discovery/JWKS URI cannot inflate the tally. Likewise a refresh that
+    coalesces onto another coroutine's in-flight fetch does no upstream work and
+    is not counted.
     """
 
     disco_hits: int = 0
@@ -62,7 +66,7 @@ class CacheCounters:
             self.disco_hits += 1
 
     def record_disco_miss(self) -> None:
-        """Count a discovery request that fetched from upstream."""
+        """Count a discovery request that fetched from upstream (incl. failures)."""
         with self._lock:
             self.disco_misses += 1
 
@@ -72,12 +76,13 @@ class CacheCounters:
             self.jwks_hits += 1
 
     def record_jwks_miss(self) -> None:
-        """Count a JWKS request that fetched from upstream."""
+        """Count a JWKS request that fetched from upstream (incl. failures)."""
         with self._lock:
             self.jwks_misses += 1
 
     def record_jwks_refresh(self) -> None:
-        """Count a forced upstream JWKS re-fetch (key-rotation recovery)."""
+        """Count a forced upstream JWKS re-fetch (key-rotation recovery, incl.
+        failures)."""
         with self._lock:
             self.jwks_refreshes += 1
 

--- a/src/tests/benchmarks/test_benchmarks.py
+++ b/src/tests/benchmarks/test_benchmarks.py
@@ -3,12 +3,25 @@
 Run with: make test-benchmark
 """
 
+import asyncio
+import base64
+import time
+
+import httpx
 import jwt as pyjwt
 import pytest
+import respx
 
 from py_identity_model import (
     validate_fapi_authorization_request,
     validate_fapi_client_config,
+)
+from py_identity_model.aio.token_validation import (
+    clear_discovery_cache,
+    clear_jwks_cache,
+)
+from py_identity_model.aio.token_validation import (
+    validate_token as aio_validate_token,
 )
 from py_identity_model.core.discovery_policy import (
     DiscoveryPolicy,
@@ -20,6 +33,7 @@ from py_identity_model.core.dpop import (
     generate_dpop_key,
 )
 from py_identity_model.core.jar import create_request_object
+from py_identity_model.core.models import TokenValidationConfig
 from py_identity_model.core.parsers import jwks_from_dict
 from py_identity_model.core.pkce import (
     generate_code_challenge,
@@ -200,3 +214,98 @@ def test_bench_pyjwt_decode_baseline(benchmark, sample_signed_jwt, ec_public_pem
 
     result = benchmark(decode_jwt)
     assert result is not None
+
+
+# ============================================================================
+# End-to-end validate_token warm-path Benchmark
+# ============================================================================
+#
+# The raw ``pyjwt.decode`` baseline above measures only the crypto verify. The
+# function that actually runs on every resource-server request is
+# ``aio.validate_token`` — discovery lookup, JWKS lookup, key resolution, decode
+# and claim validation. On the warm path (disco + JWKS both cached) every
+# upstream fetch is skipped, so this micro measures the per-request overhead the
+# cache is meant to eliminate. Upstream is respx-mocked and the caches are
+# pre-warmed once, so the benched runs never touch the network.
+
+_BENCH_ISSUER = "https://bench.example.com"
+_BENCH_DISCO_URL = f"{_BENCH_ISSUER}/.well-known/openid-configuration"
+_BENCH_JWKS_URL = f"{_BENCH_ISSUER}/jwks"
+_BENCH_AUDIENCE = "bench-api"
+
+
+def _rsa_public_jwk(public_key, kid: str) -> dict:
+    """Build an RS256 JWK dict from a cryptography RSA public key."""
+    numbers = public_key.public_numbers()
+
+    def _b64u(value: int, length: int) -> str:
+        return (
+            base64.urlsafe_b64encode(value.to_bytes(length, "big"))
+            .rstrip(b"=")
+            .decode()
+        )
+
+    return {
+        "kty": "RSA",
+        "kid": kid,
+        "n": _b64u(numbers.n, 256),
+        "e": _b64u(numbers.e, 3),
+        "alg": "RS256",
+        "use": "sig",
+    }
+
+
+@pytest.mark.benchmark(group="validation")
+def test_bench_validate_token_warm_path(benchmark, rsa_private_key, rsa_private_pem):
+    """Benchmark the async ``validate_token`` warm path (disco + JWKS cached)."""
+    kid = "bench-validate-key"
+    jwk = _rsa_public_jwk(rsa_private_key.public_key(), kid)
+    disco_doc = {
+        "issuer": _BENCH_ISSUER,
+        "authorization_endpoint": f"{_BENCH_ISSUER}/authorize",
+        "token_endpoint": f"{_BENCH_ISSUER}/token",
+        "jwks_uri": _BENCH_JWKS_URL,
+        "response_types_supported": ["code"],
+        "subject_types_supported": ["public"],
+        "id_token_signing_alg_values_supported": ["RS256"],
+    }
+    now = int(time.time())
+    token = pyjwt.encode(
+        {
+            "iss": _BENCH_ISSUER,
+            "sub": "bench-user",
+            "aud": _BENCH_AUDIENCE,
+            "exp": now + 86400,
+            "iat": now,
+            "nbf": now,
+        },
+        rsa_private_pem,
+        algorithm="RS256",
+        headers={"kid": kid},
+    )
+    config = TokenValidationConfig(perform_disco=True, audience=_BENCH_AUDIENCE)
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(clear_discovery_cache())
+        loop.run_until_complete(clear_jwks_cache())
+        with respx.mock:
+            respx.get(_BENCH_DISCO_URL).mock(
+                return_value=httpx.Response(200, json=disco_doc)
+            )
+            respx.get(_BENCH_JWKS_URL).mock(
+                return_value=httpx.Response(200, json={"keys": [jwk]})
+            )
+            # Warm both caches once so the benched runs are pure cache-hit path.
+            loop.run_until_complete(aio_validate_token(token, config, _BENCH_DISCO_URL))
+            result = benchmark(
+                lambda: loop.run_until_complete(
+                    aio_validate_token(token, config, _BENCH_DISCO_URL)
+                )
+            )
+        assert result is not None
+        assert result["sub"] == "bench-user"
+    finally:
+        loop.run_until_complete(clear_discovery_cache())
+        loop.run_until_complete(clear_jwks_cache())
+        loop.close()

--- a/src/tests/harness/__init__.py
+++ b/src/tests/harness/__init__.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from .corpus import CORPUS_AUDIENCE, ForgedToken, build_corpus
 from .mock_op import MockOP, MockOPControls, SigningKey
+from .mock_op_server import serve_mock_op
 from .token_source import (
     Grant,
     HarnessCapabilityError,
@@ -48,4 +49,5 @@ __all__ = [
     "TokenSource",
     "build_corpus",
     "prime_pool",
+    "serve_mock_op",
 ]

--- a/src/tests/harness/__init__.py
+++ b/src/tests/harness/__init__.py
@@ -12,7 +12,7 @@ A single home for the pieces T300/T301/T311 share:
 from __future__ import annotations
 
 from .corpus import CORPUS_AUDIENCE, ForgedToken, build_corpus
-from .mock_op import MockOP, MockOPControls, SigningKey
+from .mock_op import MockOP, MockOPControls, RequestStats, SigningKey
 from .mock_op_server import serve_mock_op
 from .token_source import (
     Grant,
@@ -45,6 +45,7 @@ __all__ = [
     "Provider",
     "ProviderConfig",
     "ReplayPool",
+    "RequestStats",
     "SigningKey",
     "TokenSource",
     "build_corpus",

--- a/src/tests/harness/__init__.py
+++ b/src/tests/harness/__init__.py
@@ -1,0 +1,51 @@
+"""Token-blaster harness shared infrastructure (epic #462, TH-1.1..TH-1.5).
+
+A single home for the pieces T300/T301/T311 share:
+
+* :class:`TokenSource` — the unified multi-provider minter (``mint``) plus the
+  pre-minted :class:`ReplayPool`.
+* :class:`MockOP` — a controllable, framework-free ASGI OpenID Provider holding
+  a known signing key (valid tokens, forged corpus, T311 failure injection).
+* :func:`build_corpus` — the forged / negative token corpus.
+"""
+
+from __future__ import annotations
+
+from .corpus import CORPUS_AUDIENCE, ForgedToken, build_corpus
+from .mock_op import MockOP, MockOPControls, SigningKey
+from .token_source import (
+    Grant,
+    HarnessCapabilityError,
+    HarnessCredentialError,
+    HarnessError,
+    Malform,
+    MintedToken,
+    MintSpec,
+    Provider,
+    ProviderConfig,
+    ReplayPool,
+    TokenSource,
+    prime_pool,
+)
+
+
+__all__ = [
+    "CORPUS_AUDIENCE",
+    "ForgedToken",
+    "Grant",
+    "HarnessCapabilityError",
+    "HarnessCredentialError",
+    "HarnessError",
+    "Malform",
+    "MintSpec",
+    "MintedToken",
+    "MockOP",
+    "MockOPControls",
+    "Provider",
+    "ProviderConfig",
+    "ReplayPool",
+    "SigningKey",
+    "TokenSource",
+    "build_corpus",
+    "prime_pool",
+]

--- a/src/tests/harness/__init__.py
+++ b/src/tests/harness/__init__.py
@@ -1,0 +1,5 @@
+"""Token-blaster harness helpers (TH-1.x).
+
+Test-only infrastructure for booting py-identity-model as a real resource
+server and driving it over HTTP. Not part of the shipped library.
+"""

--- a/src/tests/harness/corpus.py
+++ b/src/tests/harness/corpus.py
@@ -1,0 +1,194 @@
+"""Forged / negative token corpus for the token-blaster harness (TH-1.1).
+
+Real OPs will not emit invalid tokens and node-oidc's keys are ephemeral and
+not exported, so the negative corpus is forged off the *known* signing key of
+the controllable :class:`~mock_op.MockOP` (design §3).
+
+Each :class:`ForgedToken` records ``library_rejects`` — whether
+:func:`py_identity_model.aio.validate_token` (signature + ``iss``/``aud``/``exp``
+checks) rejects it. Note the distinction from *resource-server* policy, which
+is T302's concern:
+
+* ``id_as_access`` and ``cnf_bound`` are *validly signed JWTs for the audience*
+  — the library ACCEPTS them; only the RS access-token marker / ``require_scope``
+  layer (F-07 / F-02) distinguishes them. They therefore carry
+  ``library_rejects=False`` here.
+* ``oversized`` / ``multi_aud_untrusted`` are likewise valid to the library.
+
+Real-issuer negatives that cannot be forged (a real OP signing an expired token
+with its real key) reuse the committed expired tokens + cross-provider
+``kid``-mismatch already in the integration suite.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import time
+from typing import TYPE_CHECKING, Any
+
+import jwt
+
+
+if TYPE_CHECKING:
+    from .mock_op import MockOP
+
+
+CORPUS_AUDIENCE = "mock-api"
+
+
+@dataclass(frozen=True)
+class ForgedToken:
+    """A single corpus entry.
+
+    Attributes:
+        name: Stable class name (matches a :class:`~token_source.Malform` value).
+        jwt: The compact-serialized token.
+        description: What makes it invalid (or, for accepted classes, why the
+            library accepts it despite RS-layer policy rejecting it).
+        library_rejects: Whether ``aio.validate_token`` rejects it outright.
+    """
+
+    name: str
+    jwt: str
+    description: str
+    library_rejects: bool
+
+
+def _base_claims(mock_op: MockOP, now: int, *, audience: Any = CORPUS_AUDIENCE) -> dict:
+    return {
+        "iss": mock_op.issuer,
+        "sub": "mock-subject",
+        "aud": audience,
+        "iat": now,
+        "nbf": now,
+        "exp": now + 300,
+        "client_id": "mock-client",
+        "scope": "read",
+    }
+
+
+def _tamper_signature(token: str) -> str:
+    """Flip the *first* character of the signature segment (invalid signature).
+
+    The first base64url character carries fully-significant bits, so flipping it
+    always changes the decoded signature bytes. (The *last* character of an
+    RSA-2048 signature encodes only 2 significant bits plus 4 discard bits, so
+    flipping it can decode to identical bytes and leave the signature valid.)
+    """
+    header, payload, signature = token.split(".")
+    flipped = "B" if signature[0] != "B" else "C"
+    return f"{header}.{payload}.{flipped}{signature[1:]}"
+
+
+def build_corpus(mock_op: MockOP) -> dict[str, ForgedToken]:
+    """Build the full forged corpus keyed to *mock_op*'s known signing key."""
+    now = int(time.time())
+    entries: list[ForgedToken] = []
+
+    def add(name: str, token: str, description: str, *, rejects: bool) -> None:
+        entries.append(ForgedToken(name, token, description, rejects))
+
+    # -- Accepted by the library (signature + iss + aud + exp all valid) -----
+    add(
+        "valid",
+        mock_op.sign(_base_claims(mock_op, now)),
+        "well-formed token signed by a published key",
+        rejects=False,
+    )
+    id_claims = _base_claims(mock_op, now)
+    id_claims.pop("scope")
+    id_claims.pop("client_id")
+    id_claims["nonce"] = "n-abc"
+    add(
+        "id_as_access",
+        mock_op.sign(id_claims),
+        "ID-token-shaped (no scope/client_id) presented as a bearer access "
+        "token — library accepts; RS marker (F-07) must reject",
+        rejects=False,
+    )
+    cnf_claims = _base_claims(mock_op, now)
+    cnf_claims["cnf"] = {"jkt": "0ZcOCORZNYy-DWpqq30jZyJGHTN0d2HglBV3uiguA4I"}
+    add(
+        "cnf_bound",
+        mock_op.sign(cnf_claims),
+        "DPoP/mTLS cnf-bound token presented as a plain bearer — library "
+        "accepts (F-02 accepted-today contract; do not assume rejection)",
+        rejects=False,
+    )
+    big_claims = _base_claims(mock_op, now)
+    for i in range(200):
+        big_claims[f"pad_{i}"] = "x" * 64
+    add(
+        "oversized",
+        mock_op.sign(big_claims),
+        "valid token bloated with 200 padding claims (resource-exhaustion probe)",
+        rejects=False,
+    )
+    multi_aud = _base_claims(mock_op, now, audience=[CORPUS_AUDIENCE, "urn:untrusted"])
+    add(
+        "multi_aud_untrusted",
+        mock_op.sign(multi_aud),
+        "multi-aud token whose secondary audience is untrusted — library "
+        "accepts because the trusted audience is present",
+        rejects=False,
+    )
+
+    # -- Rejected by the library --------------------------------------------
+    expired = _base_claims(mock_op, now)
+    expired["iat"] = expired["nbf"] = now - 600
+    expired["exp"] = now - 300
+    add("expired", mock_op.sign(expired), "exp in the past", rejects=True)
+
+    nbf_future = _base_claims(mock_op, now)
+    nbf_future["nbf"] = now + 3600
+    add("nbf_future", mock_op.sign(nbf_future), "nbf in the future", rejects=True)
+
+    wrong_iss = _base_claims(mock_op, now)
+    wrong_iss["iss"] = "https://evil.example.com"
+    add(
+        "wrong_iss",
+        mock_op.sign(wrong_iss),
+        "iss does not match discovery",
+        rejects=True,
+    )
+
+    wrong_aud = _base_claims(mock_op, now, audience="urn:some-other-api")
+    add(
+        "wrong_aud",
+        mock_op.sign(wrong_aud),
+        "aud does not match expected",
+        rejects=True,
+    )
+
+    add(
+        "tampered_sig",
+        _tamper_signature(mock_op.sign(_base_claims(mock_op, now))),
+        "byte-flipped signature",
+        rejects=True,
+    )
+    add(
+        "unknown_kid",
+        mock_op.sign(_base_claims(mock_op, now), key=mock_op.unpublished_key),
+        "signed by a key whose kid is absent from JWKS",
+        rejects=True,
+    )
+    add(
+        "wrong_alg",
+        jwt.encode(
+            _base_claims(mock_op, now),
+            # >= 32 bytes to avoid PyJWT's InsecureKeyLengthWarning; the exact
+            # secret is irrelevant — the point is HS256 against an RSA kid.
+            "harness-hmac-confusion-secret-key-32b",
+            algorithm="HS256",
+            headers={"kid": mock_op.primary_key.kid},
+        ),
+        "HS256 signed while claiming an RSA kid (alg-confusion)",
+        rejects=True,
+    )
+    add(
+        "alg_none",
+        jwt.encode(_base_claims(mock_op, now), "", algorithm="none"),
+        "unsigned token with alg:none",
+        rejects=True,
+    )
+    return {entry.name: entry for entry in entries}

--- a/src/tests/harness/mock_op.py
+++ b/src/tests/harness/mock_op.py
@@ -27,7 +27,7 @@ from collections.abc import Awaitable, Callable, MutableMapping
 from dataclasses import dataclass
 import json
 import time
-from typing import Any
+from typing import Any, get_args, get_type_hints
 from urllib.parse import parse_qs
 
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
@@ -110,6 +110,43 @@ class MockOPControls:
     jwks_cache_control: str | None = None
     serve_empty_jwks: bool = False
     oversized_jwks_padding: int = 0
+
+
+def _resolve_control_types() -> dict[str, tuple[type, ...]]:
+    """Resolved ``{field_name: accepted_types}`` for :class:`MockOPControls`."""
+    mapping: dict[str, tuple[type, ...]] = {}
+    for name, anno in get_type_hints(MockOPControls).items():
+        args = get_args(anno)
+        mapping[name] = tuple(a for a in (args or (anno,)) if isinstance(a, type))
+    return mapping
+
+
+# Field -> accepted types, resolved once (the dataclass is immutable in shape).
+_CONTROL_TYPES: dict[str, tuple[type, ...]] = _resolve_control_types()
+
+
+def _set_control(controls: MockOPControls, name: str, value: Any) -> bool:
+    """Type-checked control mutation; returns True if the value was applied.
+
+    A stray ``{"jwks_status": "boom"}`` or ``{"retry_after": 3}`` (JSON number,
+    not string) would otherwise poison a *later* request — an ``int`` handed to
+    an ASGI ``status`` field, or a ``.encode()`` on a non-string. Reject the
+    mismatch at the control call so the failure is local and obvious.
+    """
+    types = _CONTROL_TYPES.get(name)
+    if not types:
+        return False
+    # ``bool`` is a subclass of ``int``: accept it only for genuine bool knobs,
+    # and never let it (or a JSON int) masquerade as a status/int field's value.
+    if isinstance(value, bool):
+        accepted = bool in types
+    elif isinstance(value, int) and float in types:
+        accepted = True  # JSON ints are fine for float knobs (latency_seconds)
+    else:
+        accepted = isinstance(value, types)
+    if accepted:
+        setattr(controls, name, value)
+    return accepted
 
 
 # ASGI scope/messages are MutableMapping (matching httpx.ASGITransport's spec).
@@ -300,7 +337,12 @@ class MockOP:
         except jwt.PyJWTError:
             return {"active": False}
         now = int(time.time())
-        active = int(claims.get("exp", 0)) > now
+        try:
+            active = int(claims.get("exp", 0)) > now
+        except (TypeError, ValueError):
+            # A malformed ``exp`` (exactly the kind of token this harness feeds)
+            # must report inactive, not 500 the endpoint.
+            active = False
         return {"active": active, **claims}
 
     # -- ASGI application ---------------------------------------------------
@@ -380,7 +422,13 @@ class MockOP:
         """Out-of-process control endpoint for the uvicorn-booted case (T311).
 
         Accepts a JSON body: ``{"rotate": true, "publish": false}`` and/or any
-        subset of :class:`MockOPControls` field names to set.
+        subset of :class:`MockOPControls` field names to set. Field values are
+        type-checked against the dataclass; mismatches are reported back in the
+        ``rejected`` list rather than poisoning a later request.
+
+        Security: this route performs key rotation and failure injection with no
+        authentication. It is a *test* fixture — bind it to loopback only. Do NOT
+        expose the booted mock OP on a routable interface.
         """
         try:
             payload = json.loads((await _read_body(receive)).decode() or "{}")
@@ -388,10 +436,16 @@ class MockOP:
             payload = {}
         if payload.pop("rotate", False):
             self.rotate_keys(publish=bool(payload.pop("publish", False)))
-        for name, value in payload.items():
-            if hasattr(self.controls, name):
-                setattr(self.controls, name, value)
-        await self._send_json(send, HTTP_OK, {"ok": True})
+        else:
+            # ``publish`` is only meaningful alongside ``rotate``; drop it so it
+            # is not mistaken for a control field below.
+            payload.pop("publish", None)
+        rejected = [
+            name
+            for name, value in payload.items()
+            if not _set_control(self.controls, name, value)
+        ]
+        await self._send_json(send, HTTP_OK, {"ok": True, "rejected": rejected})
 
     # -- ASGI helpers -------------------------------------------------------
 

--- a/src/tests/harness/mock_op.py
+++ b/src/tests/harness/mock_op.py
@@ -1,0 +1,444 @@
+"""Controllable mock OpenID Provider for the token-blaster harness (TH-1.1).
+
+The mock OP holds a *known* signing key (unlike real IdPs, whose keys are
+ephemeral and not exportable), which lets the harness:
+
+1. mint genuinely valid tokens, and
+2. forge the negative corpus (:mod:`corpus`) — tampered signatures, unknown
+   ``kid``, ``alg:none``, wrong ``iss``/``aud``, etc. — that a real OP will
+   never emit.
+
+It is a framework-free ASGI application (``fastapi``/``starlette`` are not root
+test dependencies), so it is both:
+
+* unit-testable in-process via ``httpx.ASGITransport`` (no network), and
+* bootable out-of-process under ``uvicorn`` for the load/soak suite (T311).
+
+The :class:`MockOPControls` object drives T311's failure injection: injected
+latency, ``429``/``Retry-After``, ``5xx``, key-rotation-on-command,
+``Cache-Control`` directives, and empty/oversized JWKS.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from collections.abc import Awaitable, Callable, MutableMapping
+from dataclasses import dataclass
+import json
+import time
+from typing import Any
+from urllib.parse import parse_qs
+
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+import jwt
+
+
+# HTTP status codes
+HTTP_OK = 200
+HTTP_NOT_FOUND = 404
+HTTP_TOO_MANY_REQUESTS = 429
+
+DEFAULT_ISSUER = "http://mock-op.local"
+DEFAULT_TOKEN_LIFETIME = 300  # seconds — mirrors the real-IdP 300s TTL (design §3)
+
+
+def _b64url_uint(value: int) -> str:
+    """Encode an unsigned integer as base64url (JWK ``n``/``e``/``x``/``y``)."""
+    length = (value.bit_length() + 7) // 8 or 1
+    return base64.urlsafe_b64encode(value.to_bytes(length, "big")).rstrip(b"=").decode()
+
+
+@dataclass(frozen=True)
+class SigningKey:
+    """A signing key the mock OP controls end-to-end.
+
+    Holds the private key (for signing / forging) and its public JWK (for the
+    ``/jwks`` document), so the harness can both mint valid tokens and forge
+    negatives keyed to a known public key.
+    """
+
+    alg: str
+    kid: str
+    private_key: Any  # cryptography private key object
+    public_jwk: dict[str, Any]
+
+
+def _rsa_signing_key(kid: str) -> SigningKey:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    numbers = private_key.public_key().public_numbers()
+    jwk = {
+        "kty": "RSA",
+        "use": "sig",
+        "alg": "RS256",
+        "kid": kid,
+        "n": _b64url_uint(numbers.n),
+        "e": _b64url_uint(numbers.e),
+    }
+    return SigningKey(alg="RS256", kid=kid, private_key=private_key, public_jwk=jwk)
+
+
+def _ec_signing_key(kid: str) -> SigningKey:
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    numbers = private_key.public_key().public_numbers()
+    jwk = {
+        "kty": "EC",
+        "use": "sig",
+        "alg": "ES256",
+        "kid": kid,
+        "crv": "P-256",
+        "x": _b64url_uint(numbers.x),
+        "y": _b64url_uint(numbers.y),
+    }
+    return SigningKey(alg="ES256", kid=kid, private_key=private_key, public_jwk=jwk)
+
+
+@dataclass
+class MockOPControls:
+    """Mutable failure-injection knobs (design §2).
+
+    Every request consults the *live* object, so a test (or a T311 control
+    route) can flip a knob between requests and observe the effect.
+    """
+
+    latency_seconds: float = 0.0
+    discovery_status: int = HTTP_OK
+    jwks_status: int = HTTP_OK
+    token_status: int = HTTP_OK
+    retry_after: str | None = None
+    discovery_cache_control: str | None = None
+    jwks_cache_control: str | None = None
+    serve_empty_jwks: bool = False
+    oversized_jwks_padding: int = 0
+
+
+# ASGI scope/messages are MutableMapping (matching httpx.ASGITransport's spec).
+ASGIScope = MutableMapping[str, Any]
+ASGIReceive = Callable[[], Awaitable[MutableMapping[str, Any]]]
+ASGISend = Callable[[MutableMapping[str, Any]], Awaitable[None]]
+ASGIApp = Callable[[ASGIScope, ASGIReceive, ASGISend], Awaitable[None]]
+
+
+class MockOP:
+    """A controllable OIDC provider serving discovery, JWKS, token, introspect.
+
+    Args:
+        issuer: The issuer / base URL. All endpoint URLs derive from it, and
+            minted tokens carry it as ``iss``.
+        controls: Failure-injection knobs. A fresh :class:`MockOPControls` is
+            created when omitted.
+    """
+
+    def __init__(
+        self,
+        issuer: str = DEFAULT_ISSUER,
+        *,
+        controls: MockOPControls | None = None,
+    ) -> None:
+        self.issuer = issuer.rstrip("/")
+        self.controls = controls or MockOPControls()
+        # Primary RS256 signs valid tokens and is published by default.
+        self.primary_key = _rsa_signing_key("mock-rs256-1")
+        # EC key exercises the ES256 path; also published.
+        self.ec_key = _ec_signing_key("mock-es256-1")
+        # Rotation spare — NOT published until :meth:`rotate_keys` publishes it,
+        # so a token freshly signed by it presents an unknown ``kid`` (design §2
+        # key-rotation-on-command failure injection).
+        self.rotation_key = _rsa_signing_key("mock-rs256-2")
+        # A key that is never published — the source of unknown-``kid`` forgeries.
+        self.unpublished_key = _rsa_signing_key("mock-rs256-unpublished")
+        self._signing_key = self.primary_key
+        self._published: list[SigningKey] = [self.primary_key, self.ec_key]
+
+    # -- URLs ---------------------------------------------------------------
+
+    @property
+    def discovery_url(self) -> str:
+        return f"{self.issuer}/.well-known/openid-configuration"
+
+    @property
+    def jwks_uri(self) -> str:
+        return f"{self.issuer}/jwks"
+
+    @property
+    def token_endpoint(self) -> str:
+        return f"{self.issuer}/token"
+
+    @property
+    def introspection_endpoint(self) -> str:
+        return f"{self.issuer}/introspect"
+
+    @property
+    def signing_key(self) -> SigningKey:
+        """The key currently used to sign freshly minted tokens."""
+        return self._signing_key
+
+    # -- Control ------------------------------------------------------------
+
+    def rotate_keys(self, *, publish: bool = False) -> SigningKey:
+        """Rotate the active signing key to the spare.
+
+        With ``publish=False`` (the default) the new key is withheld from the
+        JWKS, so tokens minted afterwards fail validation with an unknown
+        ``kid`` until :meth:`publish_signing_key` is called — the head-of-line
+        rotation scenario the harness needs to reproduce.
+        """
+        self._signing_key = self.rotation_key
+        if publish:
+            self.publish_signing_key()
+        return self._signing_key
+
+    def publish_signing_key(self) -> None:
+        """Add the active signing key to the published JWKS (idempotent)."""
+        if self._signing_key not in self._published:
+            self._published.append(self._signing_key)
+
+    # -- Documents ----------------------------------------------------------
+
+    def discovery_document(self) -> dict[str, Any]:
+        return {
+            "issuer": self.issuer,
+            "jwks_uri": self.jwks_uri,
+            "token_endpoint": self.token_endpoint,
+            "introspection_endpoint": self.introspection_endpoint,
+            "authorization_endpoint": f"{self.issuer}/authorize",
+            "response_types_supported": ["code", "token"],
+            "grant_types_supported": [
+                "client_credentials",
+                "authorization_code",
+                "refresh_token",
+            ],
+            "id_token_signing_alg_values_supported": ["RS256", "ES256"],
+            "scopes_supported": ["openid", "profile", "email"],
+            "code_challenge_methods_supported": ["S256"],
+            "subject_types_supported": ["public"],
+            "token_endpoint_auth_methods_supported": [
+                "client_secret_basic",
+                "client_secret_post",
+                "private_key_jwt",
+            ],
+        }
+
+    def jwks(self) -> dict[str, Any]:
+        if self.controls.serve_empty_jwks:
+            return {"keys": []}
+        keys = [dict(k.public_jwk) for k in self._published]
+        for i in range(self.controls.oversized_jwks_padding):
+            pad = _rsa_signing_key(f"mock-pad-{i}")
+            keys.append(dict(pad.public_jwk))
+        return {"keys": keys}
+
+    # -- Minting ------------------------------------------------------------
+
+    def sign(
+        self,
+        claims: dict[str, Any],
+        *,
+        key: SigningKey | None = None,
+        alg: str | None = None,
+        headers: dict[str, Any] | None = None,
+    ) -> str:
+        """Sign *claims* into a compact JWS with a mock-OP key.
+
+        Used both by the token endpoint (valid tokens) and by
+        :mod:`corpus` (forged negatives keyed to a known public key).
+        """
+        signing_key = key or self._signing_key
+        merged_headers = {"kid": signing_key.kid}
+        if headers:
+            merged_headers.update(headers)
+        return jwt.encode(
+            claims,
+            signing_key.private_key,
+            algorithm=alg or signing_key.alg,
+            headers=merged_headers,
+        )
+
+    def mint_access_token(
+        self,
+        *,
+        scopes: str | None = None,
+        tenant: str | None = None,
+        audience: str = "mock-api",
+        subject: str = "mock-subject",
+        lifetime: int = DEFAULT_TOKEN_LIFETIME,
+        extra_claims: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Mint a valid access token, returning an OAuth token-response dict.
+
+        ``tenant`` shapes the Descope-style multi-tenant claims (``dct`` +
+        ``tenants``) the node-oidc offline fixture also carries (design §2/§3).
+        """
+        now = int(time.time())
+        claims: dict[str, Any] = {
+            "iss": self.issuer,
+            "sub": subject,
+            "aud": audience,
+            "iat": now,
+            "nbf": now,
+            "exp": now + lifetime,
+            "client_id": "mock-client",
+            "scope": scopes or "read",
+        }
+        if tenant is not None:
+            claims["dct"] = tenant
+            claims["tenants"] = {tenant: {"roles": ["user"]}}
+        if extra_claims:
+            claims.update(extra_claims)
+        access_token = self.sign(claims)
+        return {
+            "access_token": access_token,
+            "token_type": "Bearer",
+            "expires_in": lifetime,
+            "scope": claims["scope"],
+        }
+
+    def introspect(self, token: str) -> dict[str, Any]:
+        """Best-effort introspection: decode without verification and echo."""
+        try:
+            claims = jwt.decode(token, options={"verify_signature": False})
+        except jwt.PyJWTError:
+            return {"active": False}
+        now = int(time.time())
+        active = int(claims.get("exp", 0)) > now
+        return {"active": active, **claims}
+
+    # -- ASGI application ---------------------------------------------------
+
+    @property
+    def app(self) -> ASGIApp:
+        """The ASGI application callable (uvicorn-bootable, httpx-drivable)."""
+        return self._app
+
+    async def _app(
+        self, scope: ASGIScope, receive: ASGIReceive, send: ASGISend
+    ) -> None:
+        if scope["type"] == "lifespan":
+            await self._handle_lifespan(receive, send)
+            return
+        if scope["type"] != "http":  # pragma: no cover - defensive
+            return
+        if self.controls.latency_seconds:
+            await asyncio.sleep(self.controls.latency_seconds)
+        path = scope["path"].rstrip("/") or "/"
+        method = scope["method"]
+        handler = self._route(method, path)
+        if handler is None:
+            await self._send_json(send, HTTP_NOT_FOUND, {"error": "not_found"})
+            return
+        await handler(receive, send)
+
+    def _route(
+        self, method: str, path: str
+    ) -> Callable[[ASGIReceive, ASGISend], Awaitable[None]] | None:
+        routes: dict[tuple[str, str], Callable[..., Awaitable[None]]] = {
+            ("GET", "/.well-known/openid-configuration"): self._handle_discovery,
+            ("GET", "/jwks"): self._handle_jwks,
+            ("POST", "/token"): self._handle_token,
+            ("POST", "/introspect"): self._handle_introspect,
+            ("POST", "/_control"): self._handle_control,
+        }
+        return routes.get((method, path))
+
+    async def _handle_lifespan(self, receive: ASGIReceive, send: ASGISend) -> None:
+        while True:
+            message = await receive()
+            if message["type"] == "lifespan.startup":
+                await send({"type": "lifespan.startup.complete"})
+            elif message["type"] == "lifespan.shutdown":
+                await send({"type": "lifespan.shutdown.complete"})
+                return
+
+    async def _handle_discovery(self, _receive: ASGIReceive, send: ASGISend) -> None:
+        headers = self._cache_control_headers(self.controls.discovery_cache_control)
+        if self.controls.discovery_status != HTTP_OK:
+            await self._send_status(send, self.controls.discovery_status, headers)
+            return
+        await self._send_json(send, HTTP_OK, self.discovery_document(), headers)
+
+    async def _handle_jwks(self, _receive: ASGIReceive, send: ASGISend) -> None:
+        headers = self._cache_control_headers(self.controls.jwks_cache_control)
+        if self.controls.jwks_status != HTTP_OK:
+            await self._send_status(send, self.controls.jwks_status, headers)
+            return
+        await self._send_json(send, HTTP_OK, self.jwks(), headers)
+
+    async def _handle_token(self, receive: ASGIReceive, send: ASGISend) -> None:
+        if self.controls.token_status != HTTP_OK:
+            await self._send_status(send, self.controls.token_status)
+            return
+        form = parse_qs((await _read_body(receive)).decode())
+        scope = form.get("scope", [None])[0]
+        await self._send_json(send, HTTP_OK, self.mint_access_token(scopes=scope))
+
+    async def _handle_introspect(self, receive: ASGIReceive, send: ASGISend) -> None:
+        form = parse_qs((await _read_body(receive)).decode())
+        token = form.get("token", [""])[0]
+        await self._send_json(send, HTTP_OK, self.introspect(token))
+
+    async def _handle_control(self, receive: ASGIReceive, send: ASGISend) -> None:
+        """Out-of-process control endpoint for the uvicorn-booted case (T311).
+
+        Accepts a JSON body: ``{"rotate": true, "publish": false}`` and/or any
+        subset of :class:`MockOPControls` field names to set.
+        """
+        try:
+            payload = json.loads((await _read_body(receive)).decode() or "{}")
+        except json.JSONDecodeError:
+            payload = {}
+        if payload.pop("rotate", False):
+            self.rotate_keys(publish=bool(payload.pop("publish", False)))
+        for name, value in payload.items():
+            if hasattr(self.controls, name):
+                setattr(self.controls, name, value)
+        await self._send_json(send, HTTP_OK, {"ok": True})
+
+    # -- ASGI helpers -------------------------------------------------------
+
+    def _cache_control_headers(
+        self, cache_control: str | None
+    ) -> list[tuple[bytes, bytes]]:
+        if cache_control is None:
+            return []
+        return [(b"cache-control", cache_control.encode())]
+
+    async def _send_status(
+        self,
+        send: ASGISend,
+        status: int,
+        headers: list[tuple[bytes, bytes]] | None = None,
+    ) -> None:
+        body = {"error": "injected_failure", "status": status}
+        extra = list(headers or [])
+        if status == HTTP_TOO_MANY_REQUESTS and self.controls.retry_after is not None:
+            extra.append((b"retry-after", self.controls.retry_after.encode()))
+        await self._send_json(send, status, body, extra)
+
+    async def _send_json(
+        self,
+        send: ASGISend,
+        status: int,
+        body: dict[str, Any],
+        headers: list[tuple[bytes, bytes]] | None = None,
+    ) -> None:
+        payload = json.dumps(body).encode()
+        response_headers = [(b"content-type", b"application/json")]
+        response_headers.extend(headers or [])
+        await send(
+            {
+                "type": "http.response.start",
+                "status": status,
+                "headers": response_headers,
+            }
+        )
+        await send({"type": "http.response.body", "body": payload})
+
+
+async def _read_body(receive: ASGIReceive) -> bytes:
+    body = b""
+    while True:
+        message = await receive()
+        body += message.get("body", b"")
+        if not message.get("more_body", False):
+            break
+    return body

--- a/src/tests/harness/mock_op.py
+++ b/src/tests/harness/mock_op.py
@@ -94,6 +94,40 @@ def _ec_signing_key(kid: str) -> SigningKey:
 
 
 @dataclass
+class RequestStats:
+    """Per-path upstream-request tallies (design §5 — upstream fetches/issuer).
+
+    Ground truth for how many times the resource server actually reached each
+    endpoint, letting the load/soak harness assert single-flight behaviour (e.g.
+    S3: a cold stampede must produce exactly one discovery + one JWKS fetch).
+    Every request that reaches a document handler is counted, regardless of the
+    injected response status — a ``429``/``5xx`` still cost an upstream round trip.
+
+    The mock OP runs on a single uvicorn event loop, so these plain ``int``
+    increments are serialised without a lock (unlike the threaded
+    :class:`~py_identity_model.core.cache_metrics.CacheCounters`).
+    """
+
+    discovery: int = 0
+    jwks: int = 0
+    token: int = 0
+    introspect: int = 0
+
+    def snapshot(self) -> dict[str, int]:
+        """Return a detached copy of every counter."""
+        return {
+            "discovery": self.discovery,
+            "jwks": self.jwks,
+            "token": self.token,
+            "introspect": self.introspect,
+        }
+
+    def reset(self) -> None:
+        """Zero every counter (per-scenario baselines)."""
+        self.discovery = self.jwks = self.token = self.introspect = 0
+
+
+@dataclass
 class MockOPControls:
     """Mutable failure-injection knobs (design §2).
 
@@ -174,6 +208,10 @@ class MockOP:
     ) -> None:
         self.issuer = issuer.rstrip("/")
         self.controls = controls or MockOPControls()
+        # Per-path upstream-request counters (design §5). Read/reset over HTTP via
+        # ``GET``/``POST /_stats`` so the out-of-process load driver can scrape
+        # them, or in-process for unit assertions.
+        self.stats = RequestStats()
         # Primary RS256 signs valid tokens and is published by default.
         self.primary_key = _rsa_signing_key("mock-rs256-1")
         # EC key exercises the ES256 path; also published.
@@ -379,6 +417,8 @@ class MockOP:
             ("POST", "/token"): self._handle_token,
             ("POST", "/introspect"): self._handle_introspect,
             ("POST", "/_control"): self._handle_control,
+            ("GET", "/_stats"): self._handle_stats,
+            ("POST", "/_stats"): self._handle_stats_reset,
         }
         return routes.get((method, path))
 
@@ -392,6 +432,7 @@ class MockOP:
                 return
 
     async def _handle_discovery(self, _receive: ASGIReceive, send: ASGISend) -> None:
+        self.stats.discovery += 1
         headers = self._cache_control_headers(self.controls.discovery_cache_control)
         if self.controls.discovery_status != HTTP_OK:
             await self._send_status(send, self.controls.discovery_status, headers)
@@ -399,6 +440,7 @@ class MockOP:
         await self._send_json(send, HTTP_OK, self.discovery_document(), headers)
 
     async def _handle_jwks(self, _receive: ASGIReceive, send: ASGISend) -> None:
+        self.stats.jwks += 1
         headers = self._cache_control_headers(self.controls.jwks_cache_control)
         if self.controls.jwks_status != HTTP_OK:
             await self._send_status(send, self.controls.jwks_status, headers)
@@ -406,6 +448,7 @@ class MockOP:
         await self._send_json(send, HTTP_OK, self.jwks(), headers)
 
     async def _handle_token(self, receive: ASGIReceive, send: ASGISend) -> None:
+        self.stats.token += 1
         if self.controls.token_status != HTTP_OK:
             await self._send_status(send, self.controls.token_status)
             return
@@ -414,9 +457,19 @@ class MockOP:
         await self._send_json(send, HTTP_OK, self.mint_access_token(scopes=scope))
 
     async def _handle_introspect(self, receive: ASGIReceive, send: ASGISend) -> None:
+        self.stats.introspect += 1
         form = parse_qs((await _read_body(receive)).decode())
         token = form.get("token", [""])[0]
         await self._send_json(send, HTTP_OK, self.introspect(token))
+
+    async def _handle_stats(self, _receive: ASGIReceive, send: ASGISend) -> None:
+        """Read the per-path upstream-request counters (design §5)."""
+        await self._send_json(send, HTTP_OK, self.stats.snapshot())
+
+    async def _handle_stats_reset(self, _receive: ASGIReceive, send: ASGISend) -> None:
+        """Zero the per-path counters, returning the (now-zero) snapshot."""
+        self.stats.reset()
+        await self._send_json(send, HTTP_OK, {"ok": True, **self.stats.snapshot()})
 
     async def _handle_control(self, receive: ASGIReceive, send: ASGISend) -> None:
         """Out-of-process control endpoint for the uvicorn-booted case (T311).

--- a/src/tests/harness/mock_op_server.py
+++ b/src/tests/harness/mock_op_server.py
@@ -34,6 +34,30 @@ if TYPE_CHECKING:
 
 
 _READY_POLL_INTERVAL = 0.05
+_SHUTDOWN_TIMEOUT = 10.0
+
+
+class _ServerThread(threading.Thread):
+    """Run ``uvicorn.Server.run`` and remember any startup exception.
+
+    ``server.run()`` raising inside a bare daemon thread is otherwise silently
+    swallowed: the thread just dies and the readiness poll blocks for the full
+    ``timeout`` before failing with an opaque message. Capturing the exception
+    (and exposing liveness) lets the poll fail fast with the real cause, the way
+    the sibling subprocess boot fails fast on ``proc.poll()`` (blind/edge
+    SHOULD-FIX).
+    """
+
+    def __init__(self, server: object) -> None:
+        super().__init__(daemon=True)
+        self._server = server
+        self.error: BaseException | None = None
+
+    def run(self) -> None:
+        try:
+            self._server.run()  # type: ignore[attr-defined]
+        except BaseException as exc:
+            self.error = exc
 
 
 @contextlib.contextmanager
@@ -80,20 +104,38 @@ def serve_mock_op(
         interface="asgi3",
     )
     server = uvicorn.Server(config)
-    thread = threading.Thread(target=server.run, daemon=True)
+    thread = _ServerThread(server)
     thread.start()
     try:
-        _wait_for_discovery(op.discovery_url, timeout)
+        _wait_for_discovery(thread, op.discovery_url, timeout)
         yield op
     finally:
         server.should_exit = True
-        thread.join(timeout)
+        thread.join(_SHUTDOWN_TIMEOUT)
+        if thread.is_alive():
+            # The server never honoured ``should_exit`` within the shutdown
+            # grace. The daemon thread — still bound to the loopback port —
+            # leaks past the ``with`` block and can wedge the next
+            # ``serve_mock_op`` reusing the port range (blind SHOULD-FIX).
+            raise RuntimeError(
+                f"mock OP did not shut down within {_SHUTDOWN_TIMEOUT}s; "
+                f"the uvicorn thread is still bound to {op.discovery_url}"
+            )
 
 
-def _wait_for_discovery(discovery_url: str, timeout: float) -> None:
+def _wait_for_discovery(
+    thread: _ServerThread, discovery_url: str, timeout: float
+) -> None:
     deadline = time.monotonic() + timeout
     last_error = "no attempt made"
     while time.monotonic() < deadline:
+        if not thread.is_alive():
+            # The uvicorn thread died during startup (bind refused, port TOCTOU
+            # collision, ASGI misconfig). Surface the captured cause immediately
+            # instead of polling the full timeout (edge [DEGRADED]).
+            raise RuntimeError(
+                f"mock OP uvicorn thread died during startup (last: {last_error})"
+            ) from thread.error
         try:
             response = httpx.get(discovery_url, timeout=2.0)
             if response.status_code == httpx.codes.OK:

--- a/src/tests/harness/mock_op_server.py
+++ b/src/tests/harness/mock_op_server.py
@@ -1,0 +1,107 @@
+"""Serve the framework-free :class:`~mock_op.MockOP` over real localhost HTTP.
+
+The RS boot (:func:`~rs_server.boot_rs`) launches uvicorn as a *subprocess*, so
+it cannot reach an in-process ASGI mock OP — it fetches discovery + JWKS over
+real HTTP. This helper runs the mock OP on a real loopback port so the booted RS
+can validate against it.
+
+The mock OP must run **in-process** (a uvicorn thread, not a subprocess): the
+forged corpus (:func:`~corpus.build_corpus`) is keyed to the *same* ``MockOP``
+instance's signing key, and a subprocess mock OP would re-import a fresh random
+key, breaking every forgery.
+
+``import uvicorn`` is deferred into the function so that plain unit-env
+collection of importers does not fail (uvicorn is not a root test dependency).
+This module is excluded from the root pyrefly lint env for the same reason
+(see ``[tool.pyrefly] project_excludes`` in ``pyproject.toml``).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+import time
+from typing import TYPE_CHECKING
+
+import httpx
+
+from .mock_op import MockOP, MockOPControls
+from .rs_server import _free_port
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+_READY_POLL_INTERVAL = 0.05
+
+
+@contextlib.contextmanager
+def serve_mock_op(
+    *,
+    controls: MockOPControls | None = None,
+    timeout: float = 30.0,
+) -> Iterator[MockOP]:
+    """Serve a :class:`MockOP` over real localhost HTTP for the duration of the
+    ``with`` block.
+
+    Binds an ephemeral loopback port, builds a ``MockOP`` whose ``issuer`` is the
+    bound ``http://127.0.0.1:<port>`` (so its discovery ``issuer`` and the RS
+    ``iss`` check both match the URL the RS actually fetches), runs it under
+    ``uvicorn`` in a daemon thread, and polls its discovery endpoint until it
+    answers ``200``.
+
+    Args:
+        controls: Failure-injection knobs handed to the ``MockOP``.
+        timeout: Seconds to wait for the first successful discovery response.
+
+    Yields:
+        The live :class:`MockOP` instance (use ``op.discovery_url`` for the RS,
+        ``op.sign`` / :func:`~corpus.build_corpus` for forged tokens).
+    """
+    # Deferred so importing this module in the root env (where uvicorn is not
+    # installed) does not ImportError — only calling serve_mock_op needs it, and
+    # that path is only taken under `uv run --all-packages`.
+    import uvicorn  # noqa: PLC0415 — intentional in-function import, see above
+
+    port = _free_port()
+    op = MockOP(issuer=f"http://127.0.0.1:{port}", controls=controls)
+    # ``lifespan="off"``: the framework-free app needs no startup, and skipping
+    # lifespan avoids driving ``MockOP._handle_lifespan`` through uvicorn.
+    # ``interface="asgi3"``: ``op.app`` is a bare 3-arg ASGI callable (not a
+    # class), which uvicorn's auto-detection otherwise mistakes for the legacy
+    # 2-arg ASGI-2 factory and calls with a single ``scope`` argument.
+    config = uvicorn.Config(
+        op.app,
+        host="127.0.0.1",
+        port=port,
+        log_level="warning",
+        lifespan="off",
+        interface="asgi3",
+    )
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    try:
+        _wait_for_discovery(op.discovery_url, timeout)
+        yield op
+    finally:
+        server.should_exit = True
+        thread.join(timeout)
+
+
+def _wait_for_discovery(discovery_url: str, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    last_error = "no attempt made"
+    while time.monotonic() < deadline:
+        try:
+            response = httpx.get(discovery_url, timeout=2.0)
+            if response.status_code == httpx.codes.OK:
+                return
+            last_error = f"HTTP {response.status_code}"
+        except httpx.HTTPError as exc:
+            last_error = str(exc)
+        time.sleep(_READY_POLL_INTERVAL)
+    raise RuntimeError(
+        f"mock OP did not serve discovery within {timeout}s (last: {last_error})"
+    )

--- a/src/tests/harness/mock_op_server.py
+++ b/src/tests/harness/mock_op_server.py
@@ -19,6 +19,7 @@ This module is excluded from the root pyrefly lint env for the same reason
 from __future__ import annotations
 
 import contextlib
+import sys
 import threading
 import time
 from typing import TYPE_CHECKING
@@ -112,11 +113,15 @@ def serve_mock_op(
     finally:
         server.should_exit = True
         thread.join(_SHUTDOWN_TIMEOUT)
-        if thread.is_alive():
+        if thread.is_alive() and sys.exc_info()[0] is None:
             # The server never honoured ``should_exit`` within the shutdown
             # grace. The daemon thread — still bound to the loopback port —
             # leaks past the ``with`` block and can wedge the next
             # ``serve_mock_op`` reusing the port range (blind SHOULD-FIX).
+            # Only raise when the body did not already fail: a raise here would
+            # otherwise supersede the real test failure, demoting it to a
+            # chained ``__context__`` and misreporting a body assertion as a
+            # shutdown bug (delta SHOULD-FIX).
             raise RuntimeError(
                 f"mock OP did not shut down within {_SHUTDOWN_TIMEOUT}s; "
                 f"the uvicorn thread is still bound to {op.discovery_url}"
@@ -130,11 +135,13 @@ def _wait_for_discovery(
     last_error = "no attempt made"
     while time.monotonic() < deadline:
         if not thread.is_alive():
-            # The uvicorn thread died during startup (bind refused, port TOCTOU
-            # collision, ASGI misconfig). Surface the captured cause immediately
-            # instead of polling the full timeout (edge [DEGRADED]).
+            # The uvicorn thread exited before discovery answered — a crash
+            # (bind refused, port TOCTOU collision, ASGI misconfig) or an
+            # unexpected clean exit. Surface it immediately instead of polling
+            # the full timeout (edge [DEGRADED]); ``thread.error`` chains the
+            # captured cause when there was one, else is ``None`` (clean exit).
             raise RuntimeError(
-                f"mock OP uvicorn thread died during startup (last: {last_error})"
+                f"mock OP uvicorn thread exited during startup (last: {last_error})"
             ) from thread.error
         try:
             response = httpx.get(discovery_url, timeout=2.0)

--- a/src/tests/harness/rs_app.py
+++ b/src/tests/harness/rs_app.py
@@ -33,11 +33,16 @@ def _truthy(value: str | None) -> bool:
 
 def _excluded_paths() -> list[str] | None:
     """Parse ``RS_EXCLUDED_PATHS`` (comma-separated) or return ``None`` so the
-    middleware falls back to its own defaults (which include ``/health``)."""
+    middleware falls back to its own defaults (which include ``/health``).
+
+    An unset OR empty ``RS_EXCLUDED_PATHS`` both fall back to the middleware
+    defaults. An empty string (which is what ``boot_rs(excluded_paths=[])``
+    serializes to) must NOT be read as an explicit "exclude nothing" list —
+    that would drop the ``/health`` exclusion and break the readiness poll."""
     raw = os.environ.get("RS_EXCLUDED_PATHS")
-    if raw is None:
+    if not raw:
         return None
-    return [p for p in raw.split(",") if p]
+    return [p for p in raw.split(",") if p] or None
 
 
 def create_app() -> FastAPI:

--- a/src/tests/harness/rs_app.py
+++ b/src/tests/harness/rs_app.py
@@ -25,6 +25,16 @@ from fastapi_identity_model import (
     TokenValidationMiddleware,
     require_scope,
 )
+from py_identity_model.core.cache_metrics import get_cache_counters
+
+
+# Mirrors ``fastapi_identity_model.config._default_excluded_paths`` — materialised
+# here so ``/metrics`` can be appended to the exclusion set without dropping the
+# health/docs excludes the middleware would otherwise apply.
+_DEFAULT_EXCLUDED_PATHS = ["/docs", "/openapi.json", "/health"]
+# Unauthenticated cache-counter readout for the load/soak harness (T311). Must be
+# excluded from token validation so the driver can scrape it without a token.
+_METRICS_PATH = "/metrics"
 
 
 def _truthy(value: str | None) -> bool:
@@ -57,12 +67,19 @@ def create_app() -> FastAPI:
     audience = os.environ["RS_AUDIENCE"]
     required_scope = os.environ.get("RS_REQUIRE_SCOPE", "api")
 
+    # Materialise the exclusion set (defaults or the RS_EXCLUDED_PATHS override)
+    # and always append ``/metrics`` — an unauthenticated readout the load driver
+    # scrapes, which must never require a token regardless of the override.
+    excluded = _excluded_paths() or list(_DEFAULT_EXCLUDED_PATHS)
+    if _METRICS_PATH not in excluded:
+        excluded.append(_METRICS_PATH)
+
     app = FastAPI(title="token-harness-rs")
     app.add_middleware(
         TokenValidationMiddleware,
         discovery_url=discovery_url,
         audience=audience,
-        excluded_paths=_excluded_paths(),
+        excluded_paths=excluded,
         require_access_token_marker=_truthy(
             os.environ.get("RS_REQUIRE_ACCESS_TOKEN_MARKER")
         ),
@@ -72,6 +89,14 @@ def create_app() -> FastAPI:
     def health() -> dict:
         # Excluded from auth (middleware default) — the readiness probe target.
         return {"status": "ok"}
+
+    @app.get("/metrics")
+    def metrics() -> dict:
+        # Excluded from auth — per-process cache hit/miss/refresh counters
+        # (T299). The load harness scrapes this at ``workers=1`` for an exact
+        # cache-hit rate; across ``--workers N`` each worker keeps its own
+        # counters, so aggregate the per-worker snapshots externally.
+        return get_cache_counters().snapshot()
 
     @app.get("/protected", dependencies=[Depends(require_scope(required_scope))])
     def protected(claims: Claims) -> dict:

--- a/src/tests/harness/rs_app.py
+++ b/src/tests/harness/rs_app.py
@@ -25,13 +25,14 @@ from fastapi_identity_model import (
     TokenValidationMiddleware,
     require_scope,
 )
+from fastapi_identity_model.config import _default_excluded_paths
 from py_identity_model.core.cache_metrics import get_cache_counters
 
 
-# Mirrors ``fastapi_identity_model.config._default_excluded_paths`` — materialised
-# here so ``/metrics`` can be appended to the exclusion set without dropping the
-# health/docs excludes the middleware would otherwise apply.
-_DEFAULT_EXCLUDED_PATHS = ["/docs", "/openapi.json", "/health"]
+# The middleware's own default exclusion set, reused (not re-listed) so this
+# harness cannot silently drift from the package if that default ever changes —
+# we materialise it only so ``/metrics`` can be appended without dropping the
+# health/docs excludes the middleware would otherwise apply on its own.
 # Unauthenticated cache-counter readout for the load/soak harness (T311). Must be
 # excluded from token validation so the driver can scrape it without a token.
 _METRICS_PATH = "/metrics"
@@ -70,7 +71,7 @@ def create_app() -> FastAPI:
     # Materialise the exclusion set (defaults or the RS_EXCLUDED_PATHS override)
     # and always append ``/metrics`` — an unauthenticated readout the load driver
     # scrapes, which must never require a token regardless of the override.
-    excluded = _excluded_paths() or list(_DEFAULT_EXCLUDED_PATHS)
+    excluded = _excluded_paths() or _default_excluded_paths()
     if _METRICS_PATH not in excluded:
         excluded.append(_METRICS_PATH)
 

--- a/src/tests/harness/rs_app.py
+++ b/src/tests/harness/rs_app.py
@@ -1,0 +1,90 @@
+"""Greenfield FastAPI resource server for the token-blaster harness (TH-1.2).
+
+A minimal RS that mounts ``TokenValidationMiddleware`` and guards routes with
+``require_scope``. All configuration comes from ``RS_*`` environment variables
+so uvicorn ``--workers N`` forked workers each re-import this module and rebuild
+an identical app (the workers are forked *after* import-string resolution, so
+they cannot share a closure — only the env).
+
+This is the ONLY harness module that imports FastAPI / fastapi-identity-model.
+It is excluded from the root pyrefly lint env (see ``[tool.pyrefly]
+project_excludes`` in ``pyproject.toml``) because that env installs only
+py-identity-model and cannot resolve the fastapi stack; it is exercised via
+``make test-harness-rs`` under ``uv run --all-packages``.
+"""
+
+from __future__ import annotations
+
+import os
+
+from fastapi import Depends, FastAPI
+
+from fastapi_identity_model import (
+    Claims,
+    CurrentUser,
+    TokenValidationMiddleware,
+    require_scope,
+)
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _excluded_paths() -> list[str] | None:
+    """Parse ``RS_EXCLUDED_PATHS`` (comma-separated) or return ``None`` so the
+    middleware falls back to its own defaults (which include ``/health``)."""
+    raw = os.environ.get("RS_EXCLUDED_PATHS")
+    if raw is None:
+        return None
+    return [p for p in raw.split(",") if p]
+
+
+def create_app() -> FastAPI:
+    """Build the resource-server app from ``RS_*`` env config.
+
+    Required env: ``RS_DISCOVERY_URL``, ``RS_AUDIENCE``.
+    Optional env: ``RS_REQUIRE_SCOPE`` (default ``api``),
+    ``RS_REQUIRE_ACCESS_TOKEN_MARKER`` (bool, F-07 opt-in),
+    ``RS_EXCLUDED_PATHS`` (comma-separated).
+    """
+    discovery_url = os.environ["RS_DISCOVERY_URL"]
+    audience = os.environ["RS_AUDIENCE"]
+    required_scope = os.environ.get("RS_REQUIRE_SCOPE", "api")
+
+    app = FastAPI(title="token-harness-rs")
+    app.add_middleware(
+        TokenValidationMiddleware,
+        discovery_url=discovery_url,
+        audience=audience,
+        excluded_paths=_excluded_paths(),
+        require_access_token_marker=_truthy(
+            os.environ.get("RS_REQUIRE_ACCESS_TOKEN_MARKER")
+        ),
+    )
+
+    @app.get("/health")
+    def health() -> dict:
+        # Excluded from auth (middleware default) — the readiness probe target.
+        return {"status": "ok"}
+
+    @app.get("/protected", dependencies=[Depends(require_scope(required_scope))])
+    def protected(claims: Claims) -> dict:
+        # Reached only after the middleware validated the token AND the token
+        # carries ``required_scope`` (else require_scope raises 403).
+        return {
+            "sub": claims.get("sub"),
+            "scope": claims.get("scope") or claims.get("scp"),
+        }
+
+    @app.get("/whoami")
+    def whoami(user: CurrentUser) -> dict:
+        identity = user.identity
+        return {"name": identity.name if identity is not None else None}
+
+    return app
+
+
+# Module-level app so uvicorn can boot it by import string
+# (``src.tests.harness.rs_app:app``) and forked workers re-import identically.
+app = create_app()

--- a/src/tests/harness/rs_server.py
+++ b/src/tests/harness/rs_server.py
@@ -87,7 +87,7 @@ def _wait_for_health(
 
 
 @contextlib.contextmanager
-def boot_rs(  # noqa: PLR0913 — each RS knob (issuer/audience/scope/workers/...) is an explicit keyword
+def boot_rs(
     *,
     discovery_url: str,
     audience: str,

--- a/src/tests/harness/rs_server.py
+++ b/src/tests/harness/rs_server.py
@@ -15,8 +15,9 @@ from pathlib import Path
 import socket
 import subprocess
 import sys
+import tempfile
 import time
-from typing import TYPE_CHECKING
+from typing import IO, TYPE_CHECKING
 
 import httpx
 
@@ -43,12 +44,23 @@ def _free_port() -> int:
         return int(sock.getsockname()[1])
 
 
-def _drain(proc: subprocess.Popen[str]) -> str:
-    return proc.stdout.read() if proc.stdout is not None else ""
+def _drain(log: IO[str]) -> str:
+    """Return everything uvicorn has written to its capture file so far.
+
+    Reading from a seekable temp file (not a live PIPE) never blocks: the child
+    writes to its own inherited fd and we snapshot from position 0. This also
+    means the child can emit an arbitrarily large traceback without filling an
+    OS pipe buffer and deadlocking on ``write()`` (blind/edge SHOULD-FIX).
+    """
+    try:
+        log.seek(0)
+        return log.read()
+    except (OSError, ValueError):  # pragma: no cover - defensive, file closed
+        return ""
 
 
 def _wait_for_health(
-    proc: subprocess.Popen[str], base_url: str, timeout: float
+    proc: subprocess.Popen[str], log: IO[str], base_url: str, timeout: float
 ) -> None:
     deadline = time.monotonic() + timeout
     last_error = "no attempt made"
@@ -56,7 +68,7 @@ def _wait_for_health(
         if proc.poll() is not None:
             raise RuntimeError(
                 f"uvicorn exited before becoming healthy "
-                f"(code {proc.returncode}):\n{_drain(proc)}"
+                f"(code {proc.returncode}):\n{_drain(log)}"
             )
         try:
             response = httpx.get(f"{base_url}/health", timeout=2.0)
@@ -70,7 +82,7 @@ def _wait_for_health(
     proc.terminate()
     raise RuntimeError(
         f"resource server did not become healthy within {timeout}s "
-        f"(last: {last_error}):\n{_drain(proc)}"
+        f"(last: {last_error}):\n{_drain(log)}"
     )
 
 
@@ -117,40 +129,46 @@ def boot_rs(  # noqa: PLR0913 — each RS knob (issuer/audience/scope/workers/..
     if extra_env:
         env.update(extra_env)
 
-    proc = subprocess.Popen(  # noqa: S603 — fixed argv, no shell, test-only
-        [
-            sys.executable,
-            "-m",
-            "uvicorn",
-            "src.tests.harness.rs_app:app",
-            "--host",
-            "127.0.0.1",
-            "--port",
-            str(port),
-            "--workers",
-            str(workers),
-            "--log-level",
-            "warning",
-        ],
-        cwd=str(_REPO_ROOT),
-        env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-    )
-    try:
-        _wait_for_health(proc, base_url, timeout)
-        yield base_url
-    finally:
-        proc.terminate()
+    # Capture uvicorn output to a seekable temp file rather than a PIPE. A PIPE
+    # is only drained on the failure path, so a healthy-but-chatty worker could
+    # fill the ~64KB OS pipe buffer and block on ``write()``, hanging the server
+    # (blind/edge SHOULD-FIX). A temp file has no such backpressure and reading
+    # it back on failure never blocks. ``TemporaryFile`` also unlinks itself on
+    # close, so there is no lingering fd for the GC to ResourceWarning over.
+    with tempfile.TemporaryFile(mode="w+") as log:
+        proc = subprocess.Popen(  # noqa: S603 — fixed argv, no shell, test-only
+            [
+                sys.executable,
+                "-m",
+                "uvicorn",
+                "src.tests.harness.rs_app:app",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(port),
+                "--workers",
+                str(workers),
+                "--log-level",
+                "warning",
+            ],
+            cwd=str(_REPO_ROOT),
+            env=env,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
         try:
-            proc.wait(timeout=_TERMINATE_GRACE)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            proc.wait(timeout=_TERMINATE_GRACE)
+            _wait_for_health(proc, log, base_url, timeout)
+            yield base_url
         finally:
-            # Close the inherited stdout pipe explicitly. Leaving it to the GC
-            # raises ResourceWarning, which pytest's ``filterwarnings=error``
-            # promotes to an unraisable-exception failure in a later test.
-            if proc.stdout is not None:
-                proc.stdout.close()
+            proc.terminate()
+            try:
+                proc.wait(timeout=_TERMINATE_GRACE)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                # A SIGKILL'd process stuck in uninterruptible I/O may still not
+                # reap within the grace window. Swallow the second timeout so
+                # teardown never raises out of ``finally`` and masks the real
+                # test result (edge [CRASH]).
+                with contextlib.suppress(subprocess.TimeoutExpired):
+                    proc.wait(timeout=_TERMINATE_GRACE)

--- a/src/tests/harness/rs_server.py
+++ b/src/tests/harness/rs_server.py
@@ -1,0 +1,150 @@
+"""Boot the harness resource server (:mod:`rs_app`) under real uvicorn workers.
+
+``boot_rs`` is deliberately free of any FastAPI / fastapi-identity-model import
+so it stays inside the root pyrefly lint env. It launches uvicorn as a
+subprocess by import-string (``src.tests.harness.rs_app:app``), passes RS
+configuration through inherited ``RS_*`` environment variables, waits for the
+``/health`` endpoint to answer over real HTTP, then tears the process down.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from pathlib import Path
+import socket
+import subprocess
+import sys
+import time
+from typing import TYPE_CHECKING
+
+import httpx
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Mapping
+
+
+# src/tests/harness/rs_server.py -> parents[3] is the repo root (holds ``src/``).
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_HEALTH_POLL_INTERVAL = 0.25
+_TERMINATE_GRACE = 10.0
+
+
+def _free_port() -> int:
+    """Bind to an ephemeral port, then release it for uvicorn to reuse.
+
+    A TOCTOU window exists between close and re-bind; the ``/health`` readiness
+    poll (which fails loudly if uvicorn never binds) is the real guard.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _drain(proc: subprocess.Popen[str]) -> str:
+    return proc.stdout.read() if proc.stdout is not None else ""
+
+
+def _wait_for_health(
+    proc: subprocess.Popen[str], base_url: str, timeout: float
+) -> None:
+    deadline = time.monotonic() + timeout
+    last_error = "no attempt made"
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(
+                f"uvicorn exited before becoming healthy "
+                f"(code {proc.returncode}):\n{_drain(proc)}"
+            )
+        try:
+            response = httpx.get(f"{base_url}/health", timeout=2.0)
+            if response.status_code == httpx.codes.OK:
+                return
+            last_error = f"HTTP {response.status_code}"
+        except httpx.HTTPError as exc:
+            last_error = str(exc)
+        time.sleep(_HEALTH_POLL_INTERVAL)
+
+    proc.terminate()
+    raise RuntimeError(
+        f"resource server did not become healthy within {timeout}s "
+        f"(last: {last_error}):\n{_drain(proc)}"
+    )
+
+
+@contextlib.contextmanager
+def boot_rs(  # noqa: PLR0913 — each RS knob (issuer/audience/scope/workers/...) is an explicit keyword
+    *,
+    discovery_url: str,
+    audience: str,
+    require_scope: str = "api",
+    workers: int = 1,
+    require_access_token_marker: bool = False,
+    excluded_paths: list[str] | None = None,
+    extra_env: Mapping[str, str] | None = None,
+    timeout: float = 30.0,
+) -> Iterator[str]:
+    """Boot a single-issuer resource server and yield its base URL.
+
+    Args:
+        discovery_url: OIDC discovery URL the middleware binds to.
+        audience: Expected ``aud`` claim (middleware requires non-empty).
+        require_scope: Scope enforced on ``/protected`` (403 if absent).
+        workers: uvicorn ``--workers`` count (>=2 proves multi-worker boot).
+        require_access_token_marker: F-07 ID-token-substitution defence opt-in.
+        excluded_paths: Override middleware excluded paths (must keep
+            ``/health`` for the readiness poll to pass).
+        extra_env: Additional environment for the uvicorn subprocess.
+        timeout: Seconds to wait for the first healthy ``/health`` response.
+
+    Yields:
+        The ``http://127.0.0.1:<port>`` base URL of the running server.
+    """
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+
+    env = dict(os.environ)
+    env["RS_DISCOVERY_URL"] = discovery_url
+    env["RS_AUDIENCE"] = audience
+    env["RS_REQUIRE_SCOPE"] = require_scope
+    env["RS_REQUIRE_ACCESS_TOKEN_MARKER"] = (
+        "true" if require_access_token_marker else "false"
+    )
+    if excluded_paths is not None:
+        env["RS_EXCLUDED_PATHS"] = ",".join(excluded_paths)
+    if extra_env:
+        env.update(extra_env)
+
+    proc = subprocess.Popen(  # noqa: S603 — fixed argv, no shell, test-only
+        [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            "src.tests.harness.rs_app:app",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--workers",
+            str(workers),
+            "--log-level",
+            "warning",
+        ],
+        cwd=str(_REPO_ROOT),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        _wait_for_health(proc, base_url, timeout)
+        yield base_url
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=_TERMINATE_GRACE)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=_TERMINATE_GRACE)

--- a/src/tests/harness/rs_server.py
+++ b/src/tests/harness/rs_server.py
@@ -148,3 +148,9 @@ def boot_rs(  # noqa: PLR0913 — each RS knob (issuer/audience/scope/workers/..
         except subprocess.TimeoutExpired:
             proc.kill()
             proc.wait(timeout=_TERMINATE_GRACE)
+        finally:
+            # Close the inherited stdout pipe explicitly. Leaving it to the GC
+            # raises ResourceWarning, which pytest's ``filterwarnings=error``
+            # promotes to an unraisable-exception failure in a later test.
+            if proc.stdout is not None:
+                proc.stdout.close()

--- a/src/tests/harness/token_source.py
+++ b/src/tests/harness/token_source.py
@@ -1,0 +1,462 @@
+"""Unified multi-provider ``TokenSource`` minter for the harness (TH-1.1, #463).
+
+One :meth:`TokenSource.mint` call unifies what the integration ``conftest``
+previously spread across ``client_credentials_token``, ``jwt_access_token``,
+``opaque_access_token`` and the ``auth_code_result`` helpers, plus the
+Descope-shaped multi-tenant minter — capability/credential-gated exactly like
+``provider_matrix.detect_capabilities``.
+
+* Real providers (node-oidc, Keycloak, Ory, Descope) mint through the library's
+  own token logic (``request_client_credentials_token`` / an injected auth-code
+  minter) — never reimplemented.
+* The ``MOCK`` provider mints valid tokens and, via ``malform=``, the forged
+  corpus (:mod:`corpus`) off the controllable mock OP (:mod:`mock_op`).
+
+Gating raises typed errors (:class:`HarnessCapabilityError` /
+:class:`HarnessCredentialError`) that the ``conftest`` fixture translates to
+``pytest.skip`` — so Ory/Descope skip cleanly when secret-gated, while ``MOCK``
+is always available.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import StrEnum
+import json
+import time
+from typing import TYPE_CHECKING, Any
+
+from py_identity_model import (
+    ClientCredentialsTokenRequest,
+    request_client_credentials_token,
+)
+
+from ..integration.provider_matrix import detect_capabilities
+from .corpus import build_corpus
+from .mock_op import MockOP
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+JWT_SEGMENT_SEPARATOR_COUNT = 2
+
+
+class Provider(StrEnum):
+    """Identity providers the harness can mint against."""
+
+    NODE_OIDC = "node-oidc"
+    KEYCLOAK = "keycloak"
+    ORY = "ory"
+    DESCOPE = "descope"
+    MOCK = "mock"
+
+
+class Grant(StrEnum):
+    """OAuth grant types the minter understands."""
+
+    CLIENT_CREDENTIALS = "client_credentials"
+    AUTHORIZATION_CODE = "authorization_code"
+    REFRESH_TOKEN = "refresh_token"
+    DEVICE_CODE = "device_code"
+
+
+class Malform(StrEnum):
+    """Forged-token classes (MOCK provider only)."""
+
+    VALID = "valid"
+    EXPIRED = "expired"
+    NBF_FUTURE = "nbf_future"
+    WRONG_ISS = "wrong_iss"
+    WRONG_AUD = "wrong_aud"
+    TAMPERED_SIG = "tampered_sig"
+    UNKNOWN_KID = "unknown_kid"
+    WRONG_ALG = "wrong_alg"
+    ALG_NONE = "alg_none"
+    ID_AS_ACCESS = "id_as_access"
+    CNF_BOUND = "cnf_bound"
+    OVERSIZED = "oversized"
+    MULTI_AUD_UNTRUSTED = "multi_aud_untrusted"
+
+
+# Grant -> provider_matrix capability key.
+_GRANT_CAPABILITY: dict[Grant, str] = {
+    Grant.CLIENT_CREDENTIALS: "client_credentials",
+    Grant.AUTHORIZATION_CODE: "authorization_code",
+    Grant.REFRESH_TOKEN: "refresh_token",
+    Grant.DEVICE_CODE: "device_authorization",
+}
+
+
+class HarnessError(Exception):
+    """Base class for token-harness errors."""
+
+
+class HarnessCapabilityError(HarnessError):
+    """The provider does not advertise the requested grant/capability."""
+
+
+class HarnessCredentialError(HarnessError):
+    """The provider supports the grant but the required credentials are absent."""
+
+
+@dataclass(frozen=True)
+class MintedToken:
+    """The result of a mint — a replayable token plus its provenance."""
+
+    access_token: str
+    provider: Provider
+    grant: Grant
+    token_type: str = "Bearer"
+    id_token: str | None = None
+    expires_at: float | None = None
+    tenant: str | None = None
+    alg: str | None = None
+    kid: str | None = None
+    malform: Malform | None = None
+
+    def is_expired(self, *, now: float | None = None, leeway: float = 0.0) -> bool:
+        """Whether the token is past its expiry (for T311 re-mint cadence)."""
+        if self.expires_at is None:
+            return False
+        return (now if now is not None else time.time()) >= self.expires_at - leeway
+
+
+# An auth-code minter returns an OAuth token-response dict (``access_token`` …),
+# letting the conftest inject ``perform_auth_code_flow`` without this module
+# importing pytest.
+AuthCodeMinter = Callable[[str | None, str | None], dict[str, Any]]
+
+
+@dataclass
+class ProviderConfig:
+    """Per-provider configuration and capabilities for the minter."""
+
+    provider: Provider
+    capabilities: set[str] = field(default_factory=set)
+    token_endpoint: str | None = None
+    client_id: str | None = None
+    client_secret: str | None = None
+    scope: str | None = None
+    mock_op: MockOP | None = None
+    auth_code_minter: AuthCodeMinter | None = None
+
+    @classmethod
+    def from_discovery(
+        cls,
+        provider: Provider,
+        raw_discovery: dict[str, Any],
+        *,
+        token_endpoint: str | None = None,
+        client_id: str | None = None,
+        client_secret: str | None = None,
+        scope: str | None = None,
+        auth_code_minter: AuthCodeMinter | None = None,
+    ) -> ProviderConfig:
+        """Build a real-provider config, deriving capabilities from discovery.
+
+        Reuses ``provider_matrix.detect_capabilities`` so the harness and the
+        capability matrix never drift.
+        """
+        caps = {name for name, ok in detect_capabilities(raw_discovery).items() if ok}
+        return cls(
+            provider=provider,
+            capabilities=caps,
+            token_endpoint=token_endpoint or raw_discovery.get("token_endpoint"),
+            client_id=client_id,
+            client_secret=client_secret,
+            scope=scope,
+            auth_code_minter=auth_code_minter,
+        )
+
+
+class TokenSource:
+    """The unified minter. One :meth:`mint` for every provider/grant/forgery."""
+
+    def __init__(self, configs: Iterable[ProviderConfig]) -> None:
+        self._configs: dict[Provider, ProviderConfig] = {
+            cfg.provider: cfg for cfg in configs
+        }
+
+    @classmethod
+    def with_mock(
+        cls, mock_op: MockOP | None = None, *, extra: Iterable[ProviderConfig] = ()
+    ) -> TokenSource:
+        """Convenience builder wiring a ``MOCK`` provider (always mintable)."""
+        mock = mock_op or MockOP()
+        mock_cfg = ProviderConfig(
+            provider=Provider.MOCK,
+            capabilities={_GRANT_CAPABILITY[g] for g in Grant},
+            mock_op=mock,
+        )
+        return cls([mock_cfg, *extra])
+
+    @property
+    def providers(self) -> list[Provider]:
+        return list(self._configs)
+
+    def config(self, provider: Provider) -> ProviderConfig:
+        try:
+            return self._configs[provider]
+        except KeyError:
+            raise HarnessCapabilityError(
+                f"provider {provider.value} is not configured in this TokenSource"
+            ) from None
+
+    def mint(
+        self,
+        provider: Provider,
+        grant: Grant = Grant.CLIENT_CREDENTIALS,
+        *,
+        tenant: str | None = None,
+        scopes: str | None = None,
+        malform: Malform | None = None,
+    ) -> MintedToken:
+        """Mint a token.
+
+        Args:
+            provider: The provider to mint against.
+            grant: The grant type (``client_credentials`` by default).
+            tenant: Optional tenant, shaping Descope-style multi-tenant claims.
+            scopes: Space-delimited scopes.
+            malform: A forged class — MOCK-only; raises
+                :class:`HarnessCapabilityError` for any real provider.
+
+        Raises:
+            HarnessCapabilityError: provider/grant/forgery unsupported.
+            HarnessCredentialError: grant supported but credentials absent.
+        """
+        cfg = self.config(provider)
+        if malform is not None:
+            return self._mint_forged(cfg, grant, tenant, malform)
+        if provider is Provider.MOCK:
+            return self._mint_mock_valid(cfg, grant, tenant, scopes)
+        self._check_capability(cfg, grant)
+        self._check_credentials(cfg, grant)
+        if grant is Grant.CLIENT_CREDENTIALS:
+            return self._mint_client_credentials(cfg, tenant, scopes)
+        if grant is Grant.AUTHORIZATION_CODE:
+            return self._mint_auth_code(cfg, tenant, scopes)
+        raise HarnessCapabilityError(
+            f"grant {grant.value} is not implemented for provider {provider.value}"
+        )
+
+    # -- Gating -------------------------------------------------------------
+
+    def _check_capability(self, cfg: ProviderConfig, grant: Grant) -> None:
+        capability = _GRANT_CAPABILITY[grant]
+        if capability not in cfg.capabilities:
+            raise HarnessCapabilityError(
+                f"{cfg.provider.value} does not advertise {capability} "
+                f"(grant {grant.value})"
+            )
+
+    def _check_credentials(self, cfg: ProviderConfig, grant: Grant) -> None:
+        if grant is Grant.CLIENT_CREDENTIALS:
+            if not (cfg.client_id and cfg.client_secret and cfg.token_endpoint):
+                raise HarnessCredentialError(
+                    f"{cfg.provider.value}: client_credentials requires "
+                    f"client_id, client_secret and a token endpoint"
+                )
+        elif grant is Grant.AUTHORIZATION_CODE and cfg.auth_code_minter is None:
+            raise HarnessCredentialError(
+                f"{cfg.provider.value}: no auth-code minter configured"
+            )
+
+    # -- Real-provider mints ------------------------------------------------
+
+    def _mint_client_credentials(
+        self, cfg: ProviderConfig, tenant: str | None, scopes: str | None
+    ) -> MintedToken:
+        assert cfg.token_endpoint
+        assert cfg.client_id
+        assert cfg.client_secret
+        response = request_client_credentials_token(
+            ClientCredentialsTokenRequest(
+                client_id=cfg.client_id,
+                client_secret=cfg.client_secret,
+                address=cfg.token_endpoint,
+                scope=scopes or cfg.scope,
+            )
+        )
+        if not response.is_successful:
+            raise HarnessError(
+                f"{cfg.provider.value}: client_credentials mint failed: "
+                f"{response.error}"
+            )
+        assert response.token is not None
+        return self._from_token_response(
+            cfg.provider, Grant.CLIENT_CREDENTIALS, response.token, tenant
+        )
+
+    def _mint_auth_code(
+        self, cfg: ProviderConfig, tenant: str | None, scopes: str | None
+    ) -> MintedToken:
+        assert cfg.auth_code_minter is not None
+        token = cfg.auth_code_minter(tenant, scopes)
+        return self._from_token_response(
+            cfg.provider, Grant.AUTHORIZATION_CODE, token, tenant
+        )
+
+    def _from_token_response(
+        self,
+        provider: Provider,
+        grant: Grant,
+        token: dict[str, Any],
+        tenant: str | None,
+    ) -> MintedToken:
+        access_token = token["access_token"]
+        expires_in = token.get("expires_in")
+        expires_at = time.time() + expires_in if expires_in else None
+        alg, kid = _peek_jwt_header(access_token)
+        return MintedToken(
+            access_token=access_token,
+            provider=provider,
+            grant=grant,
+            token_type=token.get("token_type", "Bearer"),
+            id_token=token.get("id_token"),
+            expires_at=expires_at,
+            tenant=tenant,
+            alg=alg,
+            kid=kid,
+        )
+
+    # -- MOCK mints ---------------------------------------------------------
+
+    def _mint_mock_valid(
+        self,
+        cfg: ProviderConfig,
+        grant: Grant,
+        tenant: str | None,
+        scopes: str | None,
+    ) -> MintedToken:
+        mock = self._require_mock(cfg)
+        token = mock.mint_access_token(scopes=scopes, tenant=tenant)
+        return MintedToken(
+            access_token=token["access_token"],
+            provider=Provider.MOCK,
+            grant=grant,
+            token_type=token["token_type"],
+            expires_at=time.time() + token["expires_in"],
+            tenant=tenant,
+            alg=mock.signing_key.alg,
+            kid=mock.signing_key.kid,
+            malform=Malform.VALID,
+        )
+
+    def _mint_forged(
+        self,
+        cfg: ProviderConfig,
+        grant: Grant,
+        tenant: str | None,
+        malform: Malform,
+    ) -> MintedToken:
+        if cfg.provider is not Provider.MOCK:
+            raise HarnessCapabilityError(
+                "forged tokens are only available from the MOCK provider "
+                "(real OPs will not emit invalid tokens)"
+            )
+        mock = self._require_mock(cfg)
+        forged = build_corpus(mock)[malform.value]
+        return MintedToken(
+            access_token=forged.jwt,
+            provider=Provider.MOCK,
+            grant=grant,
+            tenant=tenant,
+            malform=malform,
+        )
+
+    def _require_mock(self, cfg: ProviderConfig) -> MockOP:
+        if cfg.mock_op is None:
+            raise HarnessCapabilityError("MOCK provider has no mock OP configured")
+        return cfg.mock_op
+
+
+def _peek_jwt_header(token: str) -> tuple[str | None, str | None]:
+    """Best-effort ``(alg, kid)`` from a compact JWT header; ``(None, None)``
+    for opaque tokens."""
+    if token.count(".") != JWT_SEGMENT_SEPARATOR_COUNT:
+        return None, None
+    header_segment = token.split(".", 1)[0]
+    padding = "=" * (-len(header_segment) % 4)
+    try:
+        header = json.loads(base64.urlsafe_b64decode(header_segment + padding))
+    except (ValueError, json.JSONDecodeError):
+        return None, None
+    return header.get("alg"), header.get("kid")
+
+
+# -- Replay pool ------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MintSpec:
+    """A single mint request for :func:`prime_pool`."""
+
+    provider: Provider
+    grant: Grant = Grant.CLIENT_CREDENTIALS
+    tenant: str | None = None
+    scopes: str | None = None
+    malform: Malform | None = None
+
+    def key(self) -> str:
+        parts = [
+            self.provider.value,
+            self.grant.value,
+            self.tenant or "-",
+            self.scopes or "-",
+            self.malform.value if self.malform else "-",
+        ]
+        return "|".join(parts)
+
+
+class ReplayPool:
+    """Pre-mint once, replay many (design §3).
+
+    Real IdPs rate-limit and validation is stateless, so the harness mints each
+    distinct spec a single time and replays the token. ``expires_at`` is tracked
+    so T311 can re-mint across the 300s TTL / classify post-expiry 401s as
+    expected rather than error-budget.
+    """
+
+    def __init__(self) -> None:
+        self._by_key: dict[str, MintedToken] = {}
+
+    def add(self, spec: MintSpec, token: MintedToken) -> None:
+        self._by_key[spec.key()] = token
+
+    def get(self, spec: MintSpec) -> MintedToken:
+        return self._by_key[spec.key()]
+
+    def all(self) -> list[MintedToken]:
+        return list(self._by_key.values())
+
+    def __len__(self) -> int:
+        return len(self._by_key)
+
+    def __iter__(self):
+        return iter(self._by_key.values())
+
+
+def prime_pool(source: TokenSource, specs: Iterable[MintSpec]) -> ReplayPool:
+    """Mint each spec once into a :class:`ReplayPool` (skips duplicate specs)."""
+    pool = ReplayPool()
+    seen: set[str] = set()
+    for spec in specs:
+        if spec.key() in seen:
+            continue
+        seen.add(spec.key())
+        pool.add(
+            spec,
+            source.mint(
+                spec.provider,
+                spec.grant,
+                tenant=spec.tenant,
+                scopes=spec.scopes,
+                malform=spec.malform,
+            ),
+        )
+    return pool

--- a/src/tests/harness/token_source.py
+++ b/src/tests/harness/token_source.py
@@ -462,11 +462,13 @@ def _descope_accesskey_exchange(
         data = created.json()
         key_id = data.get("key", {}).get("id", "")
         cleartext = data.get("cleartext", "")
+    # Once a key exists, the finally must delete it — even if ``cleartext`` is
+    # absent — so the raise lives inside the try, not before it.
+    try:
         if not cleartext:
             raise HarnessError(
                 f"descope access-key create returned no cleartext: {data}"
             )
-    try:
         with httpx.Client(timeout=_DESCOPE_HTTP_TIMEOUT) as client:
             exchanged = client.post(
                 f"{base}/v1/auth/accesskey/exchange",
@@ -482,15 +484,16 @@ def _descope_accesskey_exchange(
                 )
             return session_jwt
     finally:
-        with (
-            contextlib.suppress(Exception),
-            httpx.Client(timeout=_DESCOPE_HTTP_TIMEOUT) as client,
-        ):
-            client.post(
-                f"{base}/v1/mgmt/accesskey/delete",
-                headers=mgmt_headers,
-                json={"id": key_id},
-            )
+        if key_id:
+            with (
+                contextlib.suppress(Exception),
+                httpx.Client(timeout=_DESCOPE_HTTP_TIMEOUT) as client,
+            ):
+                client.post(
+                    f"{base}/v1/mgmt/accesskey/delete",
+                    headers=mgmt_headers,
+                    json={"id": key_id},
+                )
 
 
 def _peek_jwt_header(token: str) -> tuple[str | None, str | None]:

--- a/src/tests/harness/token_source.py
+++ b/src/tests/harness/token_source.py
@@ -22,11 +22,15 @@ from __future__ import annotations
 
 import base64
 from collections.abc import Callable
+import contextlib
 from dataclasses import dataclass, field
 from enum import StrEnum
 import json
 import time
 from typing import TYPE_CHECKING, Any
+import uuid
+
+import httpx
 
 from py_identity_model import (
     ClientCredentialsTokenRequest,
@@ -143,6 +147,12 @@ class ProviderConfig:
     scope: str | None = None
     mock_op: MockOP | None = None
     auth_code_minter: AuthCodeMinter | None = None
+    # Descope multi-tenant (access-key -> /v1/auth/accesskey/exchange) config.
+    # When present, ``mint(DESCOPE, tenant=…)`` produces a session JWT carrying
+    # distinct ``dct``/``tenants`` claims (AC-3); absent -> credential skip.
+    descope_project_id: str | None = None
+    descope_management_key: str | None = None
+    descope_base_url: str | None = None
 
     @classmethod
     def from_discovery(
@@ -155,6 +165,9 @@ class ProviderConfig:
         client_secret: str | None = None,
         scope: str | None = None,
         auth_code_minter: AuthCodeMinter | None = None,
+        descope_project_id: str | None = None,
+        descope_management_key: str | None = None,
+        descope_base_url: str | None = None,
     ) -> ProviderConfig:
         """Build a real-provider config, deriving capabilities from discovery.
 
@@ -170,6 +183,9 @@ class ProviderConfig:
             client_secret=client_secret,
             scope=scope,
             auth_code_minter=auth_code_minter,
+            descope_project_id=descope_project_id,
+            descope_management_key=descope_management_key,
+            descope_base_url=descope_base_url,
         )
 
 
@@ -234,6 +250,14 @@ class TokenSource:
             return self._mint_forged(cfg, grant, tenant, malform)
         if provider is Provider.MOCK:
             return self._mint_mock_valid(cfg, grant, tenant, scopes)
+        if (
+            provider is Provider.DESCOPE
+            and grant is Grant.CLIENT_CREDENTIALS
+            and tenant is not None
+        ):
+            # AC-3: the Descope multi-tenant path is the access-key -> session-JWT
+            # exchange (distinct dct/tenants), NOT the plain OIDC token endpoint.
+            return self._mint_descope_tenant(cfg, tenant)
         self._check_capability(cfg, grant)
         self._check_credentials(cfg, grant)
         if grant is Grant.CLIENT_CREDENTIALS:
@@ -299,6 +323,37 @@ class TokenSource:
         token = cfg.auth_code_minter(tenant, scopes)
         return self._from_token_response(
             cfg.provider, Grant.AUTHORIZATION_CODE, token, tenant
+        )
+
+    def _mint_descope_tenant(self, cfg: ProviderConfig, tenant: str) -> MintedToken:
+        """Reuse the identity-stack access-key -> session-JWT exchange (AC-3).
+
+        Creates a temporary tenant-scoped access key, exchanges it via
+        ``/v1/auth/accesskey/exchange`` for a Descope *session JWT* carrying
+        distinct ``dct``/``tenants`` claims, then deletes the key. Credential-
+        gated: absent Descope management config raises
+        :class:`HarnessCredentialError` (translated to ``pytest.skip``).
+        """
+        if not (
+            cfg.descope_project_id
+            and cfg.descope_management_key
+            and cfg.descope_base_url
+        ):
+            raise HarnessCredentialError(
+                "descope: multi-tenant mint requires descope_project_id, "
+                "descope_management_key and descope_base_url"
+            )
+        session_jwt = _descope_accesskey_exchange(
+            base_url=cfg.descope_base_url,
+            project_id=cfg.descope_project_id,
+            management_key=cfg.descope_management_key,
+            tenant=tenant,
+        )
+        return self._from_token_response(
+            Provider.DESCOPE,
+            Grant.CLIENT_CREDENTIALS,
+            {"access_token": session_jwt, "token_type": "Bearer"},
+            tenant,
         )
 
     def _from_token_response(
@@ -375,6 +430,69 @@ class TokenSource:
         return cfg.mock_op
 
 
+_DESCOPE_HTTP_TIMEOUT = 30.0
+
+
+def _descope_accesskey_exchange(
+    *,
+    base_url: str,
+    project_id: str,
+    management_key: str,
+    tenant: str,
+    roles: Iterable[str] = ("owner", "admin"),
+) -> str:
+    """Access-key create -> exchange -> delete, returning the session JWT.
+
+    Mirrors the identity-stack e2e minter: a ``keyTenants`` (array) access key
+    is required so the exchanged session JWT includes ``dct``/``tenants`` claims
+    (a top-level ``tenantId`` does not). The temporary key is deleted best-effort.
+    """
+    base = base_url.rstrip("/")
+    mgmt_headers = {"Authorization": f"Bearer {project_id}:{management_key}"}
+    with httpx.Client(timeout=_DESCOPE_HTTP_TIMEOUT) as client:
+        created = client.post(
+            f"{base}/v1/mgmt/accesskey/create",
+            headers=mgmt_headers,
+            json={
+                "name": f"harness-{uuid.uuid4().hex[:8]}",
+                "keyTenants": [{"tenantId": tenant, "roleNames": list(roles)}],
+            },
+        )
+        created.raise_for_status()
+        data = created.json()
+        key_id = data.get("key", {}).get("id", "")
+        cleartext = data.get("cleartext", "")
+        if not cleartext:
+            raise HarnessError(
+                f"descope access-key create returned no cleartext: {data}"
+            )
+    try:
+        with httpx.Client(timeout=_DESCOPE_HTTP_TIMEOUT) as client:
+            exchanged = client.post(
+                f"{base}/v1/auth/accesskey/exchange",
+                headers={"Authorization": f"Bearer {project_id}:{cleartext}"},
+                json={},
+            )
+            exchanged.raise_for_status()
+            session_jwt = exchanged.json().get("sessionJwt", "")
+            if not session_jwt:
+                raise HarnessError(
+                    f"descope access-key exchange returned no sessionJwt: "
+                    f"{exchanged.json()}"
+                )
+            return session_jwt
+    finally:
+        with (
+            contextlib.suppress(Exception),
+            httpx.Client(timeout=_DESCOPE_HTTP_TIMEOUT) as client,
+        ):
+            client.post(
+                f"{base}/v1/mgmt/accesskey/delete",
+                headers=mgmt_headers,
+                json={"id": key_id},
+            )
+
+
 def _peek_jwt_header(token: str) -> tuple[str | None, str | None]:
     """Best-effort ``(alg, kid)`` from a compact JWT header; ``(None, None)``
     for opaque tokens."""
@@ -385,6 +503,8 @@ def _peek_jwt_header(token: str) -> tuple[str | None, str | None]:
     try:
         header = json.loads(base64.urlsafe_b64decode(header_segment + padding))
     except (ValueError, json.JSONDecodeError):
+        return None, None
+    if not isinstance(header, dict):
         return None, None
     return header.get("alg"), header.get("kid")
 

--- a/src/tests/integration/.env.descope.example
+++ b/src/tests/integration/.env.descope.example
@@ -29,3 +29,12 @@ TEST_AUDIENCE=
 
 # Expired token for testing (generate a token and let it expire, or use an invalid token)
 TEST_EXPIRED_TOKEN=
+
+# Multi-tenant access-key exchange (TH-1.1 AC-3). When all four are set, the
+# harness TokenSource.mint(Provider.DESCOPE, tenant=…) reuses the identity-stack
+# access-key -> /v1/auth/accesskey/exchange flow to produce a session JWT
+# carrying distinct dct/tenants claims. Absent -> the multi-tenant test skips.
+DESCOPE_BASE_URL=https://api.descope.com
+DESCOPE_PROJECT_ID=
+DESCOPE_MANAGEMENT_KEY=
+DESCOPE_TEST_TENANT_ID=

--- a/src/tests/integration/README.md
+++ b/src/tests/integration/README.md
@@ -80,6 +80,15 @@ TEST_AUDIENCE=YOUR_PROJECT_ID
 
 # Optional: Generate an expired token for expiration tests
 TEST_EXPIRED_TOKEN=
+
+# Optional: Multi-tenant access-key exchange (harness TokenSource).
+# When all four are set, `TokenSource.mint(Provider.DESCOPE, tenant=…)` reuses
+# the access-key -> /v1/auth/accesskey/exchange flow to produce a session JWT
+# carrying distinct dct/tenants claims; absent, the multi-tenant test skips.
+DESCOPE_BASE_URL=https://api.descope.com
+DESCOPE_PROJECT_ID=
+DESCOPE_MANAGEMENT_KEY=
+DESCOPE_TEST_TENANT_ID=
 ```
 
 3. Load the environment variables:

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -705,6 +705,10 @@ def token_source(
         client_secret=test_config.get("TEST_CLIENT_SECRET"),
         scope=test_config.get("TEST_SCOPE"),
         auth_code_minter=auth_code_minter,
+        # Descope multi-tenant access-key exchange (AC-3); absent -> skip.
+        descope_project_id=test_config.get("DESCOPE_PROJECT_ID"),
+        descope_management_key=test_config.get("DESCOPE_MANAGEMENT_KEY"),
+        descope_base_url=test_config.get("DESCOPE_BASE_URL"),
     )
     return TokenSource.with_mock(extra=[real_cfg])
 

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -57,6 +57,12 @@ from py_identity_model.core.pkce import generate_pkce_pair
 from py_identity_model.exceptions import TokenValidationException
 from py_identity_model.sync.http_client import close_http_client
 
+from ..harness import (
+    HarnessError,
+    Provider,
+    ProviderConfig,
+    TokenSource,
+)
 from .test_utils import get_config
 
 
@@ -610,6 +616,97 @@ def opaque_access_token(
         access_token = response.token["access_token"]
         cache_file.write_text(json.dumps({"access_token": access_token}))
         return access_token
+
+
+# ============================================================================
+# Unified token-source harness (TH-1.1, #463)
+# ============================================================================
+
+# The provider slug (derived from the ``.env.<slug>`` file) maps onto the
+# harness ``Provider`` enum. An unrecognised slug (e.g. ``.env.local``) leaves
+# the real provider unwired, so only the always-available MOCK provider is
+# offered and the real-IdP tests skip cleanly.
+_SLUG_TO_PROVIDER: dict[str, Provider] = {
+    "node-oidc": Provider.NODE_OIDC,
+    "keycloak": Provider.KEYCLOAK,
+    "ory": Provider.ORY,
+    "descope": Provider.DESCOPE,
+}
+
+
+@pytest.fixture(scope="session")
+def harness_provider(provider_slug) -> Provider | None:
+    """The real :class:`Provider` under test, or ``None`` for an unknown slug."""
+    return _SLUG_TO_PROVIDER.get(provider_slug)
+
+
+@pytest.fixture(scope="session")
+def token_source(
+    harness_provider,
+    raw_discovery,
+    discovery_document,
+    provider_capabilities,
+    test_config,
+) -> TokenSource:
+    """Session-scoped unified minter (:class:`TokenSource`) for the harness.
+
+    Wires the real provider under test — capabilities derived from live
+    discovery via ``provider_matrix.detect_capabilities`` (so the harness and
+    the capability matrix never drift), credentials from the env file — plus
+    the always-available MOCK provider. When the provider supports automated
+    auth-code flows (devInteractions) and the auth-code client is configured,
+    an ``auth_code_minter`` wrapping :func:`perform_auth_code_flow` is injected
+    so ``Grant.AUTHORIZATION_CODE`` mints end-to-end.
+
+    Tests translate the typed gating errors
+    (:class:`HarnessCapabilityError` / :class:`HarnessCredentialError`) to
+    ``pytest.skip`` so secret-gated providers (Ory/Descope) skip cleanly while
+    MOCK is always mintable.
+    """
+    if harness_provider is None:
+        return TokenSource.with_mock()
+
+    auth_code_minter = None
+    if "dev_interactions" in provider_capabilities:
+        client_id = test_config.get("TEST_AUTH_CODE_CLIENT_ID")
+        redirect_uri = test_config.get("TEST_AUTH_CODE_REDIRECT_URI")
+        client_secret = test_config.get("TEST_AUTH_CODE_CLIENT_SECRET")
+        if client_id and redirect_uri:
+
+            def auth_code_minter(
+                tenant: str | None,
+                scopes: str | None,
+                *,
+                _client_id: str = client_id,
+                _redirect_uri: str = redirect_uri,
+                _client_secret: str | None = client_secret,
+            ) -> dict[str, Any]:
+                del tenant  # single-tenant local fixtures ignore tenant shaping
+                result = perform_auth_code_flow(
+                    discovery=discovery_document,
+                    client_id=_client_id,
+                    redirect_uri=_redirect_uri,
+                    config=AuthCodeFlowConfig(
+                        client_secret=_client_secret,
+                        scope=scopes or "openid profile email offline_access",
+                        resource="urn:test:api",
+                    ),
+                )
+                token_response = result["token_response"]
+                if not token_response.is_successful or token_response.token is None:
+                    raise HarnessError(f"auth-code mint failed: {token_response.error}")
+                return dict(token_response.token)
+
+    real_cfg = ProviderConfig.from_discovery(
+        harness_provider,
+        raw_discovery,
+        token_endpoint=discovery_document.token_endpoint,
+        client_id=test_config.get("TEST_CLIENT_ID"),
+        client_secret=test_config.get("TEST_CLIENT_SECRET"),
+        scope=test_config.get("TEST_SCOPE"),
+        auth_code_minter=auth_code_minter,
+    )
+    return TokenSource.with_mock(extra=[real_cfg])
 
 
 @pytest.fixture(autouse=True)

--- a/src/tests/integration/test_correctness_matrix.py
+++ b/src/tests/integration/test_correctness_matrix.py
@@ -249,9 +249,9 @@ def _granted_scopes(access_token: str) -> list[str]:
     raw = claims.get("scope") or claims.get("scp") or ""
     if isinstance(raw, str):
         return raw.split()
-    if isinstance(raw, (list, tuple)):
+    if isinstance(raw, (list, tuple, set, frozenset)):
         return [s for s in raw if isinstance(s, str)]
-    # A non-str, non-sequence scope claim (e.g. a JSON int) is not iterable —
+    # A non-str, non-collection scope claim (e.g. a JSON int) is not iterable —
     # treat it as no granted scopes rather than crashing on ``for`` (edge guard).
     return []
 

--- a/src/tests/integration/test_correctness_matrix.py
+++ b/src/tests/integration/test_correctness_matrix.py
@@ -1,0 +1,302 @@
+"""Token correctness assertion matrix — TH-1.3 (#465 · epic #462, design §4 S8).
+
+Sends ONE token per class through the **booted resource server**
+(:func:`~harness.rs_server.boot_rs` — real uvicorn, real HTTP) and asserts the
+contract: ``200`` for valid tokens, ``401`` with the uniform (F-18) body for
+every validation-failure class, ``403``/``401`` for the RS-policy classes, and
+that **nothing is silently accepted**.
+
+Two groups:
+
+* **Group A — forged-corpus matrix.** The controllable :class:`~harness.MockOP`
+  (served over real localhost HTTP by :func:`~harness.serve_mock_op` so the
+  out-of-process RS can fetch its discovery + JWKS) supplies the full forged
+  corpus keyed to its known signing key. This is self-contained: no Docker, runs
+  under ``uv run --all-packages``.
+* **Group B — real-issuer leg.** A live node-oidc token proves the same contract
+  against a REAL IdP over real HTTP. Gated to node-oidc (the remote matrix
+  providers mint different aud/scope), mirroring ``test_rs_boot``.
+
+Run via ``make test-harness-matrix`` (Docker node-oidc + ``--all-packages`` so
+``fastapi_identity_model`` and ``uvicorn`` resolve). Under a plain env the module
+importorskips cleanly.
+"""
+
+from collections import namedtuple
+import time
+from urllib.parse import urlparse
+
+import httpx
+import jwt
+import pytest
+
+from ..harness import CORPUS_AUDIENCE, build_corpus, serve_mock_op
+from ..harness.rs_server import boot_rs
+
+
+pytest.importorskip("fastapi_identity_model")
+pytest.importorskip("uvicorn")
+
+pytestmark = pytest.mark.integration
+
+GENERIC_401_BODY = {"detail": "Invalid or unauthorized token"}
+
+# The 8 classes a validating library rejects outright (sig / iss / aud / exp /
+# nbf / kid / alg). Every one must collapse to the SAME generic 401 body (F-18).
+VALIDATION_FAIL_CLASSES = [
+    "expired",
+    "nbf_future",
+    "wrong_iss",
+    "wrong_aud",
+    "tampered_sig",
+    "unknown_kid",
+    "wrong_alg",
+    "alg_none",
+]
+
+# Validly signed, correct-audience tokens carrying the ``read`` scope — the
+# library AND the RS scope guard accept them (200). ``cnf_bound`` is here on
+# purpose: the cnf-bound-as-bearer token is ACCEPTED today (F-02, #478); this
+# suite asserts the *current* contract, it does not assume rejection.
+ACCEPTED_200_CLASSES = ["valid", "cnf_bound", "oversized", "multi_aud_untrusted"]
+
+# The middleware's always-on negative ID-token defense (F-07): a token carrying
+# an ID-token-only claim (``nonce``/``at_hash``/``c_hash``) is rejected before
+# ``require_scope`` runs, regardless of the ``require_access_token_marker`` opt-in.
+ID_TOKEN_DETAIL = "ID token cannot be used as an access token"
+
+# What the module fixture exposes: the live mock OP (to mint bespoke tokens), the
+# booted RS base URL, the forged corpus, and the mock OP discovery URL (so a
+# second RS can be booted against the same issuer for the F-07 marker case).
+MockMatrix = namedtuple("MockMatrix", "op base_url corpus discovery_url")
+
+
+def _get_protected(base_url: str, token: str) -> httpx.Response:
+    return httpx.get(
+        f"{base_url}/protected",
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=10.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Group A — forged-corpus matrix through the mock-OP-backed RS
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def mock_matrix():
+    """One mock OP + one booted RS (audience=mock-api, require_scope=read).
+
+    Yields a :class:`MockMatrix`; the RS is a single uvicorn subprocess reused
+    across all parametrized cases (a boot is ~1-2s, so we batch, not re-boot).
+    """
+    with (
+        serve_mock_op() as op,
+        boot_rs(
+            discovery_url=op.discovery_url,
+            audience=CORPUS_AUDIENCE,
+            require_scope="read",
+        ) as base_url,
+    ):
+        yield MockMatrix(op, base_url, build_corpus(op), op.discovery_url)
+
+
+@pytest.mark.parametrize("name", ACCEPTED_200_CLASSES)
+def test_accepted_classes_reach_protected(mock_matrix, name):
+    """Validly signed, correctly scoped tokens → 200 (F-02 contract included)."""
+    response = _get_protected(mock_matrix.base_url, mock_matrix.corpus[name].jwt)
+    assert response.status_code == httpx.codes.OK
+
+
+def test_valid_token_body_echoes_claims(mock_matrix):
+    """The canonical valid token → 200 with the validated sub + scope echoed."""
+    response = _get_protected(mock_matrix.base_url, mock_matrix.corpus["valid"].jwt)
+    assert response.status_code == httpx.codes.OK
+    body = response.json()
+    assert body["sub"] == "mock-subject"
+    assert body["scope"] == "read"
+
+
+@pytest.mark.parametrize("name", VALIDATION_FAIL_CLASSES)
+def test_validation_failures_are_uniform_401(mock_matrix, name):
+    """Each validation-failure class → 401 with the generic (F-18) body."""
+    response = _get_protected(mock_matrix.base_url, mock_matrix.corpus[name].jwt)
+    assert response.status_code == httpx.codes.UNAUTHORIZED
+    assert response.json() == GENERIC_401_BODY
+
+
+def test_f18_body_uniform_across_all_failure_stages(mock_matrix):
+    """F-18: every validation stage returns the *same* 401 body (no leakage).
+
+    A single divergent body (e.g. an ``exp``-specific message) would let a
+    caller distinguish rejection reasons — the vulnerability F-18 closed.
+    """
+    bodies = [
+        _get_protected(mock_matrix.base_url, mock_matrix.corpus[name].jwt).json()
+        for name in VALIDATION_FAIL_CLASSES
+    ]
+    assert bodies == [GENERIC_401_BODY] * len(VALIDATION_FAIL_CLASSES)
+
+
+def test_id_as_access_rejected_by_negative_defense(mock_matrix):
+    """F-07 negative (always on): an ID-token presented as a bearer → 401.
+
+    The corpus ID-token carries ``nonce`` (an ID-token-only claim), so the
+    middleware rejects it as the wrong token type BEFORE ``require_scope`` runs
+    — on the default RS, with no marker opt-in required. This is the passive
+    token-type-confusion defense; the opt-in *positive* marker path is proven in
+    :func:`test_scopeless_access_token_marker_gate`.
+    """
+    response = _get_protected(
+        mock_matrix.base_url, mock_matrix.corpus["id_as_access"].jwt
+    )
+    assert response.status_code == httpx.codes.UNAUTHORIZED
+    assert response.json() == {"detail": ID_TOKEN_DETAIL}
+
+
+def test_f02_cnf_bound_accepted_today(mock_matrix):
+    """F-02: a cnf-bound token presented as a plain bearer → 200 TODAY.
+
+    This asserts the *current* accepted-today contract, NOT desired behaviour;
+    #478 tracks rejecting sender-constrained tokens at the RS. When #478 lands
+    this expectation flips to 401 — that is intended, not a regression here.
+    """
+    response = _get_protected(mock_matrix.base_url, mock_matrix.corpus["cnf_bound"].jwt)
+    assert response.status_code == httpx.codes.OK
+
+
+def test_nothing_silently_accepted(mock_matrix):
+    """Every class outside the accepted set is rejected (never a silent 200)."""
+    for name, forged in mock_matrix.corpus.items():
+        if name in ACCEPTED_200_CLASSES:
+            continue
+        response = _get_protected(mock_matrix.base_url, forged.jwt)
+        assert response.status_code != httpx.codes.OK, (
+            f"class {name!r} was silently accepted (200)"
+        )
+
+
+def _mint_scopeless_access_token(op) -> str:
+    """A validly signed token with NO ``scope``/``scp`` and NO ID-token-only
+    claim — passes signature/aud/type validation but carries no access-token
+    marker (the exact shape the positive F-07 marker gate exists to catch)."""
+    now = int(time.time())
+    return op.sign(
+        {
+            "iss": op.issuer,
+            "sub": "marker-subject",
+            "aud": CORPUS_AUDIENCE,
+            "iat": now,
+            "nbf": now,
+            "exp": now + 300,
+            "client_id": "mock-client",
+        }
+    )
+
+
+def test_scopeless_access_token_marker_gate(mock_matrix):
+    """F-07 positive (opt-in ``require_access_token_marker``).
+
+    A scope-less token with no ID-token-only claim slips past the negative
+    defense. On the default RS it validates and is handed to
+    ``require_scope("read")`` → 403 (missing scope). On a marker-enabled RS the
+    access-token marker gate rejects it FIRST → 401 — proving the opt-in marker
+    is what distinguishes the two, not the always-on negative check.
+    """
+    token = _mint_scopeless_access_token(mock_matrix.op)
+
+    default = _get_protected(mock_matrix.base_url, token)
+    assert default.status_code == httpx.codes.FORBIDDEN
+
+    with boot_rs(
+        discovery_url=mock_matrix.discovery_url,
+        audience=CORPUS_AUDIENCE,
+        require_scope="read",
+        require_access_token_marker=True,
+    ) as marker_base:
+        marked = _get_protected(marker_base, token)
+    assert marked.status_code == httpx.codes.UNAUTHORIZED
+
+
+# ---------------------------------------------------------------------------
+# Group B — real-issuer leg (node-oidc), gated like test_rs_boot
+# ---------------------------------------------------------------------------
+
+NODE_OIDC_AUDIENCE = "urn:test:api"
+
+
+def _is_node_oidc_fixture(raw_discovery: dict) -> bool:
+    """Whether the active provider is the bundled node-oidc-provider fixture.
+
+    The fixed ``urn:test:api`` audience this leg asserts on only exists in the
+    local node-oidc-provider; the remote matrix providers (Keycloak/Ory/Descope)
+    mint a different audience, so they must skip. node-oidc serves discovery at
+    the localhost host root — the check that distinguishes it from Keycloak,
+    which also runs on localhost but under ``/realms/<realm>`` (mirrors
+    ``test_rs_boot._is_node_oidc_fixture``).
+    """
+    parsed = urlparse(raw_discovery.get("issuer", ""))
+    is_local = parsed.hostname in ("localhost", "127.0.0.1")
+    at_host_root = parsed.path in ("", "/")
+    return is_local and at_host_root
+
+
+def _granted_scopes(access_token: str) -> list[str]:
+    claims = jwt.decode(access_token, options={"verify_signature": False})
+    raw = claims.get("scope") or claims.get("scp") or ""
+    if isinstance(raw, str):
+        return raw.split()
+    return [s for s in raw if isinstance(s, str)]
+
+
+@pytest.fixture(scope="module")
+def node_oidc_discovery_url(test_config, raw_discovery) -> str:
+    if not _is_node_oidc_fixture(raw_discovery):
+        pytest.skip(
+            "correctness-matrix real-issuer leg asserts node-oidc's "
+            "urn:test:api audience; remote matrix providers mint different tokens"
+        )
+    return test_config["TEST_DISCO_ADDRESS"]
+
+
+def test_real_issuer_valid_token_accepted(
+    node_oidc_discovery_url, client_credentials_token
+):
+    """A REAL node-oidc CC token → 200 through the booted RS (real HTTP DoD)."""
+    access_token = client_credentials_token.token.get("access_token", "")
+    assert access_token, "CC fixture returned no access_token"
+    scopes = _granted_scopes(access_token)
+    assert scopes, "minted token carried no scopes to guard on"
+
+    with boot_rs(
+        discovery_url=node_oidc_discovery_url,
+        audience=NODE_OIDC_AUDIENCE,
+        require_scope=scopes[0],
+    ) as base_url:
+        response = _get_protected(base_url, access_token)
+
+    assert response.status_code == httpx.codes.OK
+    assert response.json()["sub"]
+
+
+def test_real_issuer_wrong_aud_rejected(
+    node_oidc_discovery_url, client_credentials_token
+):
+    """A REAL node-oidc token against an RS expecting a different aud → 401.
+
+    A real-issuer negative the corpus cannot forge: a genuinely signed token
+    whose ``aud`` does not match the RS's configured audience. Proves the
+    uniform 401 contract end-to-end against a live IdP.
+    """
+    access_token = client_credentials_token.token.get("access_token", "")
+    assert access_token, "CC fixture returned no access_token"
+
+    with boot_rs(
+        discovery_url=node_oidc_discovery_url,
+        audience="urn:does-not-match-any-real-token",
+    ) as base_url:
+        response = _get_protected(base_url, access_token)
+
+    assert response.status_code == httpx.codes.UNAUTHORIZED
+    assert response.json() == GENERIC_401_BODY

--- a/src/tests/integration/test_correctness_matrix.py
+++ b/src/tests/integration/test_correctness_matrix.py
@@ -88,8 +88,10 @@ def _get_protected(base_url: str, token: str) -> httpx.Response:
 def mock_matrix():
     """One mock OP + one booted RS (audience=mock-api, require_scope=read).
 
-    Yields a :class:`MockMatrix`; the RS is a single uvicorn subprocess reused
-    across all parametrized cases (a boot is ~1-2s, so we batch, not re-boot).
+    Yields a :class:`MockMatrix`. The mock OP runs in-process (a uvicorn daemon
+    thread inside ``serve_mock_op``); the RS is a separate uvicorn subprocess
+    (``boot_rs``). Both are reused across all parametrized cases — a boot is
+    ~1-2s, so we batch rather than re-boot per case.
     """
     with (
         serve_mock_op() as op,
@@ -247,7 +249,11 @@ def _granted_scopes(access_token: str) -> list[str]:
     raw = claims.get("scope") or claims.get("scp") or ""
     if isinstance(raw, str):
         return raw.split()
-    return [s for s in raw if isinstance(s, str)]
+    if isinstance(raw, (list, tuple)):
+        return [s for s in raw if isinstance(s, str)]
+    # A non-str, non-sequence scope claim (e.g. a JSON int) is not iterable —
+    # treat it as no granted scopes rather than crashing on ``for`` (edge guard).
+    return []
 
 
 @pytest.fixture(scope="module")

--- a/src/tests/integration/test_rs_boot.py
+++ b/src/tests/integration/test_rs_boot.py
@@ -11,6 +11,8 @@ so ``fastapi_identity_model`` and ``uvicorn`` resolve). Under plain
 importorskips cleanly.
 """
 
+from urllib.parse import urlparse
+
 import httpx
 import jwt
 import pytest
@@ -26,6 +28,22 @@ pytestmark = pytest.mark.integration
 # resourceIndicators.defaultResource (test-fixtures/node-oidc-provider).
 RS_AUDIENCE = "urn:test:api"
 GENERIC_401_DETAIL = "Invalid or unauthorized token"
+
+
+def _is_node_oidc_fixture(raw_discovery: dict) -> bool:
+    """Whether the active provider is the bundled node-oidc-provider fixture.
+
+    The fixed ``urn:test:api`` audience and ``api`` scope this suite asserts on
+    only exist in the local node-oidc-provider (``resourceIndicators``); the
+    remote CI-matrix providers (Keycloak/Ory/Descope) mint tokens with a
+    different audience/scope, so they must skip. node-oidc serves discovery at
+    the localhost host root — the check that distinguishes it from Keycloak,
+    which also runs on localhost but under ``/realms/<realm>``.
+    """
+    parsed = urlparse(raw_discovery.get("issuer", ""))
+    is_local = parsed.hostname in ("localhost", "127.0.0.1")
+    at_host_root = parsed.path in ("", "/")
+    return is_local and at_host_root
 
 
 def _access_token(client_credentials_token) -> str:
@@ -44,7 +62,12 @@ def _granted_scopes(access_token: str) -> list[str]:
 
 
 @pytest.fixture(scope="module")
-def rs_discovery_url(test_config) -> str:
+def rs_discovery_url(test_config, raw_discovery) -> str:
+    if not _is_node_oidc_fixture(raw_discovery):
+        pytest.skip(
+            "RS boot suite asserts node-oidc's urn:test:api audience / api "
+            "scope; remote matrix providers mint different tokens"
+        )
     return test_config["TEST_DISCO_ADDRESS"]
 
 

--- a/src/tests/integration/test_rs_boot.py
+++ b/src/tests/integration/test_rs_boot.py
@@ -1,0 +1,146 @@
+"""Real-HTTP DoD proof for TH-1.2 (#464 · epic #462).
+
+Boots the greenfield resource server (``TokenValidationMiddleware +
+require_scope``) under real uvicorn workers and drives it over httpx against a
+live node-oidc issuer. This is the acceptance proof that the RS runs the
+shipped middleware end-to-end — not an ASGI in-process shim.
+
+Run via ``make test-harness-rs`` (Docker node-oidc + ``uv run --all-packages``
+so ``fastapi_identity_model`` and ``uvicorn`` resolve). Under plain
+``make test-integration-node-oidc`` the fastapi stack is absent, so the module
+importorskips cleanly.
+"""
+
+import httpx
+import jwt
+import pytest
+
+from ..harness.rs_server import boot_rs
+
+
+pytest.importorskip("fastapi_identity_model")
+
+pytestmark = pytest.mark.integration
+
+# node-oidc issues JWT access tokens with aud=urn:test:api via
+# resourceIndicators.defaultResource (test-fixtures/node-oidc-provider).
+RS_AUDIENCE = "urn:test:api"
+GENERIC_401_DETAIL = "Invalid or unauthorized token"
+
+
+def _access_token(client_credentials_token) -> str:
+    token = client_credentials_token.token.get("access_token", "")
+    assert token, "CC fixture returned no access_token"
+    return token
+
+
+def _granted_scopes(access_token: str) -> list[str]:
+    """Scopes actually present on the minted token (unverified decode)."""
+    claims = jwt.decode(access_token, options={"verify_signature": False})
+    raw = claims.get("scope") or claims.get("scp") or ""
+    if isinstance(raw, str):
+        return raw.split()
+    return [s for s in raw if isinstance(s, str)]
+
+
+@pytest.fixture(scope="module")
+def rs_discovery_url(test_config) -> str:
+    return test_config["TEST_DISCO_ADDRESS"]
+
+
+def test_valid_token_reaches_protected_route(
+    rs_discovery_url, client_credentials_token
+):
+    """Valid CC token → 200, body echoes the validated claims."""
+    access_token = _access_token(client_credentials_token)
+    scopes = _granted_scopes(access_token)
+    assert scopes, "minted token carried no scopes to guard on"
+
+    with boot_rs(
+        discovery_url=rs_discovery_url,
+        audience=RS_AUDIENCE,
+        require_scope=scopes[0],
+    ) as base_url:
+        response = httpx.get(
+            f"{base_url}/protected",
+            headers={"Authorization": f"Bearer {access_token}"},
+            timeout=10.0,
+        )
+
+    assert response.status_code == httpx.codes.OK
+    body = response.json()
+    assert body["sub"]
+    assert scopes[0] in (body["scope"] or "")
+
+
+def test_missing_authorization_is_uniform_401(rs_discovery_url):
+    """No Authorization header → 401 with the middleware's own detail."""
+    with boot_rs(discovery_url=rs_discovery_url, audience=RS_AUDIENCE) as base_url:
+        response = httpx.get(f"{base_url}/protected", timeout=10.0)
+
+    assert response.status_code == httpx.codes.UNAUTHORIZED
+    assert response.json() == {"detail": "Missing Authorization header"}
+
+
+def test_malformed_bearer_is_uniform_401(rs_discovery_url):
+    """Garbage bearer → 401 with the generic (F-18) uniform body."""
+    with boot_rs(discovery_url=rs_discovery_url, audience=RS_AUDIENCE) as base_url:
+        response = httpx.get(
+            f"{base_url}/protected",
+            headers={"Authorization": "Bearer not-a-real-jwt"},
+            timeout=10.0,
+        )
+
+    assert response.status_code == httpx.codes.UNAUTHORIZED
+    assert response.json() == {"detail": GENERIC_401_DETAIL}
+
+
+def test_missing_required_scope_is_403(rs_discovery_url, client_credentials_token):
+    """Valid token but RS requires a scope the token lacks → 403 (require_scope)."""
+    access_token = _access_token(client_credentials_token)
+    absent_scope = "scope-the-token-does-not-carry"
+    assert absent_scope not in _granted_scopes(access_token)
+
+    with boot_rs(
+        discovery_url=rs_discovery_url,
+        audience=RS_AUDIENCE,
+        require_scope=absent_scope,
+    ) as base_url:
+        response = httpx.get(
+            f"{base_url}/protected",
+            headers={"Authorization": f"Bearer {access_token}"},
+            timeout=10.0,
+        )
+
+    assert response.status_code == httpx.codes.FORBIDDEN
+    assert absent_scope in response.json()["detail"]
+
+
+def test_health_route_is_unauthenticated(rs_discovery_url):
+    """Excluded /health answers 200 with no Authorization (readiness proof)."""
+    with boot_rs(discovery_url=rs_discovery_url, audience=RS_AUDIENCE) as base_url:
+        response = httpx.get(f"{base_url}/health", timeout=10.0)
+
+    assert response.status_code == httpx.codes.OK
+    assert response.json() == {"status": "ok"}
+
+
+def test_boots_under_multiple_workers(rs_discovery_url, client_credentials_token):
+    """uvicorn --workers 2 boots and serves a valid token → 200."""
+    access_token = _access_token(client_credentials_token)
+    scopes = _granted_scopes(access_token)
+    assert scopes, "minted token carried no scopes to guard on"
+
+    with boot_rs(
+        discovery_url=rs_discovery_url,
+        audience=RS_AUDIENCE,
+        require_scope=scopes[0],
+        workers=2,
+    ) as base_url:
+        response = httpx.get(
+            f"{base_url}/protected",
+            headers={"Authorization": f"Bearer {access_token}"},
+            timeout=10.0,
+        )
+
+    assert response.status_code == httpx.codes.OK

--- a/src/tests/integration/test_token_source.py
+++ b/src/tests/integration/test_token_source.py
@@ -15,6 +15,9 @@ signature-valid token the library accepts.
 
 from __future__ import annotations
 
+import base64
+import json
+
 import pytest
 
 from py_identity_model import (
@@ -144,6 +147,34 @@ def test_forged_tokens_require_mock_provider(token_source, harness_provider):
             Grant.CLIENT_CREDENTIALS,
             malform=Malform.TAMPERED_SIG,
         )
+
+
+def test_descope_multitenant_mint_carries_dct_tenants(
+    token_source, harness_provider, test_config
+):
+    """AC-3: the Descope multi-tenant path yields distinct ``dct``/``tenants``.
+
+    Reuses the identity-stack access-key -> ``/v1/auth/accesskey/exchange`` flow
+    (credential-gated on ``DESCOPE_PROJECT_ID``/``DESCOPE_MANAGEMENT_KEY``/
+    ``DESCOPE_BASE_URL`` + a tenant id) so it skips cleanly off Descope.
+    """
+    if harness_provider is not Provider.DESCOPE:
+        pytest.skip("Descope-only: multi-tenant access-key exchange")
+    tenant = test_config.get("DESCOPE_TEST_TENANT_ID")
+    if not tenant:
+        pytest.skip("DESCOPE_TEST_TENANT_ID not configured")
+
+    minted = _mint_or_skip(
+        token_source, Provider.DESCOPE, Grant.CLIENT_CREDENTIALS, tenant=tenant
+    )
+    assert minted.tenant == tenant
+    # Session JWT must carry the Descope multi-tenant claims (dct/tenants).
+    payload_segment = minted.access_token.split(".")[1]
+    payload = json.loads(
+        base64.urlsafe_b64decode(payload_segment + "=" * (-len(payload_segment) % 4))
+    )
+    assert payload.get("dct") == tenant
+    assert tenant in payload.get("tenants", {})
 
 
 def test_mock_provider_always_mintable(token_source):

--- a/src/tests/integration/test_token_source.py
+++ b/src/tests/integration/test_token_source.py
@@ -1,0 +1,170 @@
+"""DoD: real-IdP proof for the unified ``TokenSource`` minter (TH-1.1, #463).
+
+This is the Definition-of-Done evidence for the minter: it mints tokens through
+a **live** identity provider (node-oidc / Keycloak under ``make
+test-integration-node-oidc`` / ``-keycloak``; Ory / Descope when secret-gated)
+and validates them end-to-end with the real library
+(:func:`py_identity_model.validate_token`) against the provider's live JWKS.
+
+The deterministic, network-free proofs (forged corpus, mock-OP failure
+injection, capability/credential gating) live in the unit suite
+(``test_mock_op.py`` / ``test_token_source_gating.py``); here we prove the one
+thing only a real IdP can: that a ``TokenSource.mint`` result is a genuine,
+signature-valid token the library accepts.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from py_identity_model import (
+    TokenValidationConfig,
+    validate_token,
+)
+
+from ..harness import (
+    Grant,
+    HarnessCapabilityError,
+    HarnessCredentialError,
+    Malform,
+    MintSpec,
+    Provider,
+    ProviderConfig,
+    TokenSource,
+    prime_pool,
+)
+from .conftest import DEFAULT_VALIDATION_OPTIONS
+
+
+pytestmark = pytest.mark.integration
+
+# JWT format: three dot-separated segments (two separators).
+JWT_SEGMENT_SEPARATOR_COUNT = 2
+
+
+def _mint_or_skip(source: TokenSource, provider: Provider, grant: Grant, **kwargs):
+    """Mint, translating the typed gating errors to ``pytest.skip``.
+
+    This is the contract the harness relies on: secret-gated providers
+    (Ory/Descope) and unsupported grants skip cleanly rather than failing.
+    """
+    try:
+        return source.mint(provider, grant, **kwargs)
+    except HarnessCapabilityError as exc:
+        pytest.skip(f"capability-gated: {exc}")
+    except HarnessCredentialError as exc:
+        pytest.skip(f"credential-gated: {exc}")
+
+
+def _validate(token: str, test_config, require_https) -> dict:
+    """Validate a token against the live provider's discovery + JWKS."""
+    config = TokenValidationConfig(
+        perform_disco=True,
+        audience=test_config["TEST_AUDIENCE"],
+        options=DEFAULT_VALIDATION_OPTIONS,
+        require_https=require_https,
+    )
+    return validate_token(
+        jwt=token,
+        disco_doc_address=test_config["TEST_DISCO_ADDRESS"],
+        token_validation_config=config,
+    )
+
+
+def test_client_credentials_mint_validates_end_to_end(
+    token_source, harness_provider, test_config, require_https
+):
+    """DoD: a client-credentials mint validates against the live JWKS."""
+    if harness_provider is None:
+        pytest.skip("no real provider wired for this env file")
+
+    minted = _mint_or_skip(token_source, harness_provider, Grant.CLIENT_CREDENTIALS)
+    assert minted.access_token
+    assert minted.provider is harness_provider
+    assert minted.grant is Grant.CLIENT_CREDENTIALS
+
+    claims = _validate(minted.access_token, test_config, require_https)
+    assert claims["iss"]
+    assert claims["exp"]
+
+
+def test_auth_code_mint_validates_when_capable(
+    token_source, harness_provider, test_config, require_https
+):
+    """Auth-code mint validates end-to-end where the provider supports it.
+
+    Skips (capability/credential-gated) on providers without devInteractions
+    or an auth-code client — the same gating the correctness matrix relies on.
+    """
+    if harness_provider is None:
+        pytest.skip("no real provider wired for this env file")
+
+    minted = _mint_or_skip(token_source, harness_provider, Grant.AUTHORIZATION_CODE)
+    assert minted.access_token
+    assert minted.grant is Grant.AUTHORIZATION_CODE
+
+    # Only JWT-format access tokens are library-validatable; opaque tokens are
+    # a legitimate outcome for some providers (introspection territory).
+    if minted.access_token.count(".") == JWT_SEGMENT_SEPARATOR_COUNT:
+        claims = _validate(minted.access_token, test_config, require_https)
+        assert claims["iss"]
+
+
+def test_replay_pool_mints_once_and_replays(token_source, harness_provider):
+    """The pre-minted pool mints each spec once and replays the same token."""
+    if harness_provider is None:
+        pytest.skip("no real provider wired for this env file")
+
+    spec = MintSpec(provider=harness_provider, grant=Grant.CLIENT_CREDENTIALS)
+    try:
+        pool = prime_pool(token_source, [spec, spec])
+    except (HarnessCapabilityError, HarnessCredentialError) as exc:
+        pytest.skip(f"gated: {exc}")
+
+    # Duplicate specs collapse to a single mint (rate-limit friendly).
+    assert len(pool) == 1
+    minted = pool.get(spec)
+    assert minted.access_token
+    # expires_at is tracked so T311 can re-mint across the 300s TTL.
+    assert minted.expires_at is None or minted.expires_at > 0
+
+
+def test_forged_tokens_require_mock_provider(token_source, harness_provider):
+    """A real provider refuses to emit forged tokens (deterministic gating).
+
+    Real OPs will not mint invalid tokens; the harness enforces that forgery
+    is MOCK-only, so the forged corpus stays in one controllable place.
+    """
+    if harness_provider is None:
+        pytest.skip("no real provider wired for this env file")
+
+    with pytest.raises(HarnessCapabilityError):
+        token_source.mint(
+            harness_provider,
+            Grant.CLIENT_CREDENTIALS,
+            malform=Malform.TAMPERED_SIG,
+        )
+
+
+def test_mock_provider_always_mintable(token_source):
+    """MOCK is always available regardless of which real provider is wired."""
+    minted = token_source.mint(Provider.MOCK, Grant.CLIENT_CREDENTIALS)
+    assert minted.provider is Provider.MOCK
+    assert minted.malform is Malform.VALID
+    assert minted.access_token.count(".") == JWT_SEGMENT_SEPARATOR_COUNT
+
+
+def test_credential_gating_raises_typed_error():
+    """A real provider without credentials raises ``HarnessCredentialError``.
+
+    Proves the contract the ``token_source`` fixture leans on to turn
+    secret-gated providers (Ory/Descope) into clean ``pytest.skip``.
+    """
+    credentialless = ProviderConfig(
+        provider=Provider.ORY,
+        capabilities={"client_credentials"},
+        token_endpoint="https://example.test/oauth2/token",
+    )
+    source = TokenSource.with_mock(extra=[credentialless])
+    with pytest.raises(HarnessCredentialError):
+        source.mint(Provider.ORY, Grant.CLIENT_CREDENTIALS)

--- a/src/tests/load/README.md
+++ b/src/tests/load/README.md
@@ -1,0 +1,153 @@
+# Load / Soak Suite (TH-1.5)
+
+A Locust-driven load and soak harness for the token-validation stack (#474, epic
+#462, design §4/§5). It swarms the booted `fastapi-identity-model` resource
+server (RS) with a **pre-minted token pool** — mint each token class once, replay
+it many times — because real IdPs rate-limit per-request minting while JWT
+validation is stateless, so replay is valid load. Each run reports RPS, latency
+percentiles, error-rate-by-class, cache-hit rate, and upstream discovery/JWKS
+fetch volume.
+
+**Split of responsibility:** pytest owns correctness and deterministic behaviour
+proofs (LRU, mix-up, `private_key_jwt`); this suite owns load and soak.
+
+## Layout
+
+| Module | Role |
+|--------|------|
+| `scenarios.py` | The S1–S12 catalogue, run profiles, and the expected-status map (authoritative profile split — see below). |
+| `pool.py` | The pre-minted replay pool (mint once, replay many). |
+| `locustfile.py` | A standalone Locust file the runner drives as a subprocess. |
+| `runner.py` | Orchestration (fresh mock OP + booted RS per scenario), metric collection, and SLO gate evaluation. |
+| `test_load_ci_short.py` | The CI-short pytest entrypoint (real Locust run over the CI_SHORT profile). |
+
+## How to run
+
+```bash
+make test-harness-load
+```
+
+which runs the CI-short profile through a real Locust process against the booted
+RS + mock OP:
+
+```bash
+uv run --group load --all-packages pytest src/tests/load/test_load_ci_short.py \
+    -m integration -p no:benchmark -v
+```
+
+Two things make the invocation non-obvious:
+
+- **`load` dependency group.** Locust lives in the opt-in `load` group
+  (`uv run --group load …`), not the root test dependencies. Locust pulls in
+  gevent, which monkey-patches the stdlib, so it must stay out of the default
+  environment. The suite skips cleanly (`importlib.util.find_spec("locust")`)
+  when the group is not installed.
+- **Locust runs OUT of process.** The runner drives Locust as a `subprocess`
+  (`locust --headless -f locustfile.py`) and **never imports it in-process**.
+  Importing locust triggers gevent's `monkey.patch_all()`, which deadlocks the
+  parent's in-process asyncio mock-OP server thread. Keeping Locust in its own
+  process isolates gevent's patched world; the pre-minted pool and the run
+  summary cross the process boundary as JSON files.
+
+Each scenario runs against a **fresh** mock OP + RS, so caches start empty and no
+failure-injection state bleeds across scenarios.
+
+### Nightly / on-demand profiles
+
+`make test-harness-load-nightly` prints the on-demand command for the NIGHTLY
+soak profile (S7/S11/S12) — a documented, not-scheduled hook (#271). The
+DIAGNOSTIC and NIGHTLY profiles are run directly via `run_profile`:
+
+```bash
+uv run --group load --all-packages python -c \
+  'from src.tests.load.runner import run_profile; from src.tests.load.scenarios import Profile; \
+   [print(r) for r in run_profile(Profile.NIGHTLY)]'
+```
+
+## Profile split
+
+Scenarios are grouped into three run profiles. The authoritative assignment lives
+in `scenarios.py`; this table mirrors it.
+
+| Profile | Scenarios | Purpose |
+|---------|-----------|---------|
+| **CI_SHORT** | S1, S2, S3, S6, S8 | The PR gate: short (~3s), deterministic, mock-OP-backed, self-contained (no Docker). |
+| **DIAGNOSTIC** | S5, S9, S10 | Head-of-line / no-store / blocking-validator probes, run on demand. |
+| **NIGHTLY** | S4, S7, S11, S12 | TTL-refresh / LRU-thrash / RSS-FD soak / multi-tenant runs, run on demand (feeds #271). |
+
+| ID | Title | Profile | Proves |
+|----|-------|---------|--------|
+| S1 | warm RPS ceiling (valid RS256, hot cache) | CI_SHORT | warm p99 knee + RPS/worker with a fully hot cache |
+| S2 | alg cost (RS256 vs ES256, warm) | CI_SHORT | the ES256/RS256 warm-validation cost ratio |
+| S3 | cold stampede (empty cache, burst) | CI_SHORT | single-flight: a cold burst fetches discovery + JWKS once each |
+| S4 | TTL refresh under load (60s TTL rollover) | NIGHTLY | mid-load TTL rollover stays single-flight, spikes no errors |
+| S5 | provider-slowness head-of-line blocking | DIAGNOSTIC | bounded cohort stall while the single-flight holder retries |
+| S6 | kid-rotation storm + unknown-kid flood | CI_SHORT | unknown-kid flood recovers within ~1 cooldown, caps upstream fetches, 401s cleanly |
+| S7 | LRU thrash > 64 issuers | NIGHTLY | bounded memory under > 64 distinct issuers |
+| S8 | rejection correctness & uniformity under contention | CI_SHORT | every class returns its correct status, uniform 401 body, zero 500s |
+| S9 | discovery no-store (re-fetch every request) | DIAGNOSTIC | no-store discovery collapses throughput while JWKS stays cached |
+| S10 | blocking claims_validator (event-loop stall) | DIAGNOSTIC | **SCAFFOLD — not implemented** (see below) |
+| S11 | RSS / FD soak | NIGHTLY | flat RSS/FD for a single issuer; bounded churn at 64 issuers |
+| S12 | multi-tenant + issuer mix-up | NIGHTLY | tenant LRU survival + RFC 9207 cross-issuer rejection under load |
+
+Two placement notes:
+
+- **S4 is NIGHTLY-only.** The cache enforces a hard 60s minimum TTL
+  (`core.jwks_cache.MIN_CACHE_TTL_SECONDS`), so a genuine TTL rollover cannot
+  happen inside a ~3s CI-short window — S4 needs a >60s run.
+- **S10 is an unimplemented scaffold.** Proving a synchronous custom claims
+  validator stalls the event loop needs a blocking validator wired into the RS
+  app, which does not exist yet. The row is a DIAGNOSTIC-only placeholder, never
+  gated, and drives no assertion. Do **not** treat it as coverage.
+
+## Calibrated SLO baseline
+
+The numbers below are measured from a DoD Locust run of `run_profile(CI_SHORT)`
+with 1 worker (mock OP + booted RS, no Docker). They are the baseline the SLO
+gates are calibrated against.
+
+| Scenario | req | fail | RPS | p50 | p95 | p99 | 5xx | upstream fetches |
+|----------|-----|------|-----|-----|-----|-----|-----|------------------|
+| S1 warm RPS ceiling (valid RS256) | 4755 | 0 | 1644.6 | 4ms | 7ms | 10ms | 0 | 0 (all cache hits) |
+| S2 alg cost (RS256 vs ES256) | 4488 | 0 | 1553.4 | 4ms | 7ms | 9ms | 0 | 0 |
+| S3 cold stampede (single-flight) | 4676 | 0 | 1618.2 | 8ms | 13ms | 24ms | 0 | discovery=1, jwks=1 (coalesced) |
+| S6 kid-rotation storm | 6049 | 0 | 2088.3 | 3ms | 7ms | 13ms | 0 | discovery=1, jwks=8 (~1/cooldown) |
+| S8 rejection uniformity under contention | 6568 | 0 | 2273.1 | 5ms | 14ms | 19ms | 0 | discovery=0, jwks=2 |
+
+**Headline:** warm p99 ~9–10ms, cold-stampede p99 ~24ms, RPS/worker
+~1550–2270, and **zero 5xx / zero unexpected failures** across every scenario.
+S3 proves single-flight directly: 4676 concurrent cold requests coalesce to
+exactly **1** discovery + **1** JWKS upstream fetch.
+
+### Recommended gates
+
+The runner's `GATES` start permissive (all thresholds `None`) so a baseline run
+never fails on an uncalibrated number. The values below are the recommended
+headroomed targets derived from the baseline above:
+
+| Gate | Target |
+|------|--------|
+| warm `max_p99` | ≤ 50ms |
+| cold-stampede `max_p99` | ≤ 200ms |
+| min RPS | ≥ 800 / worker |
+| max error-rate | ≤ 0.001 (0.1%) — **error excludes** expected 401s for invalid token classes |
+| min cache-hit-rate | ≥ 0.99 (read at `workers=1` for exactness) |
+| 5xx count | == 0 (hard gate) |
+| single-flight | cold-stampede upstream fetches == 1 discovery + 1 JWKS per issuer |
+
+Two invariants hold regardless of threshold calibration and are asserted today: a
+scenario must emit **zero** server errors (5xx), and a *steady-state* scenario
+must have **zero** unexpected-status divergences (every class returns its expected
+200/401/403). Expected 401/403 rejections for invalid token classes are the
+correct outcome and stay out of the error budget.
+
+## Metrics sources
+
+- **Latency / RPS / per-class p50-p99** — Locust's own aggregate + per-class
+  stats, serialised from `locustfile.py`.
+- **Cache-hit rate** — scraped from the RS `/metrics` endpoint (the per-process
+  `get_cache_counters()` snapshot). Read at `workers=1` for an exact rate; across
+  `--workers N` each worker keeps its own counters, so aggregate externally.
+- **Upstream fetches per issuer** — the mock OP's in-process `/_stats` counters,
+  reset after any warmup so the measured window is clean. These are the
+  authoritative single-flight proof.

--- a/src/tests/load/__init__.py
+++ b/src/tests/load/__init__.py
@@ -1,0 +1,21 @@
+"""Load / soak suite for the token-blaster harness (TH-1.5, #474, epic #462).
+
+Drives the booted resource server (:func:`~tests.harness.rs_server.boot_rs`) with
+the pre-minted replay pool and the controllable mock OP
+(:func:`~tests.harness.serve_mock_op`) under Locust, implementing design §4's
+scenarios S1-S12 and reporting the §5 metrics (RPS, latency percentiles,
+error-rate-by-class, cache-hit-rate, upstream fetches/issuer).
+
+* :mod:`scenarios` — the S1-S12 catalogue + run profiles + expected-status map.
+* :mod:`pool` — the pre-minted replay pool (mint once, replay many).
+* :mod:`locustfile` — a standalone Locust file the runner drives as a subprocess.
+* :mod:`runner` — orchestration (fresh mock OP + booted RS per scenario) + metric
+  collection + SLO gates.
+
+``locust`` is a ``load`` dependency-group extra. Importing it triggers gevent's
+``monkey.patch_all()``, which deadlocks the parent's in-process asyncio mock-OP
+server thread, so :mod:`runner` runs Locust OUT of process (never importing it)
+and :mod:`locustfile` — the only module that imports ``locust`` — runs only in
+that subprocess. Both are excluded from the root pyrefly lint env; run the suite
+via ``make test-harness-load``.
+"""

--- a/src/tests/load/locustfile.py
+++ b/src/tests/load/locustfile.py
@@ -10,9 +10,11 @@ The parent hands two file paths through the environment:
 
 * ``HARNESS_POOL_FILE`` — a JSON array of ``{"name", "token", "expected_status"}``
   entries (the pre-minted replay pool).
-* ``HARNESS_RESULT_FILE`` — where this file writes the run summary on quit
-  (per-class request/failure counts, latency percentiles, RPS, and the 5xx count
-  the parent asserts is zero).
+* ``HARNESS_RESULT_FILE`` — where this file writes the run summary on quit:
+  aggregate RPS + p50/p95/p99/p999 latency, the 5xx count the parent asserts is
+  zero, and a per-class breakdown carrying each class's request/failure counts
+  **and** its p50/p95/p99 latency (so the S2 RS256-vs-ES256 cost ratio is
+  computable from the result).
 
 A response is scored a *failure* only when its status diverges from the class's
 ``expected_status`` — expected 401/403 rejections are the correct outcome and stay
@@ -79,11 +81,16 @@ def _count_server_errors(response: Any = None, **_kw: Any) -> None:
 def _write_summary(environment: Any, **_kw: Any) -> None:
     """Serialise the run summary for the parent runner to read back."""
     total = environment.stats.total
-    by_class: dict[str, dict[str, int]] = {}
+    by_class: dict[str, dict[str, float]] = {}
     for (name, _method), entry in environment.stats.entries.items():
+        # Per-class latency percentiles (not just counts) so the parent can
+        # compute the S2 alg-cost ratio (ES256 vs RS256) from the summary.
         by_class[name] = {
             "requests": entry.num_requests,
             "failures": entry.num_failures,
+            "p50": float(entry.get_response_time_percentile(0.5)),
+            "p95": float(entry.get_response_time_percentile(0.95)),
+            "p99": float(entry.get_response_time_percentile(0.99)),
         }
     summary = {
         "num_requests": total.num_requests,
@@ -92,6 +99,7 @@ def _write_summary(environment: Any, **_kw: Any) -> None:
         "p50": float(total.get_response_time_percentile(0.5)),
         "p95": float(total.get_response_time_percentile(0.95)),
         "p99": float(total.get_response_time_percentile(0.99)),
+        "p999": float(total.get_response_time_percentile(0.999)),
         "server_errors": _server_errors[0],
         "by_class": by_class,
     }

--- a/src/tests/load/locustfile.py
+++ b/src/tests/load/locustfile.py
@@ -1,0 +1,98 @@
+"""Standalone Locust file replaying the pre-minted pool against the booted RS.
+
+Run as a **subprocess** (``locust --headless -f locustfile.py``) by :mod:`runner`,
+NOT imported in-process: locust imports trigger gevent's ``monkey.patch_all()``,
+which deadlocks the parent's in-process asyncio mock-OP server thread. Isolating
+Locust in its own process keeps gevent's patched world away from the mock OP
+(served in the parent) and the RS (a separate uvicorn subprocess).
+
+The parent hands two file paths through the environment:
+
+* ``HARNESS_POOL_FILE`` — a JSON array of ``{"name", "token", "expected_status"}``
+  entries (the pre-minted replay pool).
+* ``HARNESS_RESULT_FILE`` — where this file writes the run summary on quit
+  (per-class request/failure counts, latency percentiles, RPS, and the 5xx count
+  the parent asserts is zero).
+
+A response is scored a *failure* only when its status diverges from the class's
+``expected_status`` — expected 401/403 rejections are the correct outcome and stay
+out of the error budget (design §5 error-rate-by-class).
+
+``locust``/``gevent`` resolve only under ``uv run --group load``; this module is
+pyrefly-excluded in the root lint env for that reason.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import secrets
+from typing import Any
+
+from locust import HttpUser, events, task
+
+
+HTTP_SERVER_ERROR_FLOOR = 500
+
+_POOL: list[dict[str, Any]] = json.loads(
+    Path(os.environ["HARNESS_POOL_FILE"]).read_text()
+)
+if not _POOL:
+    raise ValueError("HARNESS_POOL_FILE described an empty replay pool")
+
+# Server-error (5xx) tally — a real defect the parent asserts is zero (design §5).
+# A one-element list (not a bare ``int`` + ``global``) so the event listener can
+# mutate it without a module-level ``global`` statement.
+_server_errors = [0]
+
+
+class ReplayUser(HttpUser):
+    """Replays a random pooled token at ``/protected`` every task."""
+
+    @task
+    def hit_protected(self) -> None:
+        entry = secrets.choice(_POOL)
+        with self.client.get(
+            "/protected",
+            headers={"Authorization": f"Bearer {entry['token']}"},
+            name=entry["name"],
+            catch_response=True,
+        ) as response:
+            if response.status_code == entry["expected_status"]:
+                response.success()
+            else:
+                response.failure(
+                    f"{entry['name']}: expected {entry['expected_status']}, "
+                    f"got {response.status_code}"
+                )
+
+
+@events.request.add_listener
+def _count_server_errors(response: Any = None, **_kw: Any) -> None:
+    status = getattr(response, "status_code", None)
+    if status is not None and status >= HTTP_SERVER_ERROR_FLOOR:
+        _server_errors[0] += 1
+
+
+@events.quitting.add_listener
+def _write_summary(environment: Any, **_kw: Any) -> None:
+    """Serialise the run summary for the parent runner to read back."""
+    total = environment.stats.total
+    by_class: dict[str, dict[str, int]] = {}
+    for (name, _method), entry in environment.stats.entries.items():
+        by_class[name] = {
+            "requests": entry.num_requests,
+            "failures": entry.num_failures,
+        }
+    summary = {
+        "num_requests": total.num_requests,
+        "num_failures": total.num_failures,
+        "rps": float(getattr(total, "total_rps", 0.0)),
+        "p50": float(total.get_response_time_percentile(0.5)),
+        "p95": float(total.get_response_time_percentile(0.95)),
+        "p99": float(total.get_response_time_percentile(0.99)),
+        "server_errors": _server_errors[0],
+        "by_class": by_class,
+    }
+    Path(os.environ["HARNESS_RESULT_FILE"]).write_text(json.dumps(summary))

--- a/src/tests/load/pool.py
+++ b/src/tests/load/pool.py
@@ -1,0 +1,148 @@
+"""Pre-minted replay pool for the load/soak suite — TH-1.5 (#474, design §3).
+
+"Pre-mint once, replay many": validation is stateless and real IdPs rate-limit,
+so each distinct token class is minted a single time and replayed under load.
+Each :class:`PoolEntry` carries the status the booted RS is expected to return
+(:data:`~scenarios.EXPECTED_STATUS`), so the Locust driver can score a response
+as a failure ONLY when the observed status diverges — expected 401/403 rejections
+are the correct outcome and stay out of the error budget (design §5).
+
+The mock-OP forged corpus supplies every forgeable class off a known signing
+key; two synthetic classes (``valid_es256``, ``scopeless``) are minted directly
+off the mock OP. The ``valid`` class is re-mintable so a long soak can refresh it
+across the 300s token TTL (:meth:`LoadPool.refresh`).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import time
+from typing import TYPE_CHECKING
+
+from ..harness.corpus import CORPUS_AUDIENCE, build_corpus
+from .scenarios import EXPECTED_STATUS
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from ..harness.mock_op import MockOP
+
+
+# Classes minted directly off the mock OP rather than taken from the forged
+# corpus (which is keyed to the RS256 primary key / carries scope="read").
+_SYNTHETIC_CLASSES = frozenset({"valid_es256", "scopeless"})
+
+_TOKEN_LIFETIME = 300  # seconds — mirrors the mock OP / real-IdP TTL (design §3)
+
+
+@dataclass
+class PoolEntry:
+    """A replayable token plus the RS status its class should produce.
+
+    ``expires_at`` is ``None`` for classes that are not re-minted (forged
+    negatives never expire meaningfully — they are already rejected).
+    """
+
+    name: str
+    token: str
+    expected_status: int
+    expires_at: float | None = None
+
+    def is_expired(self, *, now: float | None = None, leeway: float = 30.0) -> bool:
+        if self.expires_at is None:
+            return False
+        return (now if now is not None else time.time()) >= self.expires_at - leeway
+
+
+def _mint_synthetic(op: MockOP, name: str, now: int) -> str:
+    """Mint the two classes that are not in the forged corpus."""
+    base = {
+        "iss": op.issuer,
+        "sub": "load-subject",
+        "aud": CORPUS_AUDIENCE,
+        "iat": now,
+        "nbf": now,
+        "exp": now + _TOKEN_LIFETIME,
+        "client_id": "mock-client",
+    }
+    if name == "valid_es256":
+        # Same valid access token, signed by the published ES256 key — exercises
+        # the ES256 validation path for the alg-cost scenario (S2).
+        return op.sign({**base, "scope": "read"}, key=op.ec_key)
+    if name == "scopeless":
+        # Validly signed, no scope/scp and no ID-token-only claim: passes
+        # validation, then fails require_scope("read") -> 403.
+        return op.sign(base)
+    raise ValueError(f"unknown synthetic token class: {name!r}")
+
+
+class LoadPool:
+    """A blend of :class:`PoolEntry` objects for one scenario."""
+
+    def __init__(self, entries: Iterable[PoolEntry], op: MockOP) -> None:
+        self._entries = list(entries)
+        self._op = op
+
+    @property
+    def entries(self) -> list[PoolEntry]:
+        return self._entries
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+    def refresh(self, *, now: float | None = None) -> int:
+        """Re-mint any expired re-mintable class in place (soak TTL cadence).
+
+        Returns the number of entries re-minted. Forged negatives (``expires_at``
+        is ``None``) are never re-minted — they are meant to be rejected.
+        """
+        stamp = int(now if now is not None else time.time())
+        refreshed = 0
+        for entry in self._entries:
+            if not entry.is_expired(now=now):
+                continue
+            entry.token = _remint(self._op, entry.name, stamp)
+            entry.expires_at = stamp + _TOKEN_LIFETIME
+            refreshed += 1
+        return refreshed
+
+
+def _remint(op: MockOP, name: str, now: int) -> str:
+    if name == "valid":
+        return op.mint_access_token(scopes="read")["access_token"]
+    if name in _SYNTHETIC_CLASSES:
+        return _mint_synthetic(op, name, now)
+    # Forged classes are not re-minted; keep the original token.
+    return build_corpus(op)[name].jwt
+
+
+def build_load_pool(op: MockOP, classes: Iterable[str]) -> LoadPool:
+    """Build the replay pool for *classes* off the live mock OP.
+
+    Every requested class must appear in :data:`~scenarios.EXPECTED_STATUS`; an
+    unknown class is a scenario-definition bug and raises rather than silently
+    dropping load coverage.
+    """
+    now = int(time.time())
+    corpus = build_corpus(op)
+    entries: list[PoolEntry] = []
+    for name in classes:
+        if name not in EXPECTED_STATUS:
+            raise ValueError(f"token class {name!r} has no EXPECTED_STATUS mapping")
+        if name in _SYNTHETIC_CLASSES:
+            token = _mint_synthetic(op, name, now)
+        else:
+            token = corpus[name].jwt
+        # Only the re-mintable valid classes carry an expiry the soak refreshes;
+        # forged negatives are already-rejected and need no re-mint.
+        remintable = name == "valid" or name in _SYNTHETIC_CLASSES
+        entries.append(
+            PoolEntry(
+                name=name,
+                token=token,
+                expected_status=EXPECTED_STATUS[name],
+                expires_at=now + _TOKEN_LIFETIME if remintable else None,
+            )
+        )
+    return LoadPool(entries, op)

--- a/src/tests/load/runner.py
+++ b/src/tests/load/runner.py
@@ -1,0 +1,312 @@
+"""Load/soak runner — TH-1.5 (#474 · epic #462, design §4/§5).
+
+Orchestrates one scenario end to end: serve the mock OP over real HTTP, boot the
+resource server under uvicorn against it, build the pre-minted replay pool, drive
+load with a **real Locust run**, then collect the metrics design §5 asks for:
+RPS, p50/p95/p99, error-rate-by-class (expected rejections excluded), cache-hit
+rate (RS ``/metrics`` at workers=1) and upstream fetches per issuer (the mock OP's
+in-process ``stats``).
+
+Locust runs in a **subprocess** (``locust --headless -f locustfile.py``) rather
+than programmatically: importing locust triggers gevent's ``monkey.patch_all()``,
+which deadlocks the parent's in-process asyncio mock-OP server thread. Keeping
+Locust out-of-process isolates gevent's patched world — the parent stays a plain
+asyncio/threading process. The pre-minted pool crosses the boundary as a JSON file
+(tokens are just strings); the run summary comes back the same way.
+
+Each scenario runs against a **fresh** mock OP + RS so caches start empty and no
+failure-injection state bleeds across scenarios.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from dataclasses import dataclass, field
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+from typing import TYPE_CHECKING
+
+import httpx
+
+from ..harness import serve_mock_op
+from ..harness.corpus import CORPUS_AUDIENCE
+from ..harness.rs_server import boot_rs
+from .pool import build_load_pool
+from .scenarios import SCENARIOS_BY_ID, Profile, Scenario, profile_scenarios
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from ..harness.mock_op import MockOP
+    from .pool import LoadPool
+
+
+HTTP_SERVER_ERROR_FLOOR = 500
+_LOCUSTFILE = Path(__file__).with_name("locustfile.py")
+_LOCUST_GRACE = 60.0  # seconds of headroom over a scenario's run-time
+
+
+@dataclass(frozen=True)
+class Gate:
+    """SLO thresholds for a scenario class (design §5).
+
+    All fields start ``None`` (permissive) so a baseline run never fails on an
+    uncalibrated threshold; the ``test`` phase measures and the ``docs`` phase
+    writes the calibrated numbers here / into the README table.
+    """
+
+    max_p99_ms: float | None = None
+    min_rps: float | None = None
+    max_error_rate: float | None = None
+    min_cache_hit_rate: float | None = None
+
+
+# Gate key -> thresholds. Permissive until the test-phase baseline calibrates them.
+GATES: dict[str, Gate] = {
+    "warm": Gate(),
+    "cold": Gate(),
+}
+
+
+@dataclass
+class LoadResult:
+    """The measured outcome of one scenario run."""
+
+    scenario_id: str
+    title: str
+    num_requests: int
+    num_failures: int
+    rps: float
+    p50_ms: float
+    p95_ms: float
+    p99_ms: float
+    server_errors: int
+    steady_state: bool
+    requests_by_class: dict[str, int] = field(default_factory=dict)
+    failures_by_class: dict[str, int] = field(default_factory=dict)
+    cache_metrics: dict[str, int] = field(default_factory=dict)
+    upstream_stats: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def error_rate(self) -> float:
+        """Unexpected-status fraction (expected 401/403 rejections excluded)."""
+        return self.num_failures / self.num_requests if self.num_requests else 0.0
+
+    @property
+    def cache_hit_rate(self) -> float:
+        """Combined discovery+JWKS hit rate over the measured window (0..1)."""
+        m = self.cache_metrics
+        hits = m.get("disco_hits", 0) + m.get("jwks_hits", 0)
+        misses = m.get("disco_misses", 0) + m.get("jwks_misses", 0)
+        total = hits + misses
+        return hits / total if total else 1.0
+
+
+def _scrape_cache_metrics(base_url: str) -> dict[str, int]:
+    try:
+        resp = httpx.get(f"{base_url}/metrics", timeout=5.0)
+        resp.raise_for_status()
+        return {k: int(v) for k, v in resp.json().items()}
+    except (httpx.HTTPError, ValueError):  # pragma: no cover - defensive
+        return {}
+
+
+def _warm_cache(base_url: str, token: str) -> None:
+    """Prime the RS discovery+JWKS cache before a warm-scenario measurement."""
+    with contextlib.suppress(httpx.HTTPError):
+        httpx.get(
+            f"{base_url}/protected",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=10.0,
+        )
+
+
+def _run_locust(base_url: str, pool: LoadPool, scenario: Scenario) -> dict:
+    """Drive a real Locust run in a subprocess; return its summary dict."""
+    with tempfile.TemporaryDirectory() as tmp:
+        pool_file = Path(tmp) / "pool.json"
+        result_file = Path(tmp) / "result.json"
+        pool_file.write_text(
+            json.dumps(
+                [
+                    {
+                        "name": e.name,
+                        "token": e.token,
+                        "expected_status": e.expected_status,
+                    }
+                    for e in pool.entries
+                ]
+            )
+        )
+        run_seconds = max(1, int(scenario.duration_seconds))
+        cmd = [
+            sys.executable,
+            "-m",
+            "locust",
+            "--headless",
+            "-f",
+            str(_LOCUSTFILE),
+            "-u",
+            str(scenario.users),
+            "-r",
+            str(scenario.users),  # ramp all users in one second
+            "-t",
+            f"{run_seconds}s",
+            "--host",
+            base_url,
+            "--loglevel",
+            "WARNING",
+            # Expected 401/403 rejections are scored as successes, but a
+            # failure-injection scenario legitimately produces failures; let the
+            # parent evaluate gates from the summary rather than the exit code.
+            "--exit-code-on-error",
+            "0",
+        ]
+        env = {
+            "HARNESS_POOL_FILE": str(pool_file),
+            "HARNESS_RESULT_FILE": str(result_file),
+        }
+        completed = subprocess.run(  # noqa: S603 — fixed argv, no shell, test-only
+            cmd,
+            env={**os.environ, **env},
+            capture_output=True,
+            text=True,
+            timeout=run_seconds + _LOCUST_GRACE,
+            check=False,
+        )
+        if not result_file.exists():
+            raise RuntimeError(
+                f"locust produced no summary for {scenario.id} "
+                f"(exit {completed.returncode}):\n{completed.stderr[-2000:]}"
+            )
+        return json.loads(result_file.read_text())
+
+
+def run_scenario(scenario: Scenario, op: MockOP, base_url: str) -> LoadResult:
+    """Drive one scenario against an already-booted RS and mock OP."""
+    pool = build_load_pool(op, scenario.classes)
+
+    # A warm scenario measures the hot-cache steady state: prime the cache with a
+    # valid token, then zero the upstream counters so the measured window starts
+    # clean. A cold scenario skips the warmup so its stampede fetches are counted.
+    if scenario.gate == "warm":
+        valid = next((e for e in pool.entries if e.name.startswith("valid")), None)
+        if valid is not None:
+            _warm_cache(base_url, valid.token)
+    # Apply failure injection AFTER the pool is minted (valid tokens signed by the
+    # published key) and after any warmup.
+    if scenario.setup is not None:
+        scenario.setup(op)
+    op.stats.reset()
+
+    summary = _run_locust(base_url, pool, scenario)
+    return _to_result(scenario, summary, base_url, op)
+
+
+def _to_result(
+    scenario: Scenario, summary: dict, base_url: str, op: MockOP
+) -> LoadResult:
+    by_class = summary.get("by_class", {})
+    return LoadResult(
+        scenario_id=scenario.id,
+        title=scenario.title,
+        num_requests=int(summary.get("num_requests", 0)),
+        num_failures=int(summary.get("num_failures", 0)),
+        rps=float(summary.get("rps", 0.0)),
+        p50_ms=float(summary.get("p50", 0.0)),
+        p95_ms=float(summary.get("p95", 0.0)),
+        p99_ms=float(summary.get("p99", 0.0)),
+        server_errors=int(summary.get("server_errors", 0)),
+        steady_state=scenario.steady_state,
+        requests_by_class={n: v["requests"] for n, v in by_class.items()},
+        failures_by_class={
+            n: v["failures"] for n, v in by_class.items() if v["failures"]
+        },
+        cache_metrics=_scrape_cache_metrics(base_url),
+        upstream_stats=op.stats.snapshot(),
+    )
+
+
+def evaluate_gates(result: LoadResult) -> list[str]:
+    """Return SLO/correctness violations for a result (empty = passed).
+
+    Two invariants hold regardless of threshold calibration: a scenario must emit
+    ZERO server errors (500s — a real defect, design §5), and a *steady-state*
+    scenario must have ZERO unexpected-status divergences (every class returned
+    its expected 200/401/403). Perf thresholds are checked only once calibrated.
+    """
+    violations: list[str] = []
+    if result.server_errors:
+        violations.append(
+            f"{result.scenario_id}: {result.server_errors} server error(s) "
+            f"(>= {HTTP_SERVER_ERROR_FLOOR}) — must be 0"
+        )
+    if result.steady_state and result.num_failures:
+        violations.append(
+            f"{result.scenario_id}: {result.num_failures} unexpected status "
+            f"divergence(s) under steady state ({result.failures_by_class})"
+        )
+    gate = GATES.get(_gate_key(result.scenario_id))
+    if gate is not None:
+        if gate.max_p99_ms is not None and result.p99_ms > gate.max_p99_ms:
+            violations.append(
+                f"{result.scenario_id}: p99 {result.p99_ms}ms > {gate.max_p99_ms}ms"
+            )
+        if gate.min_rps is not None and result.rps < gate.min_rps:
+            violations.append(
+                f"{result.scenario_id}: rps {result.rps:.1f} < {gate.min_rps}"
+            )
+        if gate.max_error_rate is not None and result.error_rate > gate.max_error_rate:
+            violations.append(
+                f"{result.scenario_id}: error-rate {result.error_rate:.4f} "
+                f"> {gate.max_error_rate}"
+            )
+        if (
+            gate.min_cache_hit_rate is not None
+            and result.cache_hit_rate < gate.min_cache_hit_rate
+        ):
+            violations.append(
+                f"{result.scenario_id}: cache-hit-rate {result.cache_hit_rate:.4f} "
+                f"< {gate.min_cache_hit_rate}"
+            )
+    return violations
+
+
+def _gate_key(scenario_id: str) -> str:
+    scenario = SCENARIOS_BY_ID.get(scenario_id)
+    return scenario.gate if scenario and scenario.gate else "warm"
+
+
+def run_profile(profile: Profile) -> list[LoadResult]:
+    """Run every scenario in *profile* against a fresh mock-OP-backed RS each.
+
+    Each scenario gets its own in-process mock OP + booted RS so caches start
+    empty and failure-injection state never bleeds across scenarios. The mock OP
+    is the design's failure-injection driver (latency, 429, key rotation), so the
+    self-contained CI_SHORT profile needs no external IdP — the node-oidc
+    real-issuer leg (real minted tokens) is a separate test-phase concern.
+    """
+    results: list[LoadResult] = []
+    for scenario in profile_scenarios(profile):
+        with _scenario_stack() as (op, base_url):
+            results.append(run_scenario(scenario, op, base_url))
+    return results
+
+
+@contextlib.contextmanager
+def _scenario_stack() -> Iterator[tuple[MockOP, str]]:
+    """Fresh mock OP + booted RS for a single scenario (clean cache each time)."""
+    with (
+        serve_mock_op() as op,
+        boot_rs(
+            discovery_url=op.discovery_url,
+            audience=CORPUS_AUDIENCE,
+            require_scope="read",
+        ) as base_url,
+    ):
+        yield op, base_url

--- a/src/tests/load/runner.py
+++ b/src/tests/load/runner.py
@@ -3,8 +3,9 @@
 Orchestrates one scenario end to end: serve the mock OP over real HTTP, boot the
 resource server under uvicorn against it, build the pre-minted replay pool, drive
 load with a **real Locust run**, then collect the metrics design §5 asks for:
-RPS, p50/p95/p99, error-rate-by-class (expected rejections excluded), cache-hit
-rate (RS ``/metrics`` at workers=1) and upstream fetches per issuer (the mock OP's
+RPS, p50/p95/p99/p999, per-class latency (the S2 alg-cost ratio),
+error-rate-by-class (expected rejections excluded), cache-hit rate (RS
+``/metrics`` at workers=1) and upstream fetches per issuer (the mock OP's
 in-process ``stats``).
 
 Locust runs in a **subprocess** (``locust --headless -f locustfile.py``) rather
@@ -85,12 +86,27 @@ class LoadResult:
     p50_ms: float
     p95_ms: float
     p99_ms: float
+    p999_ms: float
     server_errors: int
     steady_state: bool
     requests_by_class: dict[str, int] = field(default_factory=dict)
     failures_by_class: dict[str, int] = field(default_factory=dict)
+    # class name -> {"p50", "p95", "p99"} ms; drives the S2 alg-cost ratio.
+    latency_by_class: dict[str, dict[str, float]] = field(default_factory=dict)
     cache_metrics: dict[str, int] = field(default_factory=dict)
     upstream_stats: dict[str, int] = field(default_factory=dict)
+
+    def alg_cost_ratio(self, numerator: str, denominator: str) -> float | None:
+        """p95 latency ratio of two token classes (e.g. ES256 vs RS256, S2).
+
+        Returns ``None`` when either class is absent or the denominator p95 is
+        zero, so a missing/degenerate sample never fabricates a ratio.
+        """
+        num = self.latency_by_class.get(numerator, {}).get("p95")
+        den = self.latency_by_class.get(denominator, {}).get("p95")
+        if not num or not den:
+            return None
+        return num / den
 
     @property
     def error_rate(self) -> float:
@@ -99,12 +115,21 @@ class LoadResult:
 
     @property
     def cache_hit_rate(self) -> float:
-        """Combined discovery+JWKS hit rate over the measured window (0..1)."""
+        """Combined discovery+JWKS hit rate over the measured window (0..1).
+
+        Returns ``0.0`` — not ``1.0`` — when the window recorded no counted
+        cache activity (``total == 0``). An all-upstream-error window now counts
+        its failed fetches as misses (see ``record_*_miss``), so ``total`` is
+        non-zero there and the rate reflects the storm; the ``total == 0`` guard
+        therefore only fires when nothing reached the counted cache paths at all,
+        and reporting that as a perfect 100% would let a broken ``/metrics``
+        scrape masquerade as a warm cache under a ``min_cache_hit_rate`` gate.
+        """
         m = self.cache_metrics
         hits = m.get("disco_hits", 0) + m.get("jwks_hits", 0)
         misses = m.get("disco_misses", 0) + m.get("jwks_misses", 0)
         total = hits + misses
-        return hits / total if total else 1.0
+        return hits / total if total else 0.0
 
 
 def _scrape_cache_metrics(base_url: str) -> dict[str, int]:
@@ -221,11 +246,16 @@ def _to_result(
         p50_ms=float(summary.get("p50", 0.0)),
         p95_ms=float(summary.get("p95", 0.0)),
         p99_ms=float(summary.get("p99", 0.0)),
+        p999_ms=float(summary.get("p999", 0.0)),
         server_errors=int(summary.get("server_errors", 0)),
         steady_state=scenario.steady_state,
         requests_by_class={n: v["requests"] for n, v in by_class.items()},
         failures_by_class={
             n: v["failures"] for n, v in by_class.items() if v["failures"]
+        },
+        latency_by_class={
+            n: {p: float(v[p]) for p in ("p50", "p95", "p99") if p in v}
+            for n, v in by_class.items()
         },
         cache_metrics=_scrape_cache_metrics(base_url),
         upstream_stats=op.stats.snapshot(),

--- a/src/tests/load/scenarios.py
+++ b/src/tests/load/scenarios.py
@@ -7,11 +7,14 @@ a scenario; :mod:`pool` builds its token blend; :mod:`locustfile` drives it.
 
 Scenarios are grouped into run **profiles**:
 
-* ``CI_SHORT`` (S1-S8) — the PR gate: short, deterministic, mock-OP-backed,
-  self-contained (no Docker).
+* ``CI_SHORT`` (S1, S2, S3, S6, S8) — the PR gate: short (~3s), deterministic,
+  mock-OP-backed, self-contained (no Docker).
 * ``DIAGNOSTIC`` (S5, S9, S10) — head-of-line / no-store / blocking-validator
   probes run on demand.
-* ``NIGHTLY`` (S7, S11, S12) — long LRU-thrash / RSS-FD soak / multi-tenant runs.
+* ``NIGHTLY`` (S4, S7, S11, S12) — TTL-refresh / LRU-thrash / RSS-FD soak /
+  multi-tenant runs. S4 lives here (not CI-short) because the cache enforces a
+  60s minimum TTL (``core.jwks_cache.MIN_CACHE_TTL_SECONDS``), so a genuine
+  TTL rollover cannot happen inside a ~3s CI-short window — it needs a >60s run.
 
 The SLO gate *thresholds* start unset (:mod:`runner` ``GATES``); the ``test``
 phase runs a baseline, and the ``docs`` phase writes the calibrated table into
@@ -161,10 +164,22 @@ def _inject_latency(op: MockOP) -> None:
     op.controls.latency_seconds = 0.25
 
 
-# The scenario catalogue. S1-S8 form CI_SHORT; S9/S10/S5 DIAGNOSTIC; S7/S11/S12
-# NIGHTLY. Deep mid-run dynamics (S4 TTL rollover, S6 rotation storm, S11 soak
-# RSS/FD trends) are calibrated in the test phase; the setup hooks here apply the
-# pre-run failure-injection state each scenario needs.
+def _short_ttl(op: MockOP) -> None:
+    """S4: advertise the shortest cacheable TTL so a >60s soak crosses the cache
+    TTL boundary and forces a single-flight refresh mid-load.
+
+    ``max-age=60`` is the floor the cache honours (values below
+    ``core.jwks_cache.MIN_CACHE_TTL_SECONDS`` are clamped up to 60s), so this is
+    the tightest rollover achievable — which is why S4 is a NIGHTLY (>60s)
+    scenario, not a CI-short one."""
+    op.controls.discovery_cache_control = "max-age=60"
+    op.controls.jwks_cache_control = "max-age=60"
+
+
+# The scenario catalogue. S1, S2, S3, S6, S8 form CI_SHORT; S5/S9/S10 DIAGNOSTIC;
+# S4/S7/S11/S12 NIGHTLY. Deep mid-run dynamics (S4 TTL rollover, S6 rotation
+# storm, S11 soak RSS/FD trends) are calibrated in the test phase; the setup
+# hooks here apply the pre-run failure-injection state each scenario needs.
 SCENARIOS: tuple[Scenario, ...] = (
     Scenario(
         id="S1",
@@ -194,12 +209,17 @@ SCENARIOS: tuple[Scenario, ...] = (
     ),
     Scenario(
         id="S4",
-        title="TTL refresh under load (short TTL)",
-        profile=Profile.CI_SHORT,
+        title="TTL refresh under load (60s TTL rollover)",
+        profile=Profile.NIGHTLY,
         classes=("valid",),
-        gate="warm",
-        notes="a cache TTL rollover mid-load must not spike errors or storm "
-        "the upstream (single-flight refresh)",
+        duration_seconds=75.0,
+        setup=_short_ttl,
+        gate="cold",
+        notes="over a >60s soak the min-TTL (60s) discovery/JWKS entries expire "
+        "mid-load; the rollover must stay single-flight (upstream re-fetch "
+        "bounded to ~1 per TTL window, not per request) and spike no errors. "
+        "NIGHTLY because the 60s cache-TTL floor cannot roll over in a CI-short "
+        "(~3s) window — calibrated nightly",
     ),
     Scenario(
         id="S5",
@@ -256,13 +276,16 @@ SCENARIOS: tuple[Scenario, ...] = (
     ),
     Scenario(
         id="S10",
-        title="blocking claims_validator (event-loop stall)",
+        title="blocking claims_validator (event-loop stall) — SCAFFOLD",
         profile=Profile.DIAGNOSTIC,
         classes=("valid",),
         steady_state=False,
         gate="warm",
-        notes="a synchronous custom claims validator stalls the loop vs an "
-        "async one (calibrated in the test phase)",
+        notes="INCOMPLETE: proving a synchronous custom claims validator stalls "
+        "the loop (vs an async one) needs a blocking validator wired into the RS "
+        "app, which is not yet implemented — this row is a placeholder for a "
+        "later iteration. DIAGNOSTIC-only, never gated; drives no assertion "
+        "today. Do NOT treat as coverage.",
     ),
     Scenario(
         id="S11",

--- a/src/tests/load/scenarios.py
+++ b/src/tests/load/scenarios.py
@@ -1,0 +1,294 @@
+"""Load/soak scenario catalogue — TH-1.5 (#474 · epic #462, design §4 S1-S12).
+
+Each :class:`Scenario` is *data*: which token classes populate the replay pool,
+what mock-OP failure injection to apply before the run, how much load to drive,
+and which SLO gate (design §5) evaluates the result. The :mod:`runner` executes
+a scenario; :mod:`pool` builds its token blend; :mod:`locustfile` drives it.
+
+Scenarios are grouped into run **profiles**:
+
+* ``CI_SHORT`` (S1-S8) — the PR gate: short, deterministic, mock-OP-backed,
+  self-contained (no Docker).
+* ``DIAGNOSTIC`` (S5, S9, S10) — head-of-line / no-store / blocking-validator
+  probes run on demand.
+* ``NIGHTLY`` (S7, S11, S12) — long LRU-thrash / RSS-FD soak / multi-tenant runs.
+
+The SLO gate *thresholds* start unset (:mod:`runner` ``GATES``); the ``test``
+phase runs a baseline, and the ``docs`` phase writes the calibrated table into
+``README.md``. Until then the gates are permissive so a baseline run never fails
+on an uncalibrated threshold.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from ..harness.mock_op import MockOP
+
+
+# HTTP status codes the RS returns for each token class (audience=mock-api,
+# require_scope=read — the same RS contract the correctness matrix asserts).
+HTTP_OK = 200
+HTTP_UNAUTHORIZED = 401
+HTTP_FORBIDDEN = 403
+
+
+# Token class -> the status the booted RS returns in STEADY STATE (no failure
+# injection). Validly signed, correctly scoped tokens reach ``/protected`` (200);
+# every validation-failure class collapses to a uniform 401 (F-18); the
+# ID-token-as-access class is rejected by the always-on F-07 negative defence;
+# the scope-less token validates but fails ``require_scope`` (403).
+EXPECTED_STATUS: dict[str, int] = {
+    "valid": HTTP_OK,
+    "valid_es256": HTTP_OK,
+    "cnf_bound": HTTP_OK,
+    "oversized": HTTP_OK,
+    "multi_aud_untrusted": HTTP_OK,
+    "id_as_access": HTTP_UNAUTHORIZED,
+    "expired": HTTP_UNAUTHORIZED,
+    "nbf_future": HTTP_UNAUTHORIZED,
+    "wrong_iss": HTTP_UNAUTHORIZED,
+    "wrong_aud": HTTP_UNAUTHORIZED,
+    "tampered_sig": HTTP_UNAUTHORIZED,
+    "unknown_kid": HTTP_UNAUTHORIZED,
+    "wrong_alg": HTTP_UNAUTHORIZED,
+    "alg_none": HTTP_UNAUTHORIZED,
+    "scopeless": HTTP_FORBIDDEN,
+}
+
+# The eight validation-failure classes whose 401s are the CORRECT outcome, not
+# an error — they are excluded from the error budget (design §5). ``id_as_access``
+# (401) and ``scopeless`` (403) are expected rejections too, tracked by their own
+# expected status above; a class is an error only when observed != expected.
+EXPECTED_REJECTION_CLASSES = frozenset(
+    {
+        "expired",
+        "nbf_future",
+        "wrong_iss",
+        "wrong_aud",
+        "tampered_sig",
+        "unknown_kid",
+        "wrong_alg",
+        "alg_none",
+        "id_as_access",
+        "scopeless",
+    }
+)
+
+# A representative mixed blend for the rejection-under-contention scenario (S8):
+# accepted classes interleaved with every rejection class.
+MIXED_CLASSES: tuple[str, ...] = (
+    "valid",
+    "cnf_bound",
+    "oversized",
+    "multi_aud_untrusted",
+    "id_as_access",
+    "expired",
+    "nbf_future",
+    "wrong_iss",
+    "wrong_aud",
+    "tampered_sig",
+    "unknown_kid",
+    "wrong_alg",
+    "alg_none",
+    "scopeless",
+)
+
+
+class Profile(StrEnum):
+    """A named set of scenarios run together."""
+
+    CI_SHORT = "ci-short"
+    DIAGNOSTIC = "diagnostic"
+    NIGHTLY = "nightly"
+
+
+# A pre-run hook mutating the mock OP (failure injection) before load starts.
+SetupHook = Callable[["MockOP"], None]
+
+
+@dataclass(frozen=True)
+class Scenario:
+    """One load/soak scenario (design §4).
+
+    Attributes:
+        id: Stable scenario id (``"S1"``…``"S12"``).
+        title: Human-readable description.
+        profile: The run profile this scenario belongs to.
+        classes: Token classes blended into the replay pool.
+        users: Concurrent Locust users.
+        duration_seconds: How long to hold load.
+        setup: Optional mock-OP failure injection applied before the run.
+        steady_state: When ``True`` a class observed != its ``EXPECTED_STATUS``
+            is an error; when ``False`` (active failure injection) the per-class
+            status distribution is *reported* but not asserted, because the
+            expected status is transient and calibrated in the ``test`` phase.
+        gate: SLO gate key (design §5) or ``None`` while uncalibrated.
+        notes: What the scenario proves.
+    """
+
+    id: str
+    title: str
+    profile: Profile
+    classes: tuple[str, ...]
+    users: int = 8
+    duration_seconds: float = 3.0
+    setup: SetupHook | None = field(default=None, repr=False)
+    steady_state: bool = True
+    gate: str | None = None
+    notes: str = ""
+
+
+def _no_store_discovery(op: MockOP) -> None:
+    """S9: force the discovery document to be re-fetched on every request."""
+    op.controls.discovery_cache_control = "no-store"
+
+
+def _rotate_unpublished(op: MockOP) -> None:
+    """S6: rotate the active signing key WITHOUT publishing it, so freshly
+    minted tokens present an unknown ``kid`` until the cooldown recovers."""
+    op.rotate_keys(publish=False)
+
+
+def _inject_latency(op: MockOP) -> None:
+    """S5: add upstream latency so a cache-miss fetch stalls the single-flight
+    holder (head-of-line blocking)."""
+    op.controls.latency_seconds = 0.25
+
+
+# The scenario catalogue. S1-S8 form CI_SHORT; S9/S10/S5 DIAGNOSTIC; S7/S11/S12
+# NIGHTLY. Deep mid-run dynamics (S4 TTL rollover, S6 rotation storm, S11 soak
+# RSS/FD trends) are calibrated in the test phase; the setup hooks here apply the
+# pre-run failure-injection state each scenario needs.
+SCENARIOS: tuple[Scenario, ...] = (
+    Scenario(
+        id="S1",
+        title="warm RPS ceiling (valid RS256, hot cache)",
+        profile=Profile.CI_SHORT,
+        classes=("valid",),
+        gate="warm",
+        notes="find the warm p99 knee and RPS/worker with a fully hot cache",
+    ),
+    Scenario(
+        id="S2",
+        title="alg cost (RS256 vs ES256, warm)",
+        profile=Profile.CI_SHORT,
+        classes=("valid", "valid_es256"),
+        gate="warm",
+        notes="report the ES256/RS256 warm-validation cost ratio",
+    ),
+    Scenario(
+        id="S3",
+        title="cold stampede (empty cache, burst)",
+        profile=Profile.CI_SHORT,
+        classes=("valid",),
+        users=16,
+        gate="cold",
+        notes="a burst against an empty cache must fetch discovery+JWKS once "
+        "each (single-flight) — asserted via the mock-OP /_stats counters",
+    ),
+    Scenario(
+        id="S4",
+        title="TTL refresh under load (short TTL)",
+        profile=Profile.CI_SHORT,
+        classes=("valid",),
+        gate="warm",
+        notes="a cache TTL rollover mid-load must not spike errors or storm "
+        "the upstream (single-flight refresh)",
+    ),
+    Scenario(
+        id="S5",
+        title="provider-slowness head-of-line blocking",
+        profile=Profile.DIAGNOSTIC,
+        classes=("valid",),
+        setup=_inject_latency,
+        steady_state=False,
+        gate="cold",
+        notes="the single-flight holder retries with backoff while holding the "
+        "fetch lock — bound the cohort stall, capture 503-vs-401",
+    ),
+    Scenario(
+        id="S6",
+        title="kid-rotation storm + unknown-kid flood",
+        profile=Profile.CI_SHORT,
+        classes=("valid", "unknown_kid"),
+        setup=_rotate_unpublished,
+        steady_state=False,
+        gate="cold",
+        notes="unknown-kid flood must recover within ~1 cooldown, cap upstream "
+        "fetches, and 401 cleanly with no 500s",
+    ),
+    Scenario(
+        id="S7",
+        title="LRU thrash > 64 issuers",
+        profile=Profile.NIGHTLY,
+        classes=("valid",),
+        duration_seconds=10.0,
+        gate="warm",
+        notes="bounded memory under > 64 distinct issuers; eviction purges the "
+        "single-flight sidecar (calibrated nightly)",
+    ),
+    Scenario(
+        id="S8",
+        title="rejection correctness & uniformity under contention",
+        profile=Profile.CI_SHORT,
+        classes=MIXED_CLASSES,
+        users=16,
+        gate="warm",
+        notes="every class returns its correct status under contention, F-18 "
+        "uniform 401 body, F-07 reject, F-02 accepted-today, ZERO 500s",
+    ),
+    Scenario(
+        id="S9",
+        title="discovery no-store (re-fetch every request)",
+        profile=Profile.DIAGNOSTIC,
+        classes=("valid",),
+        setup=_no_store_discovery,
+        steady_state=False,
+        gate="cold",
+        notes="no-store discovery collapses throughput (re-fetch per request) "
+        "while JWKS stays cached",
+    ),
+    Scenario(
+        id="S10",
+        title="blocking claims_validator (event-loop stall)",
+        profile=Profile.DIAGNOSTIC,
+        classes=("valid",),
+        steady_state=False,
+        gate="warm",
+        notes="a synchronous custom claims validator stalls the loop vs an "
+        "async one (calibrated in the test phase)",
+    ),
+    Scenario(
+        id="S11",
+        title="RSS / FD soak",
+        profile=Profile.NIGHTLY,
+        classes=("valid",),
+        duration_seconds=30.0,
+        gate="warm",
+        notes="flat RSS/FD for a single issuer; bounded churn at 64 issuers "
+        "(calibrated nightly)",
+    ),
+    Scenario(
+        id="S12",
+        title="multi-tenant + issuer mix-up",
+        profile=Profile.NIGHTLY,
+        classes=("valid", "wrong_iss"),
+        gate="warm",
+        notes="dct/tenants LRU survival (TH-2.1) + RFC 9207 cross-issuer "
+        "rejection (TH-2.2) under load (calibrated nightly)",
+    ),
+)
+
+# id -> Scenario, for lookup by the runner and tests.
+SCENARIOS_BY_ID: dict[str, Scenario] = {s.id: s for s in SCENARIOS}
+
+
+def profile_scenarios(profile: Profile) -> list[Scenario]:
+    """The scenarios that belong to *profile*, in catalogue order."""
+    return [s for s in SCENARIOS if s.profile is profile]

--- a/src/tests/load/test_load_ci_short.py
+++ b/src/tests/load/test_load_ci_short.py
@@ -1,0 +1,95 @@
+"""Real-Locust CI-short proof for the load suite — TH-1.5 (#474, epic #462).
+
+This is the ``test`` phase's DoD entrypoint: a REAL Locust run (programmatic,
+headless) driving the booted resource server (real uvicorn subprocess, real HTTP)
+with the pre-minted replay pool, over the CI_SHORT scenario profile (S1-S8). A
+green *unit* run is not proof — this drives actual load and scores real responses.
+
+Self-contained: the controllable mock OP is the design's failure-injection driver
+(latency, key rotation, contention), so no external IdP is needed. The suite skips
+cleanly in a plain unit env (``locust``/fastapi absent); run it via
+``make test-harness-load`` under ``uv run --group load --all-packages``.
+
+The ``locust`` availability check uses :func:`importlib.util.find_spec` and does
+NOT import locust in this process: importing locust triggers gevent's
+``monkey.patch_all()``, which would deadlock the in-process asyncio mock-OP server
+thread the runner boots. Locust only ever runs in the runner's subprocess.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+
+if importlib.util.find_spec("locust") is None:
+    pytest.skip("locust (load group) not installed", allow_module_level=True)
+pytest.importorskip("fastapi_identity_model")
+pytest.importorskip("uvicorn")
+
+from ..load.runner import evaluate_gates, run_profile
+from ..load.scenarios import Profile, profile_scenarios
+
+
+pytestmark = pytest.mark.integration
+
+_CI_SHORT_IDS = [s.id for s in profile_scenarios(Profile.CI_SHORT)]
+
+
+@pytest.fixture(scope="module")
+def ci_short_results():
+    """Run the CI_SHORT profile once; share the per-scenario results.
+
+    Each scenario boots its own mock OP + RS, so this is a few seconds per
+    scenario — run once at module scope and assert over the results.
+    """
+    return {result.scenario_id: result for result in run_profile(Profile.CI_SHORT)}
+
+
+def test_every_ci_short_scenario_ran(ci_short_results):
+    """The profile executed exactly the S1-S8 catalogue."""
+    assert set(ci_short_results) == set(_CI_SHORT_IDS)
+
+
+@pytest.mark.parametrize("scenario_id", _CI_SHORT_IDS)
+def test_scenario_drove_load_and_met_gates(ci_short_results, scenario_id):
+    """Each scenario drove real requests and violated no SLO/correctness gate."""
+    result = ci_short_results[scenario_id]
+    assert result.num_requests > 0, f"{scenario_id} drove no load"
+    violations = evaluate_gates(result)
+    assert not violations, "; ".join(violations)
+
+
+def test_no_server_errors_anywhere(ci_short_results):
+    """Design §5 hard invariant: ZERO 500s across the whole profile."""
+    offenders = {
+        sid: r.server_errors for sid, r in ci_short_results.items() if r.server_errors
+    }
+    assert not offenders, f"server errors (5xx): {offenders}"
+
+
+def test_s3_cold_stampede_is_single_flight(ci_short_results):
+    """S3: a cold burst must fetch discovery + JWKS exactly once each.
+
+    The single-flight cache coalesces the concurrent cold-cache misses, so the
+    mock-OP upstream counters must show one discovery fetch and one JWKS fetch
+    for the whole stampede — the core anti-stampede proof (design §4 S3).
+    """
+    s3 = ci_short_results["S3"]
+    assert s3.upstream_stats.get("discovery") == 1, s3.upstream_stats
+    assert s3.upstream_stats.get("jwks") == 1, s3.upstream_stats
+
+
+def test_s1_warm_cache_is_all_hits(ci_short_results):
+    """S1: after warmup the measured window serves entirely from cache.
+
+    The authoritative proof is the mock-OP upstream counters (reset after the
+    warmup): ZERO discovery/JWKS fetches during the measured window. The RS-side
+    cache-hit rate is near-1 rather than exactly 1 because its per-process
+    counters also include the single warmup miss (no reset route).
+    """
+    s1 = ci_short_results["S1"]
+    assert s1.upstream_stats.get("discovery", 0) == 0, s1.upstream_stats
+    assert s1.upstream_stats.get("jwks", 0) == 0, s1.upstream_stats
+    assert s1.cache_hit_rate >= 0.99, s1.cache_metrics

--- a/src/tests/load/test_load_ci_short.py
+++ b/src/tests/load/test_load_ci_short.py
@@ -2,8 +2,10 @@
 
 This is the ``test`` phase's DoD entrypoint: a REAL Locust run (programmatic,
 headless) driving the booted resource server (real uvicorn subprocess, real HTTP)
-with the pre-minted replay pool, over the CI_SHORT scenario profile (S1-S8). A
-green *unit* run is not proof — this drives actual load and scores real responses.
+with the pre-minted replay pool, over the CI_SHORT scenario profile
+(S1, S2, S3, S6, S8). A green *unit* run is not proof — this drives actual load
+and scores real responses. (S4 TTL-rollover needs a >60s window per the 60s cache
+TTL floor and lives in NIGHTLY; S5/S9/S10 are DIAGNOSTIC.)
 
 Self-contained: the controllable mock OP is the design's failure-injection driver
 (latency, key rotation, contention), so no external IdP is needed. The suite skips
@@ -48,8 +50,23 @@ def ci_short_results():
 
 
 def test_every_ci_short_scenario_ran(ci_short_results):
-    """The profile executed exactly the S1-S8 catalogue."""
+    """The profile executed exactly the CI-short catalogue (S1, S2, S3, S6, S8)."""
     assert set(ci_short_results) == set(_CI_SHORT_IDS)
+
+
+def test_s2_alg_cost_ratio_is_reportable(ci_short_results):
+    """S2 (design §4): the RS256-vs-ES256 warm cost ratio is computable.
+
+    Per-class p95 latency is captured in the summary, so the ES256/RS256 ratio
+    the scenario exists to report can actually be derived from the result (both
+    classes drove load and the ratio is a positive, finite number).
+    """
+    s2 = ci_short_results["S2"]
+    assert s2.requests_by_class.get("valid", 0) > 0, s2.requests_by_class
+    assert s2.requests_by_class.get("valid_es256", 0) > 0, s2.requests_by_class
+    ratio = s2.alg_cost_ratio("valid_es256", "valid")
+    assert ratio is not None, s2.latency_by_class
+    assert ratio > 0, s2.latency_by_class
 
 
 @pytest.mark.parametrize("scenario_id", _CI_SHORT_IDS)

--- a/src/tests/load/test_load_ci_short.py
+++ b/src/tests/load/test_load_ci_short.py
@@ -74,6 +74,9 @@ def test_scenario_drove_load_and_met_gates(ci_short_results, scenario_id):
     """Each scenario drove real requests and violated no SLO/correctness gate."""
     result = ci_short_results[scenario_id]
     assert result.num_requests > 0, f"{scenario_id} drove no load"
+    # p999 (design §5) is captured from the run summary, not dropped — it is a
+    # percentile so it must be >= p99 (a reverted/zeroed p999 field fails here).
+    assert result.p999_ms >= result.p99_ms, (result.p999_ms, result.p99_ms)
     violations = evaluate_gates(result)
     assert not violations, "; ".join(violations)
 

--- a/src/tests/load/test_load_nightly.py
+++ b/src/tests/load/test_load_nightly.py
@@ -1,0 +1,72 @@
+"""Real-Locust nightly soak proof for the load suite — TH-1.5 (#271, epic #462).
+
+The scheduled counterpart to :mod:`test_load_ci_short`. Runs the NIGHTLY scenario
+profile (S4 TTL-rollover — needs a >60s window past the 60s cache-TTL floor — plus
+the S7 LRU-thrash and S11/S12 RSS/FD soak scenarios) with the same real-Locust-vs-
+booted-RS machinery, but the long-window work that does not belong on the PR gate.
+
+Scheduled by ``.github/workflows/nightly.yml``; run on demand via
+``make test-harness-load-nightly`` under ``uv run --group load --all-packages``.
+
+Self-contained (the controllable mock OP is the failure-injection driver — no
+external IdP). See :mod:`test_load_ci_short` for why locust is never imported in
+this process (gevent ``monkey.patch_all`` would deadlock the in-process mock OP).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+
+if importlib.util.find_spec("locust") is None:
+    pytest.skip("locust (load group) not installed", allow_module_level=True)
+pytest.importorskip("fastapi_identity_model")
+pytest.importorskip("uvicorn")
+
+from ..load.runner import evaluate_gates, run_profile
+from ..load.scenarios import Profile, profile_scenarios
+
+
+pytestmark = pytest.mark.integration
+
+_NIGHTLY_IDS = [s.id for s in profile_scenarios(Profile.NIGHTLY)]
+
+
+@pytest.fixture(scope="module")
+def nightly_results():
+    """Run the NIGHTLY soak profile once; share the per-scenario results.
+
+    Each scenario boots its own mock OP + RS. S4 alone runs past the 60s cache
+    TTL, so this fixture takes minutes — module scope so it runs once.
+    """
+    return {result.scenario_id: result for result in run_profile(Profile.NIGHTLY)}
+
+
+def test_every_nightly_scenario_ran(nightly_results):
+    """The profile executed exactly the NIGHTLY soak catalogue (S4, S7, S11, S12)."""
+    assert set(nightly_results) == set(_NIGHTLY_IDS)
+
+
+@pytest.mark.parametrize("scenario_id", _NIGHTLY_IDS)
+def test_soak_scenario_drove_load_and_met_gates(nightly_results, scenario_id):
+    """Each soak scenario drove real requests and violated no SLO/correctness gate."""
+    result = nightly_results[scenario_id]
+    assert result.num_requests > 0, f"{scenario_id} drove no load"
+    # p999 is a percentile so it must be >= p99 (a reverted/zeroed field fails here).
+    assert result.p999_ms >= result.p99_ms, (result.p999_ms, result.p99_ms)
+    violations = evaluate_gates(result)
+    assert not violations, "; ".join(violations)
+
+
+def test_no_server_errors_anywhere(nightly_results):
+    """Design §5 hard invariant: ZERO 500s across the whole soak.
+
+    Under a multi-minute soak this is the leak/exhaustion tripwire — a resource
+    leak that eventually 500s (OOM, FD exhaustion, pool starvation) shows up here.
+    """
+    offenders = {
+        sid: r.server_errors for sid, r in nightly_results.items() if r.server_errors
+    }
+    assert not offenders, f"server errors (5xx): {offenders}"

--- a/src/tests/security/test_aio_cache_fetch_controls.py
+++ b/src/tests/security/test_aio_cache_fetch_controls.py
@@ -1,0 +1,393 @@
+"""Fail-closed controls for the async cache fetch paths (T299).
+
+T299 instrumented the three module-level singleton cache functions in
+``py_identity_model.aio.token_validation`` with observability counters:
+``_get_disco_response``, ``_get_cached_jwks`` and ``_refresh_jwks``. These are
+security-gated (``tools/mutation_security.py``). This module pins the
+security-relevant behaviour of those functions so a regression cannot silently:
+
+* drop the HTTPS scheme enforcement (policy default flip / ``policy=None`` /
+  dropped ``policy`` kwarg) — an SSRF / HTTPS->HTTP downgrade,
+* stop threading the caller's ``require_https`` through to ``get_jwks`` — a
+  legitimate ``require_https=False`` fetch would break,
+* drop the ``cooldown`` sidecar cleanup on eviction — an unbounded-growth
+  memory leak keyed by attacker-controlled URIs,
+* lose the double-checked-lock cache hit / LRU-recency refresh — cache-stampede
+  and hot-entry-eviction regressions (#397),
+* break the empty-keys retained-cache fallback (``and``->``or``) or the
+  refresh coalescing guard (``>=``->``>``).
+
+The double-checked-hit branch is normally only reachable under concurrency
+(one coroutine populates the entry while another waits on the fetch lock). We
+reach it deterministically instead by stubbing ``is_cache_expired`` to report
+the pre-seeded entry as *expired* on the lock-free fast-path check and *fresh*
+on the under-lock re-check — exactly the state a concurrent populate produces.
+"""
+
+import time
+from unittest.mock import Mock
+
+import httpx
+import pytest
+import respx
+
+from py_identity_model import get_cache_counters
+from py_identity_model.aio import token_validation as aio_tv
+from py_identity_model.aio.token_validation import (
+    _get_cached_jwks,
+    _get_disco_response,
+    _refresh_jwks,
+    clear_discovery_cache,
+    clear_jwks_cache,
+)
+from py_identity_model.core.jwks_cache import (
+    DiscoCacheEntry,
+    JwksCacheEntry,
+    _reset_env_for_testing,
+)
+from py_identity_model.core.models import (
+    DiscoveryDocumentResponse,
+    JwksResponse,
+)
+from py_identity_model.core.parsers import jwks_from_dict
+from py_identity_model.exceptions import ConfigurationException
+
+from ..unit.token_validation_helpers import generate_rsa_keypair
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+async def _clean_state():
+    """Reset all shared module-global cache state + counters between tests."""
+    await clear_discovery_cache()
+    await clear_jwks_cache()
+    aio_tv._kid_miss_last_attempt.clear()
+    get_cache_counters().reset()
+    _reset_env_for_testing()
+    yield
+    await clear_discovery_cache()
+    await clear_jwks_cache()
+    aio_tv._kid_miss_last_attempt.clear()
+    get_cache_counters().reset()
+    _reset_env_for_testing()
+
+
+# Generate ONE RSA keypair for the whole module. These tests exercise cache /
+# counter / single-flight behaviour and never verify a signature, so the key
+# content is irrelevant — any valid JWK works. Generating per-test would add
+# ~15 RSA-2048 keygens of CPU contention under ``-n auto``, which is enough to
+# slow the wall-clock-sensitive kid-miss-cooldown tests past their 5s window.
+_KEY_DICT, _ = generate_rsa_keypair()
+
+
+def _jwk():
+    return jwks_from_dict(_KEY_DICT)
+
+
+def _jwks_resp(keys):
+    return JwksResponse(is_successful=True, keys=keys)
+
+
+def _disco_resp(issuer="https://opx.example"):
+    return DiscoveryDocumentResponse(is_successful=True, issuer=issuer)
+
+
+# ---------------------------------------------------------------------------
+# Scheme enforcement (SSRF / HTTPS->HTTP downgrade)
+# ---------------------------------------------------------------------------
+
+
+class TestSchemeEnforcement:
+    """A plaintext ``http://`` JWKS endpoint must be rejected under the default
+    (``require_https`` omitted) policy, and only fetched when the caller
+    explicitly relaxes the policy — pinning the ``require_https`` default and
+    the policy thread-through against flip / ``None`` / dropped-kwarg mutants."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_cached_jwks_default_rejects_plaintext_http(self):
+        route = respx.get("http://op.example/jwks").mock(
+            return_value=httpx.Response(
+                200,
+                json={"keys": [_KEY_DICT]},
+                headers={"Cache-Control": "max-age=3600"},
+            )
+        )
+        # Default require_https=True -> plaintext non-loopback HTTP is rejected
+        # by the pre-flight scheme check inside get_jwks BEFORE any network I/O.
+        result = await _get_cached_jwks("http://op.example/jwks")
+        assert result.is_successful is False
+        assert route.call_count == 0
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_refresh_default_rejects_plaintext_http(self):
+        route = respx.get("http://op.example/jwks").mock(
+            return_value=httpx.Response(
+                200,
+                json={"keys": [_KEY_DICT]},
+                headers={"Cache-Control": "max-age=3600"},
+            )
+        )
+        response, from_retained = await _refresh_jwks("http://op.example/jwks")
+        assert response.is_successful is False
+        assert from_retained is False
+        assert route.call_count == 0
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_refresh_threads_require_https_false_allows_http(self):
+        key = _KEY_DICT
+        route = respx.get("http://op.example/jwks").mock(
+            return_value=httpx.Response(
+                200,
+                json={"keys": [key]},
+                headers={"Cache-Control": "max-age=3600"},
+            )
+        )
+        # Caller explicitly opts out of HTTPS; the policy MUST be threaded
+        # through to get_jwks (not dropped/None, which would re-impose the
+        # strict default and reject this legitimate fetch).
+        response, _ = await _refresh_jwks("http://op.example/jwks", require_https=False)
+        assert response.is_successful is True
+        assert response.keys
+        assert route.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Cooldown sidecar eviction (unbounded-growth / memory leak)
+# ---------------------------------------------------------------------------
+
+
+class TestCooldownSidecarEviction:
+    """When the JWKS cache evicts an entry, its ``_kid_miss_last_attempt``
+    cooldown sidecar entry must be evicted too. Dropping the ``cooldown`` kwarg
+    (or passing ``None``) leaks the sidecar unboundedly under attacker-driven
+    distinct-URI churn even though the cache itself is bounded."""
+
+    def _seed(self, monkeypatch, old_uri):
+        monkeypatch.setenv("JWKS_CACHE_MAX_ENTRIES", "1")
+        _reset_env_for_testing()
+        aio_tv._jwks_cache[old_uri] = JwksCacheEntry(
+            response=_jwks_resp([_jwk()]),
+            cached_at=time.monotonic(),
+            ttl=1e9,
+        )
+        aio_tv._kid_miss_last_attempt[old_uri] = 123.0
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_cached_jwks_eviction_clears_cooldown(self, monkeypatch):
+        old_uri = "https://old.example/jwks"
+        new_uri = "https://new.example/jwks"
+        self._seed(monkeypatch, old_uri)
+        respx.get(new_uri).mock(
+            return_value=httpx.Response(
+                200,
+                json={"keys": [_KEY_DICT]},
+                headers={"Cache-Control": "max-age=3600"},
+            )
+        )
+        await _get_cached_jwks(new_uri)
+        # old_uri was evicted (max=1); its cooldown sidecar entry must be gone.
+        assert old_uri not in aio_tv._jwks_cache
+        assert old_uri not in aio_tv._kid_miss_last_attempt
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_refresh_eviction_clears_cooldown(self, monkeypatch):
+        old_uri = "https://old.example/jwks"
+        new_uri = "https://new.example/jwks"
+        self._seed(monkeypatch, old_uri)
+        respx.get(new_uri).mock(
+            return_value=httpx.Response(
+                200,
+                json={"keys": [_KEY_DICT]},
+                headers={"Cache-Control": "max-age=3600"},
+            )
+        )
+        await _refresh_jwks(new_uri)
+        assert old_uri not in aio_tv._jwks_cache
+        assert old_uri not in aio_tv._kid_miss_last_attempt
+
+
+# ---------------------------------------------------------------------------
+# _refresh_jwks empty-keys fallback + coalescing guard
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshSemantics:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_empty_refresh_does_not_falsely_fall_back(self):
+        """``and``->``or`` guard: a retained entry with EMPTY keys must NOT be
+        surfaced as a fallback. Only a retained entry with real keys does.
+
+        Original: ``retained is not None and retained.response.keys`` -> the
+        empty retained entry is falsy -> no fallback -> returns the empty
+        upstream response with ``from_retained=False``. The mutated ``or`` would
+        fall back and mislabel it ``from_retained=True``.
+        """
+        uri = "https://op.example/jwks"
+        aio_tv._jwks_cache[uri] = JwksCacheEntry(
+            response=_jwks_resp([]),  # retained but EMPTY
+            cached_at=time.monotonic() - 1000.0,  # old -> not coalesced
+            ttl=1e9,
+        )
+        respx.get(uri).mock(return_value=httpx.Response(200, json={"keys": []}))
+
+        response, from_retained = await _refresh_jwks(uri)
+        assert from_retained is False
+        assert (response.keys or []) == []
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_refresh_coalesces_on_equal_timestamp(self, monkeypatch):
+        """``>=``->``>`` guard: when a concurrent refresh already wrote an entry
+        whose ``cached_at`` equals this refresh's ``request_time`` (captured
+        inside the lock), this call must coalesce and return WITHOUT issuing an
+        upstream fetch. Forcing ``time.monotonic()`` to the entry's exact
+        ``cached_at`` exercises the boundary the ``>=`` protects."""
+        uri = "https://op.example/jwks"
+        seeded = _jwks_resp([_jwk()])
+        fixed_t = 5000.0
+        aio_tv._jwks_cache[uri] = JwksCacheEntry(
+            response=seeded, cached_at=fixed_t, ttl=1e9
+        )
+        route = respx.get(uri).mock(
+            return_value=httpx.Response(
+                200,
+                json={"keys": [_KEY_DICT]},
+                headers={"Cache-Control": "max-age=3600"},
+            )
+        )
+        monkeypatch.setattr(aio_tv.time, "monotonic", lambda: fixed_t)
+
+        response, from_retained = await _refresh_jwks(uri)
+        assert response is seeded
+        assert from_retained is False
+        assert route.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Discovery required-address error message
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoRequiredAddress:
+    @pytest.mark.asyncio
+    async def test_none_address_raises_with_actionable_message(self):
+        with pytest.raises(ConfigurationException) as exc:
+            await _get_disco_response(None)
+        assert (
+            str(exc.value) == "disco_doc_address is required when perform_disco is True"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Double-checked-lock hit + LRU recency (cache stampede / hot-entry eviction)
+# ---------------------------------------------------------------------------
+
+
+def _expired_then_fresh():
+    """is_cache_expired stub: True on the fast-path check (entry looks stale),
+    False on the under-lock re-check (entry is fresh) — the exact state a
+    concurrent populate leaves for the second coroutine."""
+    return Mock(side_effect=[True, False])
+
+
+class TestDoubleCheckedLockAndLru:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_disco_double_checked_hit_refreshes_recency(self, monkeypatch):
+        """The under-lock double-checked hit returns the cached response with NO
+        upstream fetch and refreshes LRU recency (moves the key to MRU).
+
+        Kills: under-lock ``entry=None`` / ``get(None)`` (would re-fetch),
+        ``touch_cache_entry`` arg mutations that raise, and the no-op
+        ``touch(cache, None)`` (recency would not move).
+        """
+        addr_x = "https://opx.example/.well-known/openid-configuration"
+        addr_y = "https://opy.example/.well-known/openid-configuration"
+        key_x = (addr_x, True)
+        key_y = (addr_y, True)
+        resp_x = _disco_resp("https://opx.example")
+        # Seed order: x (oldest) then y (newest).
+        aio_tv._disco_cache[key_x] = DiscoCacheEntry(
+            response=resp_x, cached_at=time.monotonic(), ttl=1e9
+        )
+        aio_tv._disco_cache[key_y] = DiscoCacheEntry(
+            response=_disco_resp("https://opy.example"),
+            cached_at=time.monotonic(),
+            ttl=1e9,
+        )
+        route = respx.get(addr_x).mock(
+            return_value=httpx.Response(200, json={"issuer": "https://opx.example"})
+        )
+        monkeypatch.setattr(aio_tv, "is_cache_expired", _expired_then_fresh())
+
+        result = await _get_disco_response(addr_x)
+
+        assert result is resp_x  # served from cache, exact object
+        assert route.call_count == 0  # no upstream fetch
+        # x moved to MRU (end); y is now the LRU-first entry.
+        assert list(aio_tv._disco_cache.keys()) == [key_y, key_x]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_disco_fast_path_hit_refreshes_recency(self, monkeypatch):
+        """The lock-free fast-path hit refreshes LRU recency. Kills the
+        fast-path ``touch(cache, None)`` no-op (hot entry would not move and
+        an attacker reading distinct addresses could evict it)."""
+        addr_x = "https://opx.example/.well-known/openid-configuration"
+        addr_y = "https://opy.example/.well-known/openid-configuration"
+        key_x = (addr_x, True)
+        key_y = (addr_y, True)
+        resp_x = _disco_resp("https://opx.example")
+        aio_tv._disco_cache[key_x] = DiscoCacheEntry(
+            response=resp_x, cached_at=time.monotonic(), ttl=1e9
+        )
+        aio_tv._disco_cache[key_y] = DiscoCacheEntry(
+            response=_disco_resp("https://opy.example"),
+            cached_at=time.monotonic(),
+            ttl=1e9,
+        )
+        route = respx.get(addr_x).mock(
+            return_value=httpx.Response(200, json={"issuer": "https://opx.example"})
+        )
+        # Fresh on the fast path -> fast-path hit taken.
+        monkeypatch.setattr(aio_tv, "is_cache_expired", Mock(side_effect=[False]))
+
+        result = await _get_disco_response(addr_x)
+
+        assert result is resp_x
+        assert route.call_count == 0
+        assert list(aio_tv._disco_cache.keys()) == [key_y, key_x]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_jwks_double_checked_hit_refreshes_recency(self, monkeypatch):
+        """Async twin of the disco double-checked-hit test for
+        ``_get_cached_jwks`` — kills the no-op ``touch(cache, None)`` on the
+        under-lock double-checked-hit branch."""
+        uri_x = "https://opx.example/jwks"
+        uri_y = "https://opy.example/jwks"
+        resp_x = _jwks_resp([_jwk()])
+        aio_tv._jwks_cache[uri_x] = JwksCacheEntry(
+            response=resp_x, cached_at=time.monotonic(), ttl=1e9
+        )
+        aio_tv._jwks_cache[uri_y] = JwksCacheEntry(
+            response=_jwks_resp([_jwk()]), cached_at=time.monotonic(), ttl=1e9
+        )
+        route = respx.get(uri_x).mock(
+            return_value=httpx.Response(200, json={"keys": []})
+        )
+        monkeypatch.setattr(aio_tv, "is_cache_expired", _expired_then_fresh())
+
+        result = await _get_cached_jwks(uri_x)
+
+        assert result is resp_x
+        assert route.call_count == 0
+        assert list(aio_tv._jwks_cache.keys()) == [uri_y, uri_x]

--- a/src/tests/security/test_aio_cache_fetch_controls.py
+++ b/src/tests/security/test_aio_cache_fetch_controls.py
@@ -120,6 +120,10 @@ class TestSchemeEnforcement:
         result = await _get_cached_jwks("http://op.example/jwks")
         assert result.is_successful is False
         assert route.call_count == 0
+        # Fail-closed observability: a scheme-rejected request issues zero
+        # upstream work, so it MUST NOT bump the upstream-fetch miss counter
+        # (else an attacker inflates the miss rate with forged http:// URIs).
+        assert get_cache_counters().snapshot()["jwks_misses"] == 0
 
     @respx.mock
     @pytest.mark.asyncio
@@ -135,6 +139,26 @@ class TestSchemeEnforcement:
         assert response.is_successful is False
         assert from_retained is False
         assert route.call_count == 0
+        # Fail-closed: a scheme-rejected refresh does zero upstream work, so the
+        # refresh (upstream re-fetch) counter MUST NOT increment.
+        assert get_cache_counters().snapshot()["jwks_refreshes"] == 0
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_disco_default_rejects_plaintext_http(self):
+        route = respx.get("http://op.example/.well-known/openid-configuration").mock(
+            return_value=httpx.Response(200, json={"issuer": "http://op.example"})
+        )
+        # Default require_https=True -> plaintext non-loopback HTTP disco is
+        # rejected by the pre-flight scheme check BEFORE any network I/O.
+        result = await _get_disco_response(
+            "http://op.example/.well-known/openid-configuration"
+        )
+        assert result.is_successful is False
+        assert route.call_count == 0
+        # Fail-closed: a scheme-rejected disco request does zero upstream work,
+        # so the disco miss (upstream-fetch) counter MUST NOT increment.
+        assert get_cache_counters().snapshot()["disco_misses"] == 0
 
     @respx.mock
     @pytest.mark.asyncio
@@ -154,6 +178,8 @@ class TestSchemeEnforcement:
         assert response.is_successful is True
         assert response.keys
         assert route.call_count == 1
+        # An upstream fetch WAS issued, so the refresh counter increments.
+        assert get_cache_counters().snapshot()["jwks_refreshes"] == 1
 
 
 # ---------------------------------------------------------------------------

--- a/src/tests/unit/test_cache_metrics.py
+++ b/src/tests/unit/test_cache_metrics.py
@@ -228,3 +228,57 @@ class TestCacheCountersIntegration:
         assert snap["jwks_refreshes"] == 1
         # A refresh is an upstream re-fetch, not a hit.
         assert snap["jwks_hits"] == 0
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_disco_failed_upstream_fetch_counts_as_miss(self):
+        """A 503 from upstream is a real round trip → it MUST count as a miss.
+
+        Guards against the regression where gating the counter on
+        ``response.is_successful`` silently dropped 429/5xx fetches, making an
+        upstream outage read as zero upstream volume (design §5 metric).
+        """
+        route = respx.get(DISCO_URL).mock(return_value=httpx.Response(503))
+
+        result = await _get_disco_response(DISCO_URL)
+        snap = get_cache_counters().snapshot()
+
+        assert result.is_successful is False
+        assert route.called  # a real network round trip happened (with retries)
+        assert snap["disco_misses"] == 1  # one logical fetch, counted once
+        assert snap["disco_hits"] == 0
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_jwks_failed_upstream_fetch_counts_as_miss(self):
+        """A 429 JWKS fetch is a real round trip → counted as a miss."""
+        route = respx.get(JWKS_URL).mock(return_value=httpx.Response(429))
+
+        result = await _get_cached_jwks(JWKS_URL)
+        snap = get_cache_counters().snapshot()
+
+        assert result.is_successful is False
+        assert route.called  # a real network round trip happened (with retries)
+        assert snap["jwks_misses"] == 1  # one logical fetch, counted once
+        assert snap["jwks_hits"] == 0
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_jwks_failed_refresh_counts_as_refresh(self):
+        """A refresh whose upstream GET returns 5xx is still an upstream re-fetch."""
+        key_dict, _pem = generate_rsa_keypair()
+        route = respx.get(JWKS_URL).mock(
+            side_effect=[
+                httpx.Response(200, json={"keys": [key_dict]}),
+                httpx.Response(502),
+            ]
+        )
+
+        await _get_cached_jwks(JWKS_URL)  # prime (miss)
+        get_cache_counters().reset()
+
+        await _refresh_jwks(JWKS_URL)  # forced re-fetch → 502
+        snap = get_cache_counters().snapshot()
+
+        assert route.call_count == 2
+        assert snap["jwks_refreshes"] == 1  # counted despite the 502

--- a/src/tests/unit/test_cache_metrics.py
+++ b/src/tests/unit/test_cache_metrics.py
@@ -1,0 +1,230 @@
+# ruff: noqa: PLR2004
+"""Unit tests for the per-process cache observability counters.
+
+Covers :class:`CacheCounters` in isolation (every ``record_*`` method,
+``snapshot`` detachment, ``reset``, thread-safety smoke) and its integration
+with the async discovery/JWKS cache paths, asserting exact hit/miss/refresh
+transitions across warm/cold/refresh scenarios.
+"""
+
+import threading
+
+import httpx
+import pytest
+import respx
+
+from py_identity_model import CacheCounters, get_cache_counters
+from py_identity_model.aio.token_validation import (
+    _get_cached_jwks,
+    _get_disco_response,
+    _refresh_jwks,
+    clear_discovery_cache,
+    clear_jwks_cache,
+)
+from py_identity_model.core.cache_metrics import CACHE_COUNTERS
+
+from .token_validation_helpers import (
+    DISCO_RESPONSE_WITH_JWKS,
+    generate_rsa_keypair,
+)
+
+
+# ============================================================================
+# CacheCounters in isolation
+# ============================================================================
+
+
+class TestCacheCountersUnit:
+    """Exercise every CacheCounters method without any cache I/O."""
+
+    def test_starts_at_zero(self):
+        counters = CacheCounters()
+        assert counters.snapshot() == {
+            "disco_hits": 0,
+            "disco_misses": 0,
+            "jwks_hits": 0,
+            "jwks_misses": 0,
+            "jwks_refreshes": 0,
+        }
+
+    def test_record_disco_hit(self):
+        counters = CacheCounters()
+        counters.record_disco_hit()
+        counters.record_disco_hit()
+        assert counters.snapshot()["disco_hits"] == 2
+
+    def test_record_disco_miss(self):
+        counters = CacheCounters()
+        counters.record_disco_miss()
+        assert counters.snapshot()["disco_misses"] == 1
+
+    def test_record_jwks_hit(self):
+        counters = CacheCounters()
+        counters.record_jwks_hit()
+        counters.record_jwks_hit()
+        counters.record_jwks_hit()
+        assert counters.snapshot()["jwks_hits"] == 3
+
+    def test_record_jwks_miss(self):
+        counters = CacheCounters()
+        counters.record_jwks_miss()
+        assert counters.snapshot()["jwks_misses"] == 1
+
+    def test_record_jwks_refresh(self):
+        counters = CacheCounters()
+        counters.record_jwks_refresh()
+        counters.record_jwks_refresh()
+        assert counters.snapshot()["jwks_refreshes"] == 2
+
+    def test_each_counter_is_independent(self):
+        counters = CacheCounters()
+        counters.record_disco_hit()
+        counters.record_disco_miss()
+        counters.record_jwks_hit()
+        counters.record_jwks_miss()
+        counters.record_jwks_refresh()
+        assert counters.snapshot() == {
+            "disco_hits": 1,
+            "disco_misses": 1,
+            "jwks_hits": 1,
+            "jwks_misses": 1,
+            "jwks_refreshes": 1,
+        }
+
+    def test_snapshot_is_detached_copy(self):
+        counters = CacheCounters()
+        counters.record_disco_hit()
+        snap = counters.snapshot()
+        # Mutating the snapshot must not touch the live counters...
+        snap["disco_hits"] = 999
+        assert counters.snapshot()["disco_hits"] == 1
+        # ...and the live counters advancing must not touch an old snapshot.
+        counters.record_disco_hit()
+        assert snap["disco_hits"] == 999
+
+    def test_reset_zeros_every_counter(self):
+        counters = CacheCounters()
+        counters.record_disco_hit()
+        counters.record_disco_miss()
+        counters.record_jwks_hit()
+        counters.record_jwks_miss()
+        counters.record_jwks_refresh()
+        counters.reset()
+        assert counters.snapshot() == {
+            "disco_hits": 0,
+            "disco_misses": 0,
+            "jwks_hits": 0,
+            "jwks_misses": 0,
+            "jwks_refreshes": 0,
+        }
+
+    def test_concurrent_increments_are_not_lost(self):
+        """Thread-safety smoke: N threads each incrementing must total N*loops."""
+        counters = CacheCounters()
+        threads_count = 8
+        per_thread = 1000
+
+        def worker():
+            for _ in range(per_thread):
+                counters.record_jwks_hit()
+
+        threads = [threading.Thread(target=worker) for _ in range(threads_count)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert counters.snapshot()["jwks_hits"] == threads_count * per_thread
+
+
+class TestCacheCountersSingleton:
+    """The module singleton is shared and reachable from the public surface."""
+
+    def test_get_cache_counters_returns_singleton(self):
+        assert get_cache_counters() is CACHE_COUNTERS
+        assert get_cache_counters() is get_cache_counters()
+
+    def test_singleton_is_a_cache_counters(self):
+        assert isinstance(get_cache_counters(), CacheCounters)
+
+
+# ============================================================================
+# Integration with the async cache paths
+# ============================================================================
+
+DISCO_URL = "https://example.com/.well-known/openid-configuration"
+JWKS_URL = "https://example.com/jwks"
+
+
+@pytest.fixture
+async def _clean_cache_state():
+    """Reset caches and counters around each async integration test."""
+    await clear_discovery_cache()
+    await clear_jwks_cache()
+    get_cache_counters().reset()
+    yield
+    await clear_discovery_cache()
+    await clear_jwks_cache()
+    get_cache_counters().reset()
+
+
+@pytest.mark.usefixtures("_clean_cache_state")
+class TestCacheCountersIntegration:
+    """Drive the real async cache functions and assert exact counter moves."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_disco_miss_then_hit(self):
+        route = respx.get(DISCO_URL).mock(
+            return_value=httpx.Response(200, json=DISCO_RESPONSE_WITH_JWKS)
+        )
+
+        # First call: cold cache → upstream fetch → one miss, no hits.
+        await _get_disco_response(DISCO_URL)
+        snap = get_cache_counters().snapshot()
+        assert snap["disco_misses"] == 1
+        assert snap["disco_hits"] == 0
+
+        # Second call: fresh entry → hit, no additional upstream fetch.
+        await _get_disco_response(DISCO_URL)
+        snap = get_cache_counters().snapshot()
+        assert snap["disco_misses"] == 1
+        assert snap["disco_hits"] == 1
+        assert route.call_count == 1  # the hit did NOT hit the network
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_jwks_miss_then_hit(self):
+        key_dict, _pem = generate_rsa_keypair()
+        route = respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(200, json={"keys": [key_dict]})
+        )
+
+        await _get_cached_jwks(JWKS_URL)
+        snap = get_cache_counters().snapshot()
+        assert snap["jwks_misses"] == 1
+        assert snap["jwks_hits"] == 0
+
+        await _get_cached_jwks(JWKS_URL)
+        snap = get_cache_counters().snapshot()
+        assert snap["jwks_misses"] == 1
+        assert snap["jwks_hits"] == 1
+        assert route.call_count == 1
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_refresh_counts_upstream_fetch(self):
+        key_dict, _pem = generate_rsa_keypair()
+        respx.get(JWKS_URL).mock(
+            return_value=httpx.Response(200, json={"keys": [key_dict]})
+        )
+
+        # Prime the cache (miss), then force a refresh (key rotation).
+        await _get_cached_jwks(JWKS_URL)
+        assert get_cache_counters().snapshot()["jwks_refreshes"] == 0
+
+        await _refresh_jwks(JWKS_URL)
+        snap = get_cache_counters().snapshot()
+        assert snap["jwks_refreshes"] == 1
+        # A refresh is an upstream re-fetch, not a hit.
+        assert snap["jwks_hits"] == 0

--- a/src/tests/unit/test_kid_miss_cooldown.py
+++ b/src/tests/unit/test_kid_miss_cooldown.py
@@ -42,6 +42,7 @@ from py_identity_model.aio.token_validation import (
 )
 from py_identity_model.core.jwks_cache import (
     DEFAULT_KID_MISS_REFRESH_COOLDOWN_SECONDS,
+    MAX_KID_MISS_COOLDOWN_SECONDS,
     JwksCacheEntry,
     _reset_env_for_testing,
     apply_jwks_cache_outcome,
@@ -107,6 +108,26 @@ def _sign_unknown_kid_token(kid: str) -> str:
         {"sub": "attacker", "iss": "https://example.com"},
         headers={"kid": kid},
     )
+
+
+def _pin_cooldown_high(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the kid-miss cooldown to the maximum so ``EXPECTED_FETCH_COUNT``
+    assertions are independent of wall-clock time.
+
+    The cooldown is measured against real ``time.monotonic()``. The
+    amplification/isolation tests below fire a 25-request attacker loop and
+    assert exactly one prime + one forced refresh — which only holds if the
+    whole loop completes inside the cooldown window. With the 5s default and
+    a per-request RSA keygen, under ``pytest -n auto`` CPU contention the loop
+    can outlast 5s and a second refresh fires, flaking the count. Pinning to
+    the max (well above any loop duration) removes the timing dependency
+    without weakening what the test proves (that the cooldown coalesces a
+    burst into a single refresh). ``_reset_env_for_testing`` clears the memo
+    so the new value is read; ``monkeypatch`` reverts the env at teardown and
+    the autouse fixture resets the memo again.
+    """
+    monkeypatch.setenv("KID_MISS_REFRESH_COOLDOWN", str(MAX_KID_MISS_COOLDOWN_SECONDS))
+    _reset_env_for_testing()
 
 
 # ============================================================================
@@ -176,7 +197,8 @@ EXPECTED_FETCH_COUNT = 2  # 1 prime + 1 refresh inside cooldown window
 
 class TestKidMissCooldownBoundsAmplification:
     @respx.mock
-    def test_sync_cooldown_caps_fetches_under_attack(self):
+    def test_sync_cooldown_caps_fetches_under_attack(self, monkeypatch):
+        _pin_cooldown_high(monkeypatch)
         defender_key_dict, _defender_pem = generate_rsa_keypair()
         defender_key_dict["kid"] = "defender-kid"
 
@@ -213,7 +235,8 @@ class TestKidMissCooldownBoundsAmplification:
 
     @pytest.mark.asyncio
     @respx.mock
-    async def test_async_cooldown_caps_fetches_under_attack(self):
+    async def test_async_cooldown_caps_fetches_under_attack(self, monkeypatch):
+        _pin_cooldown_high(monkeypatch)
         defender_key_dict, _defender_pem = generate_rsa_keypair()
         defender_key_dict["kid"] = "defender-kid"
 
@@ -365,7 +388,8 @@ class TestCooldownDoesNotBlockLegitimateTraffic:
 
 class TestCooldownIsolationAcrossIssuers:
     @respx.mock
-    def test_per_issuer_cooldown_does_not_cross_contaminate(self):
+    def test_per_issuer_cooldown_does_not_cross_contaminate(self, monkeypatch):
+        _pin_cooldown_high(monkeypatch)
         other_disco_url = "https://other.example/.well-known/openid-configuration"
         other_jwks_url = "https://other.example/jwks"
         other_disco_response = {

--- a/src/tests/unit/test_load_result.py
+++ b/src/tests/unit/test_load_result.py
@@ -1,0 +1,99 @@
+"""Unit tests for the load-runner result model — TH-1.5 (#474, epic #462).
+
+These cover the pure-logic properties of :class:`LoadResult` without needing the
+``load`` dependency group: the module imports cleanly in the plain unit env
+because :mod:`runner` spawns Locust in a subprocess and never imports it at
+top level. The end-to-end Locust proof lives in ``src/tests/load``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ..load.runner import LoadResult
+
+
+pytestmark = pytest.mark.unit
+
+
+def _result(**overrides) -> LoadResult:
+    base = {
+        "scenario_id": "S0",
+        "title": "unit",
+        "num_requests": 0,
+        "num_failures": 0,
+        "rps": 0.0,
+        "p50_ms": 0.0,
+        "p95_ms": 0.0,
+        "p99_ms": 0.0,
+        "p999_ms": 0.0,
+        "server_errors": 0,
+        "steady_state": True,
+    }
+    base.update(overrides)
+    return LoadResult(**base)
+
+
+class TestCacheHitRate:
+    def test_empty_window_reports_zero_not_one(self):
+        """An empty/failed-scrape window must NOT read as a perfect 100%.
+
+        Reporting 1.0 for ``total == 0`` would let a broken ``/metrics`` scrape
+        masquerade as a warm cache under a ``min_cache_hit_rate`` gate.
+        """
+        assert _result(cache_metrics={}).cache_hit_rate == 0.0
+
+    def test_all_hits_is_one(self):
+        r = _result(cache_metrics={"disco_hits": 3, "jwks_hits": 7})
+        assert r.cache_hit_rate == 1.0
+
+    def test_mixed_hits_and_misses(self):
+        r = _result(
+            cache_metrics={
+                "disco_hits": 1,
+                "disco_misses": 1,
+                "jwks_hits": 1,
+                "jwks_misses": 1,
+            }
+        )
+        two_hits_two_misses = 2 / 4
+        assert r.cache_hit_rate == two_hits_two_misses
+
+    def test_all_misses_is_zero(self):
+        # After the counter fix an all-error window records its failed fetches as
+        # misses, so this is the storm case — it must read 0.0, not 1.0.
+        r = _result(cache_metrics={"disco_misses": 4, "jwks_misses": 6})
+        assert r.cache_hit_rate == 0.0
+
+
+class TestAlgCostRatio:
+    def test_ratio_of_two_classes(self):
+        rs256_p95, es256_p95 = 5.0, 15.0
+        r = _result(
+            latency_by_class={
+                "valid": {"p95": rs256_p95},
+                "valid_es256": {"p95": es256_p95},
+            }
+        )
+        assert r.alg_cost_ratio("valid_es256", "valid") == es256_p95 / rs256_p95
+
+    def test_missing_class_returns_none(self):
+        r = _result(latency_by_class={"valid": {"p95": 5.0}})
+        assert r.alg_cost_ratio("valid_es256", "valid") is None
+
+    def test_zero_denominator_returns_none(self):
+        r = _result(
+            latency_by_class={
+                "valid": {"p95": 0.0},
+                "valid_es256": {"p95": 5.0},
+            }
+        )
+        assert r.alg_cost_ratio("valid_es256", "valid") is None
+
+
+def test_p999_is_a_reported_field():
+    """p999 (design §5 metric) is carried on the result, not silently dropped."""
+    p99, p999 = 10.0, 25.0
+    r = _result(p99_ms=p99, p999_ms=p999)
+    assert r.p999_ms == p999
+    assert r.p999_ms >= r.p99_ms

--- a/src/tests/unit/test_mock_op.py
+++ b/src/tests/unit/test_mock_op.py
@@ -1,0 +1,228 @@
+"""Unit tests for the controllable mock OP and forged corpus (TH-1.1, #463).
+
+Deterministic and network-free: the framework-free ASGI app is driven in-process
+via ``httpx.ASGITransport``, and the *real* library
+(:func:`py_identity_model.aio.validate_token`) validates minted / forged tokens
+through the mock OP's discovery + JWKS documents.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from py_identity_model.aio.managed_client import AsyncHTTPClient
+from py_identity_model.aio.token_validation import validate_token
+from py_identity_model.core.models import TokenValidationConfig
+from py_identity_model.exceptions import PyIdentityModelException
+
+from ..harness import CORPUS_AUDIENCE, MockOP, build_corpus
+from ..harness import mock_op as mock_op_mod
+
+
+HTTP_OK = 200
+HTTP_TOO_MANY_REQUESTS = 429
+HTTP_SERVICE_UNAVAILABLE = 503
+PUBLISHED_KEY_COUNT = 2
+OVERSIZED_PADDING = 50
+
+
+def _client(mock: MockOP) -> AsyncHTTPClient:
+    """An AsyncHTTPClient routed at the in-process mock OP (no network)."""
+    transport = httpx.ASGITransport(app=mock.app)
+    return AsyncHTTPClient(
+        client=httpx.AsyncClient(
+            transport=transport, base_url=mock.issuer, follow_redirects=False
+        )
+    )
+
+
+def _validation_config() -> TokenValidationConfig:
+    return TokenValidationConfig(
+        perform_disco=True,
+        audience=CORPUS_AUDIENCE,
+        algorithms=["RS256", "ES256"],
+        require_https=False,
+    )
+
+
+async def _validate(mock: MockOP, token: str) -> dict:
+    client = _client(mock)
+    try:
+        return await validate_token(
+            token,
+            _validation_config(),
+            disco_doc_address=mock.discovery_url,
+            http_client=client,
+        )
+    finally:
+        await client.close()
+
+
+# -- Documents served over ASGI --------------------------------------------
+
+
+async def test_discovery_document_served() -> None:
+    mock = MockOP()
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        resp = await client.get(mock.discovery_url)
+    assert resp.status_code == HTTP_OK
+    doc = resp.json()
+    assert doc["issuer"] == mock.issuer
+    assert doc["jwks_uri"] == mock.jwks_uri
+    assert doc["token_endpoint"] == mock.token_endpoint
+
+
+async def test_jwks_served_with_published_keys() -> None:
+    mock = MockOP()
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        resp = await client.get(mock.jwks_uri)
+    kids = {k["kid"] for k in resp.json()["keys"]}
+    assert mock.primary_key.kid in kids
+    assert mock.ec_key.kid in kids
+    assert mock.unpublished_key.kid not in kids
+
+
+async def test_token_endpoint_mints_valid_token() -> None:
+    mock = MockOP()
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        resp = await client.post(
+            mock.token_endpoint,
+            data={"grant_type": "client_credentials", "scope": "read"},
+        )
+    body = resp.json()
+    assert body["token_type"] == "Bearer"
+    claims = await _validate(mock, body["access_token"])
+    assert claims["iss"] == mock.issuer
+
+
+# -- End-to-end validation of the corpus -----------------------------------
+
+
+async def test_valid_token_validates_end_to_end() -> None:
+    mock = MockOP()
+    corpus = build_corpus(mock)
+    claims = await _validate(mock, corpus["valid"].jwt)
+    assert claims["scope"] == "read"
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "expired",
+        "nbf_future",
+        "wrong_iss",
+        "wrong_aud",
+        "tampered_sig",
+        "unknown_kid",
+        "wrong_alg",
+        "alg_none",
+    ],
+)
+async def test_forged_tokens_are_rejected(name: str) -> None:
+    mock = MockOP()
+    forged = build_corpus(mock)[name]
+    assert forged.library_rejects is True
+    with pytest.raises(PyIdentityModelException):
+        await _validate(mock, forged.jwt)
+
+
+@pytest.mark.parametrize("name", ["id_as_access", "cnf_bound", "oversized"])
+async def test_library_accepted_classes_are_signature_valid(name: str) -> None:
+    # These are validly signed for the audience — the library ACCEPTS them.
+    # Only the RS access-token marker / require_scope layer (F-07/F-02) rejects
+    # them; that distinction is proven in T302, not here.
+    mock = MockOP()
+    forged = build_corpus(mock)[name]
+    assert forged.library_rejects is False
+    claims = await _validate(mock, forged.jwt)
+    assert claims["iss"] == mock.issuer
+
+
+# -- Failure injection (design §2) -----------------------------------------
+
+
+async def test_key_rotation_then_republish() -> None:
+    mock = MockOP()
+    # Rotate to the spare WITHOUT publishing -> tokens present an unknown kid.
+    mock.rotate_keys(publish=False)
+    token = mock.mint_access_token()["access_token"]
+    with pytest.raises(PyIdentityModelException):
+        await _validate(mock, token)
+    # Publishing the rotated key lets the same token validate on refetch.
+    mock.publish_signing_key()
+    claims = await _validate(mock, token)
+    assert claims["iss"] == mock.issuer
+
+
+async def test_empty_jwks_control() -> None:
+    mock = MockOP()
+    mock.controls.serve_empty_jwks = True
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        resp = await client.get(mock.jwks_uri)
+    assert resp.json()["keys"] == []
+
+
+async def test_oversized_jwks_control() -> None:
+    mock = MockOP()
+    mock.controls.oversized_jwks_padding = OVERSIZED_PADDING
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        resp = await client.get(mock.jwks_uri)
+    assert len(resp.json()["keys"]) == PUBLISHED_KEY_COUNT + OVERSIZED_PADDING
+
+
+async def test_rate_limit_control_sets_retry_after() -> None:
+    mock = MockOP()
+    mock.controls.discovery_status = HTTP_TOO_MANY_REQUESTS
+    mock.controls.retry_after = "3"
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        resp = await client.get(mock.discovery_url)
+    assert resp.status_code == HTTP_TOO_MANY_REQUESTS
+    assert resp.headers["retry-after"] == "3"
+
+
+async def test_no_store_cache_control_on_jwks() -> None:
+    mock = MockOP()
+    mock.controls.jwks_cache_control = "no-store"
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        resp = await client.get(mock.jwks_uri)
+    assert resp.headers["cache-control"] == "no-store"
+
+
+async def test_injected_latency(monkeypatch: pytest.MonkeyPatch) -> None:
+    mock = MockOP()
+    slept: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        slept.append(seconds)
+
+    monkeypatch.setattr(mock_op_mod.asyncio, "sleep", fake_sleep)
+    mock.controls.latency_seconds = 0.25
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        await client.get(mock.discovery_url)
+    assert slept == [0.25]
+
+
+async def test_control_route_rotates_and_sets_knobs() -> None:
+    mock = MockOP()
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        resp = await client.post(
+            f"{mock.issuer}/_control",
+            json={
+                "rotate": True,
+                "publish": True,
+                "jwks_status": HTTP_SERVICE_UNAVAILABLE,
+            },
+        )
+    assert resp.json() == {"ok": True}
+    assert mock.controls.jwks_status == HTTP_SERVICE_UNAVAILABLE
+    assert mock.signing_key is mock.rotation_key

--- a/src/tests/unit/test_mock_op.py
+++ b/src/tests/unit/test_mock_op.py
@@ -280,3 +280,66 @@ def test_introspect_survives_malformed_exp() -> None:
 def test_introspect_reports_inactive_for_non_jwt() -> None:
     result = MockOP().introspect("not.a.jwt")
     assert result["active"] is False
+
+
+# -- Per-path request counters (design §5 — upstream fetches/issuer) ---------
+
+
+async def test_stats_count_each_upstream_request() -> None:
+    """Every document handler bumps its counter — the S3 single-flight ground
+    truth (a cold stampede must show exactly one discovery + one JWKS fetch)."""
+    mock = MockOP()
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        await client.get(mock.discovery_url)
+        await client.get(mock.jwks_uri)
+        await client.get(mock.jwks_uri)
+        await client.post(mock.token_endpoint, data={"scope": "read"})
+    assert mock.stats.snapshot() == {
+        "discovery": 1,
+        "jwks": 2,
+        "token": 1,
+        "introspect": 0,
+    }
+
+
+async def test_stats_count_injected_failures() -> None:
+    """A ``429``/``5xx`` still costs an upstream round trip, so it is counted."""
+    mock = MockOP()
+    mock.controls.jwks_status = HTTP_SERVICE_UNAVAILABLE
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        resp = await client.get(mock.jwks_uri)
+    assert resp.status_code == HTTP_SERVICE_UNAVAILABLE
+    assert mock.stats.jwks == 1
+
+
+async def test_stats_route_reads_and_resets() -> None:
+    """The ``/_stats`` route mirrors ``mock.stats`` and ``POST`` zeroes it — how
+    the out-of-process load driver scrapes upstream-fetch counts per scenario."""
+    mock = MockOP()
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        await client.get(mock.discovery_url)
+        read = await client.get(f"{mock.issuer}/_stats")
+        assert read.json() == {
+            "discovery": 1,
+            "jwks": 0,
+            "token": 0,
+            "introspect": 0,
+        }
+        # The /_stats read itself must NOT count as an upstream document fetch.
+        reset = await client.post(f"{mock.issuer}/_stats")
+        assert reset.json() == {
+            "ok": True,
+            "discovery": 0,
+            "jwks": 0,
+            "token": 0,
+            "introspect": 0,
+        }
+        assert mock.stats.snapshot() == {
+            "discovery": 0,
+            "jwks": 0,
+            "token": 0,
+            "introspect": 0,
+        }

--- a/src/tests/unit/test_mock_op.py
+++ b/src/tests/unit/test_mock_op.py
@@ -9,6 +9,7 @@ through the mock OP's discovery + JWKS documents.
 from __future__ import annotations
 
 import httpx
+import jwt
 import pytest
 
 from py_identity_model.aio.managed_client import AsyncHTTPClient
@@ -223,6 +224,59 @@ async def test_control_route_rotates_and_sets_knobs() -> None:
                 "jwks_status": HTTP_SERVICE_UNAVAILABLE,
             },
         )
-    assert resp.json() == {"ok": True}
+    assert resp.json() == {"ok": True, "rejected": []}
     assert mock.controls.jwks_status == HTTP_SERVICE_UNAVAILABLE
     assert mock.signing_key is mock.rotation_key
+
+
+async def test_control_route_rejects_type_mismatched_values() -> None:
+    """A stray JSON type must be rejected at the control call, not crash a later
+    request (design: fail local, not downstream)."""
+    mock = MockOP()
+    transport = httpx.ASGITransport(app=mock.app)
+    async with httpx.AsyncClient(transport=transport, base_url=mock.issuer) as client:
+        resp = await client.post(
+            f"{mock.issuer}/_control",
+            json={
+                "jwks_status": "boom",  # str for an int field -> reject
+                "retry_after": 3,  # int for a str|None field -> reject
+                "oversized_jwks_padding": "big",  # str for an int field -> reject
+                "discovery_status": HTTP_SERVICE_UNAVAILABLE,  # valid int -> apply
+            },
+        )
+        body = resp.json()
+        # The valid knob applied; the mismatches were reported, not applied.
+        assert body["ok"] is True
+        assert set(body["rejected"]) == {
+            "jwks_status",
+            "retry_after",
+            "oversized_jwks_padding",
+        }
+        assert mock.controls.jwks_status == HTTP_OK
+        assert mock.controls.retry_after is None
+        assert mock.controls.oversized_jwks_padding == 0
+        assert mock.controls.discovery_status == HTTP_SERVICE_UNAVAILABLE
+        # The next /jwks request must still succeed (no poisoned state).
+        mock.controls.jwks_status = HTTP_OK
+        jwks = await client.get(mock.jwks_uri)
+        assert jwks.status_code == HTTP_OK
+
+
+def test_introspect_reports_active_for_valid_token() -> None:
+    mock = MockOP()
+    minted = mock.mint_access_token()
+    result = mock.introspect(minted["access_token"])
+    assert result["active"] is True
+
+
+def test_introspect_survives_malformed_exp() -> None:
+    """A token with a non-numeric ``exp`` (exactly what this harness forges)
+    must report inactive, not 500 the introspect endpoint."""
+    token = jwt.encode({"exp": "not-a-number"}, "x" * 32, algorithm="HS256")
+    result = MockOP().introspect(token)
+    assert result["active"] is False
+
+
+def test_introspect_reports_inactive_for_non_jwt() -> None:
+    result = MockOP().introspect("not.a.jwt")
+    assert result["active"] is False

--- a/src/tests/unit/test_token_source_gating.py
+++ b/src/tests/unit/test_token_source_gating.py
@@ -8,7 +8,12 @@ is always mintable (valid + forged).
 
 from __future__ import annotations
 
+import base64
+import json
+
+import jwt
 import pytest
+import respx
 
 from ..harness import (
     Grant,
@@ -21,6 +26,7 @@ from ..harness import (
     TokenSource,
     prime_pool,
 )
+from ..harness.token_source import _peek_jwt_header
 
 
 JWT_SEGMENT_COUNT = 2
@@ -135,6 +141,72 @@ def test_auth_code_minter_is_invoked() -> None:
     )
     assert token.access_token == "opaque-token"
     assert calls == [("t1", "openid")]
+
+
+def test_descope_multitenant_requires_management_creds() -> None:
+    # Plain CC creds present, but the multi-tenant (tenant=…) path needs the
+    # access-key exchange config; absent -> credential error (drives skip).
+    descope = ProviderConfig(
+        provider=Provider.DESCOPE,
+        capabilities={"client_credentials"},
+        token_endpoint="https://api.descope.com/oauth2/v1/token",
+        client_id="cid",
+        client_secret="secret",
+    )
+    source = TokenSource([descope])
+    with pytest.raises(HarnessCredentialError, match="multi-tenant"):
+        source.mint(Provider.DESCOPE, Grant.CLIENT_CREDENTIALS, tenant="t1")
+
+
+@respx.mock
+def test_descope_multitenant_exchange_produces_dct_tenants() -> None:
+    # AC-3: the multi-tenant path reuses access-key create -> exchange -> delete
+    # and returns the session JWT carrying distinct dct/tenants claims.
+    base = "https://api.descope.com"
+    session_jwt = jwt.encode(
+        {"sub": "u1", "dct": "t1", "tenants": {"t1": {"roles": ["admin"]}}},
+        "x" * 32,
+        algorithm="HS256",
+    )
+    create = respx.post(f"{base}/v1/mgmt/accesskey/create").respond(
+        json={"key": {"id": "k1"}, "cleartext": "ck"}
+    )
+    exchange = respx.post(f"{base}/v1/auth/accesskey/exchange").respond(
+        json={"sessionJwt": session_jwt}
+    )
+    delete = respx.post(f"{base}/v1/mgmt/accesskey/delete").respond(json={})
+
+    cfg = ProviderConfig(
+        provider=Provider.DESCOPE,
+        capabilities={"client_credentials"},
+        descope_project_id="P1",
+        descope_management_key="MK",
+        descope_base_url=base,
+    )
+    token = TokenSource([cfg]).mint(
+        Provider.DESCOPE, Grant.CLIENT_CREDENTIALS, tenant="t1"
+    )
+
+    assert token.access_token == session_jwt
+    assert token.tenant == "t1"
+    # keyTenants array shaping (not top-level tenantId) is what yields dct/tenants.
+    body = json.loads(create.calls.last.request.content)
+    assert body["keyTenants"] == [{"tenantId": "t1", "roleNames": ["owner", "admin"]}]
+    payload = json.loads(
+        base64.urlsafe_b64decode(token.access_token.split(".")[1] + "==").decode()
+    )
+    assert payload["dct"] == "t1"
+    assert "t1" in payload["tenants"]
+    assert exchange.called
+    assert delete.called  # temporary key cleaned up
+
+
+def test_peek_jwt_header_guards_non_object_header() -> None:
+    """A JWT whose header segment decodes to a non-object (e.g. ``5``) must not
+    crash header inspection — return ``(None, None)`` like an opaque token."""
+    non_object_header = base64.urlsafe_b64encode(b"5").rstrip(b"=").decode()
+    token = f"{non_object_header}.{non_object_header}.sig"
+    assert _peek_jwt_header(token) == (None, None)
 
 
 def test_replay_pool_mints_once() -> None:

--- a/src/tests/unit/test_token_source_gating.py
+++ b/src/tests/unit/test_token_source_gating.py
@@ -1,0 +1,150 @@
+"""Unit tests for TokenSource capability/credential gating (TH-1.1, #463).
+
+The gating mirrors ``provider_matrix.detect_capabilities``: an unsupported
+grant raises :class:`HarnessCapabilityError`, a supported grant with absent
+credentials raises :class:`HarnessCredentialError`, and the ``MOCK`` provider
+is always mintable (valid + forged).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ..harness import (
+    Grant,
+    HarnessCapabilityError,
+    HarnessCredentialError,
+    Malform,
+    MintSpec,
+    Provider,
+    ProviderConfig,
+    TokenSource,
+    prime_pool,
+)
+
+
+JWT_SEGMENT_COUNT = 2
+DEDUPED_POOL_SIZE = 2
+
+
+def test_mock_provider_is_always_mintable() -> None:
+    source = TokenSource.with_mock()
+    token = source.mint(Provider.MOCK, Grant.CLIENT_CREDENTIALS)
+    assert token.provider is Provider.MOCK
+    assert token.malform is Malform.VALID
+    assert token.access_token.count(".") == JWT_SEGMENT_COUNT  # a real JWT
+    assert token.expires_at is not None
+    assert token.alg == "RS256"
+
+
+def test_mock_provider_mints_every_forged_class() -> None:
+    source = TokenSource.with_mock()
+    for malform in Malform:
+        token = source.mint(Provider.MOCK, malform=malform)
+        assert token.malform is malform
+        assert token.access_token  # non-empty
+
+
+def test_forged_tokens_are_mock_only() -> None:
+    node = ProviderConfig(
+        provider=Provider.NODE_OIDC,
+        capabilities={"client_credentials"},
+        token_endpoint="https://issuer.example/token",
+        client_id="cid",
+        client_secret="secret",
+    )
+    source = TokenSource([node])
+    with pytest.raises(HarnessCapabilityError, match="MOCK provider"):
+        source.mint(Provider.NODE_OIDC, malform=Malform.ALG_NONE)
+
+
+def test_capability_gating_rejects_unsupported_grant() -> None:
+    # Advertises only client_credentials — auth_code must be capability-gated.
+    node = ProviderConfig(
+        provider=Provider.NODE_OIDC,
+        capabilities={"client_credentials"},
+        token_endpoint="https://issuer.example/token",
+        client_id="cid",
+        client_secret="secret",
+    )
+    source = TokenSource([node])
+    with pytest.raises(HarnessCapabilityError, match="authorization_code"):
+        source.mint(Provider.NODE_OIDC, Grant.AUTHORIZATION_CODE)
+
+
+def test_credential_gating_when_secret_absent() -> None:
+    # Capability present, credentials missing -> credential error (drives skip).
+    ory = ProviderConfig(
+        provider=Provider.ORY,
+        capabilities={"client_credentials"},
+        token_endpoint="https://issuer.example/token",
+        client_id=None,
+        client_secret=None,
+    )
+    source = TokenSource([ory])
+    with pytest.raises(HarnessCredentialError):
+        source.mint(Provider.ORY, Grant.CLIENT_CREDENTIALS)
+
+
+def test_auth_code_requires_injected_minter() -> None:
+    keycloak = ProviderConfig(
+        provider=Provider.KEYCLOAK,
+        capabilities={"authorization_code"},
+    )
+    source = TokenSource([keycloak])
+    with pytest.raises(HarnessCredentialError, match="auth-code minter"):
+        source.mint(Provider.KEYCLOAK, Grant.AUTHORIZATION_CODE)
+
+
+def test_unconfigured_provider_raises_capability_error() -> None:
+    source = TokenSource.with_mock()
+    with pytest.raises(HarnessCapabilityError, match="not configured"):
+        source.mint(Provider.DESCOPE, Grant.CLIENT_CREDENTIALS)
+
+
+def test_from_discovery_derives_capabilities() -> None:
+    disco = {
+        "issuer": "http://localhost:9000",
+        "token_endpoint": "http://localhost:9000/token",
+        "authorization_endpoint": "http://localhost:9000/auth",
+        "grant_types_supported": ["client_credentials", "authorization_code"],
+    }
+    cfg = ProviderConfig.from_discovery(
+        Provider.NODE_OIDC, disco, client_id="cid", client_secret="secret"
+    )
+    assert "client_credentials" in cfg.capabilities
+    assert "authorization_code" in cfg.capabilities
+    assert cfg.token_endpoint == "http://localhost:9000/token"
+
+
+def test_auth_code_minter_is_invoked() -> None:
+    calls: list[tuple[str | None, str | None]] = []
+
+    def minter(tenant: str | None, scopes: str | None) -> dict:
+        calls.append((tenant, scopes))
+        return {"access_token": "opaque-token", "token_type": "Bearer"}
+
+    cfg = ProviderConfig(
+        provider=Provider.KEYCLOAK,
+        capabilities={"authorization_code"},
+        auth_code_minter=minter,
+    )
+    source = TokenSource([cfg])
+    token = source.mint(
+        Provider.KEYCLOAK, Grant.AUTHORIZATION_CODE, tenant="t1", scopes="openid"
+    )
+    assert token.access_token == "opaque-token"
+    assert calls == [("t1", "openid")]
+
+
+def test_replay_pool_mints_once() -> None:
+    source = TokenSource.with_mock()
+    specs = [
+        MintSpec(Provider.MOCK, Grant.CLIENT_CREDENTIALS),
+        MintSpec(Provider.MOCK, Grant.CLIENT_CREDENTIALS),  # duplicate -> deduped
+        MintSpec(Provider.MOCK, malform=Malform.EXPIRED),
+    ]
+    pool = prime_pool(source, specs)
+    assert len(pool) == DEDUPED_POOL_SIZE
+    valid = pool.get(MintSpec(Provider.MOCK, Grant.CLIENT_CREDENTIALS))
+    assert valid.malform is Malform.VALID

--- a/tools/mutation_security_allowlist.txt
+++ b/tools/mutation_security_allowlist.txt
@@ -22,3 +22,37 @@
 # below is never reached. No input that reaches the else branch can observe []
 # vs None: semantically equivalent, unkillable.
 py_identity_model.core.token_validation_logic.x__enforce_allowed_issuers__mutmut_6
+
+# ── T299 cache-observability counters (aio.token_validation) ──────────────────
+#
+# Lock-stripe distribution (class 2): ``_get_*_fetch_lock(None)`` makes
+# ``hash(None) % STRIPES`` pick one fixed valid stripe instead of hashing the
+# URI/key. Single-flight correctness is unaffected — same-URI fetches still
+# serialise on the same lock object — only which of the 32 stripes is selected
+# changes, which is not observable.
+py_identity_model.aio.token_validation.x__get_disco_response__mutmut_19
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_3
+
+# Log-only (class 1): message-text / logger-arg mutations of the "Forcing JWKS
+# refresh" info line (11-17) and the empty-keys retained-cache fallback info
+# line (42-52). These are human-readable log strings, not security controls;
+# they change no control flow, return value, or counter. Asserting exact log
+# text is brittle and out of scope.
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_11
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_12
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_13
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_14
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_15
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_16
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_17
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_42
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_43
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_44
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_45
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_46
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_47
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_48
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_49
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_50
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_51
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_52

--- a/tools/mutation_security_allowlist.txt
+++ b/tools/mutation_security_allowlist.txt
@@ -35,9 +35,10 @@ py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_3
 
 # Log-only (class 1): message-text / logger-arg mutations of the "Forcing JWKS
 # refresh" info line (11-17) and the empty-keys retained-cache fallback info
-# line (42-52). These are human-readable log strings, not security controls;
+# line (42-56). These are human-readable log strings, not security controls;
 # they change no control flow, return value, or counter. Asserting exact log
-# text is brittle and out of scope.
+# text is brittle and out of scope. (53-56 mutate the "falling back ... in-flight
+# validation" segments of that same info line — identical justification.)
 py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_11
 py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_12
 py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_13
@@ -56,3 +57,7 @@ py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_49
 py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_50
 py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_51
 py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_52
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_53
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_54
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_55
+py_identity_model.aio.token_validation.x__refresh_jwks__mutmut_56

--- a/uv.lock
+++ b/uv.lock
@@ -78,6 +78,62 @@ wheels = [
 ]
 
 [[package]]
+name = "bidict"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/6e/026678aa5a830e07cd9498a05d3e7e650a4f56a42f267a53d22bcda1bdc9/bidict-0.23.1.tar.gz", hash = "sha256:03069d763bc387bbd20e7d49914e75fc4132a41937fa3405417e1a5a2d006d71", size = 29093, upload-time = "2024-02-18T19:09:05.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/37/e8730c3587a65eb5645d4aba2d27aae48e8003614d6aaf15dda67f702f1f/bidict-0.23.1-py3-none-any.whl", hash = "sha256:5dae8d4d79b552a71cbabc7deb25dfe8ce710b17ff41711e13010ead2abfc3e5", size = 32764, upload-time = "2024-02-18T19:09:04.156Z" },
+]
+
+[[package]]
+name = "blinker"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
+]
+
+[[package]]
+name = "brotli"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/16/c92ca344d646e71a43b8bb353f0a6490d7f6e06210f8554c8f874e454285/brotli-1.2.0.tar.gz", hash = "sha256:e310f77e41941c13340a95976fe66a8a95b01e783d430eeaf7a2f87e0a57dd0a", size = 7388632, upload-time = "2025-11-05T18:39:42.86Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/ee/b0a11ab2315c69bb9b45a2aaed022499c9c24a205c3a49c3513b541a7967/brotli-1.2.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:35d382625778834a7f3061b15423919aa03e4f5da34ac8e02c074e4b75ab4f84", size = 861543, upload-time = "2025-11-05T18:38:24.183Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2f/29c1459513cd35828e25531ebfcbf3e92a5e49f560b1777a9af7203eb46e/brotli-1.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7a61c06b334bd99bc5ae84f1eeb36bfe01400264b3c352f968c6e30a10f9d08b", size = 444288, upload-time = "2025-11-05T18:38:25.139Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/6f/feba03130d5fceadfa3a1bb102cb14650798c848b1df2a808356f939bb16/brotli-1.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:acec55bb7c90f1dfc476126f9711a8e81c9af7fb617409a9ee2953115343f08d", size = 1528071, upload-time = "2025-11-05T18:38:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/38/f3abb554eee089bd15471057ba85f47e53a44a462cfce265d9bf7088eb09/brotli-1.2.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:260d3692396e1895c5034f204f0db022c056f9e2ac841593a4cf9426e2a3faca", size = 1626913, upload-time = "2025-11-05T18:38:27.284Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a7/03aa61fbc3c5cbf99b44d158665f9b0dd3d8059be16c460208d9e385c837/brotli-1.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:072e7624b1fc4d601036ab3f4f27942ef772887e876beff0301d261210bca97f", size = 1419762, upload-time = "2025-11-05T18:38:28.295Z" },
+    { url = "https://files.pythonhosted.org/packages/21/1b/0374a89ee27d152a5069c356c96b93afd1b94eae83f1e004b57eb6ce2f10/brotli-1.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:adedc4a67e15327dfdd04884873c6d5a01d3e3b6f61406f99b1ed4865a2f6d28", size = 1484494, upload-time = "2025-11-05T18:38:29.29Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/57/69d4fe84a67aef4f524dcd075c6eee868d7850e85bf01d778a857d8dbe0a/brotli-1.2.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:7a47ce5c2288702e09dc22a44d0ee6152f2c7eda97b3c8482d826a1f3cfc7da7", size = 1593302, upload-time = "2025-11-05T18:38:30.639Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/3b/39e13ce78a8e9a621c5df3aeb5fd181fcc8caba8c48a194cd629771f6828/brotli-1.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:af43b8711a8264bb4e7d6d9a6d004c3a2019c04c01127a868709ec29962b6036", size = 1487913, upload-time = "2025-11-05T18:38:31.618Z" },
+    { url = "https://files.pythonhosted.org/packages/62/28/4d00cb9bd76a6357a66fcd54b4b6d70288385584063f4b07884c1e7286ac/brotli-1.2.0-cp312-cp312-win32.whl", hash = "sha256:e99befa0b48f3cd293dafeacdd0d191804d105d279e0b387a32054c1180f3161", size = 334362, upload-time = "2025-11-05T18:38:32.939Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/4e/bc1dcac9498859d5e353c9b153627a3752868a9d5f05ce8dedd81a2354ab/brotli-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:b35c13ce241abdd44cb8ca70683f20c0c079728a36a996297adb5334adfc1c44", size = 369115, upload-time = "2025-11-05T18:38:33.765Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d4/4ad5432ac98c73096159d9ce7ffeb82d151c2ac84adcc6168e476bb54674/brotli-1.2.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9e5825ba2c9998375530504578fd4d5d1059d09621a02065d1b6bfc41a8e05ab", size = 861523, upload-time = "2025-11-05T18:38:34.67Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9f/9cc5bd03ee68a85dc4bc89114f7067c056a3c14b3d95f171918c088bf88d/brotli-1.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0cf8c3b8ba93d496b2fae778039e2f5ecc7cff99df84df337ca31d8f2252896c", size = 444289, upload-time = "2025-11-05T18:38:35.6Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b6/fe84227c56a865d16a6614e2c4722864b380cb14b13f3e6bef441e73a85a/brotli-1.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c8565e3cdc1808b1a34714b553b262c5de5fbda202285782173ec137fd13709f", size = 1528076, upload-time = "2025-11-05T18:38:36.639Z" },
+    { url = "https://files.pythonhosted.org/packages/55/de/de4ae0aaca06c790371cf6e7ee93a024f6b4bb0568727da8c3de112e726c/brotli-1.2.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:26e8d3ecb0ee458a9804f47f21b74845cc823fd1bb19f02272be70774f56e2a6", size = 1626880, upload-time = "2025-11-05T18:38:37.623Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/16/a1b22cbea436642e071adcaf8d4b350a2ad02f5e0ad0da879a1be16188a0/brotli-1.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:67a91c5187e1eec76a61625c77a6c8c785650f5b576ca732bd33ef58b0dff49c", size = 1419737, upload-time = "2025-11-05T18:38:38.729Z" },
+    { url = "https://files.pythonhosted.org/packages/46/63/c968a97cbb3bdbf7f974ef5a6ab467a2879b82afbc5ffb65b8acbb744f95/brotli-1.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4ecdb3b6dc36e6d6e14d3a1bdc6c1057c8cbf80db04031d566eb6080ce283a48", size = 1484440, upload-time = "2025-11-05T18:38:39.916Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9d/102c67ea5c9fc171f423e8399e585dabea29b5bc79b05572891e70013cdd/brotli-1.2.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3e1b35d56856f3ed326b140d3c6d9db91740f22e14b06e840fe4bb1923439a18", size = 1593313, upload-time = "2025-11-05T18:38:41.24Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/4a/9526d14fa6b87bc827ba1755a8440e214ff90de03095cacd78a64abe2b7d/brotli-1.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:54a50a9dad16b32136b2241ddea9e4df159b41247b2ce6aac0b3276a66a8f1e5", size = 1487945, upload-time = "2025-11-05T18:38:42.277Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e8/3fe1ffed70cbef83c5236166acaed7bb9c766509b157854c80e2f766b38c/brotli-1.2.0-cp313-cp313-win32.whl", hash = "sha256:1b1d6a4efedd53671c793be6dd760fcf2107da3a52331ad9ea429edf0902f27a", size = 334368, upload-time = "2025-11-05T18:38:43.345Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/91/e739587be970a113b37b821eae8097aac5a48e5f0eca438c22e4c7dd8648/brotli-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:b63daa43d82f0cdabf98dee215b375b4058cce72871fd07934f179885aad16e8", size = 369116, upload-time = "2025-11-05T18:38:44.609Z" },
+    { url = "https://files.pythonhosted.org/packages/17/e1/298c2ddf786bb7347a1cd71d63a347a79e5712a7c0cba9e3c3458ebd976f/brotli-1.2.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6c12dad5cd04530323e723787ff762bac749a7b256a5bece32b2243dd5c27b21", size = 863080, upload-time = "2025-11-05T18:38:45.503Z" },
+    { url = "https://files.pythonhosted.org/packages/84/0c/aac98e286ba66868b2b3b50338ffbd85a35c7122e9531a73a37a29763d38/brotli-1.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3219bd9e69868e57183316ee19c84e03e8f8b5a1d1f2667e1aa8c2f91cb061ac", size = 445453, upload-time = "2025-11-05T18:38:46.433Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/f1/0ca1f3f99ae300372635ab3fe2f7a79fa335fee3d874fa7f9e68575e0e62/brotli-1.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:963a08f3bebd8b75ac57661045402da15991468a621f014be54e50f53a58d19e", size = 1528168, upload-time = "2025-11-05T18:38:47.371Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a6/2ebfc8f766d46df8d3e65b880a2e220732395e6d7dc312c1e1244b0f074a/brotli-1.2.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9322b9f8656782414b37e6af884146869d46ab85158201d82bab9abbcb971dc7", size = 1627098, upload-time = "2025-11-05T18:38:48.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/2f/0976d5b097ff8a22163b10617f76b2557f15f0f39d6a0fe1f02b1a53e92b/brotli-1.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cf9cba6f5b78a2071ec6fb1e7bd39acf35071d90a81231d67e92d637776a6a63", size = 1419861, upload-time = "2025-11-05T18:38:49.372Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/d76df7176a2ce7616ff94c1fb72d307c9a30d2189fe877f3dd99af00ea5a/brotli-1.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7547369c4392b47d30a3467fe8c3330b4f2e0f7730e45e3103d7d636678a808b", size = 1484594, upload-time = "2025-11-05T18:38:50.655Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/93/14cf0b1216f43df5609f5b272050b0abd219e0b54ea80b47cef9867b45e7/brotli-1.2.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:fc1530af5c3c275b8524f2e24841cbe2599d74462455e9bae5109e9ff42e9361", size = 1593455, upload-time = "2025-11-05T18:38:51.624Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/73/3183c9e41ca755713bdf2cc1d0810df742c09484e2e1ddd693bee53877c1/brotli-1.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d2d085ded05278d1c7f65560aae97b3160aeb2ea2c0b3e26204856beccb60888", size = 1488164, upload-time = "2025-11-05T18:38:53.079Z" },
+    { url = "https://files.pythonhosted.org/packages/64/6a/0c78d8f3a582859236482fd9fa86a65a60328a00983006bcf6d83b7b2253/brotli-1.2.0-cp314-cp314-win32.whl", hash = "sha256:832c115a020e463c2f67664560449a7bea26b0c1fdd690352addad6d0a08714d", size = 339280, upload-time = "2025-11-05T18:38:54.02Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/10/56978295c14794b2c12007b07f3e41ba26acda9257457d7085b0bb3bb90c/brotli-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:e7c0af964e0b4e3412a0ebf341ea26ec767fa0b4cf81abb5e897c9338b5ad6a3", size = 375639, upload-time = "2025-11-05T18:38:55.67Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.5.20"
 source = { registry = "https://pypi.org/simple" }
@@ -244,6 +300,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "configargparse"
+version = "1.7.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/0b/30328302903c55218ffc5199646d0e9d28348ff26c02ba77b2ffc58d294a/configargparse-1.7.5.tar.gz", hash = "sha256:e3f9a7bb6be34d66b2e3c4a2f58e3045f8dfae47b0dc039f87bcfaa0f193fb0f", size = 53548, upload-time = "2026-03-11T02:19:38.144Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/19/3ba5e1b0bcc7b91aeab6c258afd70e4907d220fed3972febe38feb40db30/configargparse-1.7.5-py3-none-any.whl", hash = "sha256:1e63fdffedf94da9cd435fc13a1cd24777e76879dd2343912c1f871d4ac8c592", size = 27692, upload-time = "2026-03-11T02:19:36.442Z" },
 ]
 
 [[package]]
@@ -471,6 +536,155 @@ wheels = [
 ]
 
 [[package]]
+name = "flask"
+version = "3.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "blinker" },
+    { name = "click" },
+    { name = "itsdangerous" },
+    { name = "jinja2" },
+    { name = "markupsafe" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/00/35d85dcce6c57fdc871f3867d465d780f302a175ea360f62533f12b27e2b/flask-3.1.3.tar.gz", hash = "sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb", size = 759004, upload-time = "2026-02-19T05:00:57.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/9c/34f6962f9b9e9c71f6e5ed806e0d0ff03c9d1b0b2340088a0cf4bce09b18/flask-3.1.3-py3-none-any.whl", hash = "sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c", size = 103424, upload-time = "2026-02-19T05:00:56.027Z" },
+]
+
+[[package]]
+name = "flask-cors"
+version = "6.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flask" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/03/4e464a50860f9adf08b5c1d3479cb8ea1f12af2aa69535c7042c6e628135/flask_cors-6.0.5.tar.gz", hash = "sha256:30c5031552cd59f620ac0c8211dac45b345d3b2df310e7721879e4f46ef9c601", size = 101386, upload-time = "2026-06-08T20:20:17.765Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/55/5bb1a2d918e9f02f131e47a59032bae70e48050e986e941511fd737a935c/flask_cors-6.0.5-py3-none-any.whl", hash = "sha256:68fcf75693e961f3af26683b23c4b9a8fb6b64de17d20d0c37b95e8de7ab2ed8", size = 16692, upload-time = "2026-06-08T20:20:16.247Z" },
+]
+
+[[package]]
+name = "flask-login"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flask" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/6e/2f4e13e373bb49e68c02c51ceadd22d172715a06716f9299d9df01b6ddb2/Flask-Login-0.6.3.tar.gz", hash = "sha256:5e23d14a607ef12806c699590b89d0f0e0d67baeec599d75947bf9c147330333", size = 48834, upload-time = "2023-10-30T14:53:21.151Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/f5/67e9cc5c2036f58115f9fe0f00d203cf6780c3ff8ae0e705e7a9d9e8ff9e/Flask_Login-0.6.3-py3-none-any.whl", hash = "sha256:849b25b82a436bf830a054e74214074af59097171562ab10bfa999e6b78aae5d", size = 17303, upload-time = "2023-10-30T14:53:19.636Z" },
+]
+
+[[package]]
+name = "gevent"
+version = "26.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation == 'CPython' and sys_platform == 'win32'" },
+    { name = "greenlet", marker = "platform_python_implementation == 'CPython'" },
+    { name = "zope-event" },
+    { name = "zope-interface" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/5c/92002455a57cb3634383e2b822e3bccf409f43cde34528e46428971475cf/gevent-26.7.0.tar.gz", hash = "sha256:5b333a556e38a302b1b8c80525bef16d437e16f1e7767947789406841856a102", size = 6729213, upload-time = "2026-07-22T20:16:04.713Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/66/104590ad3a9e671b3ef77ad19c1cc50e7f1c8c220b27ddfaf34e5f88bd9c/gevent-26.7.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:92f256285fb43a57f152bd2e51a59cde1cd0b20869ae1e6da583b6beab88ed8a", size = 2953977, upload-time = "2026-07-22T16:23:41.654Z" },
+    { url = "https://files.pythonhosted.org/packages/64/07/350d87161378633714184828bdc57c66f9b525eca5249ad1294dc7f8cf58/gevent-26.7.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:0e4fea187c5df7168b9538b4f543fcb0fcbaeb93be3d6cd499c324652c740704", size = 1800960, upload-time = "2026-07-22T18:11:27.242Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/6c/ddfe298c2ecb1cfc72a03dd69ba751759f7e7835d3135f171b284eb09ed1/gevent-26.7.0-cp312-cp312-manylinux_2_28_ppc64le.whl", hash = "sha256:ce732fe08d0ea65de07eff6e46bade8ac6a6fdb65cc748c713f3d31ae122529e", size = 1900387, upload-time = "2026-07-22T18:10:42.973Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/89/2647bbbf1da35a1c271a54452e76065308cbaf684ee32a79f989ca4265f6/gevent-26.7.0-cp312-cp312-manylinux_2_28_s390x.whl", hash = "sha256:c25b3522072137aecf3389031039230190038f888e257f490b3897d0e0620f74", size = 1848046, upload-time = "2026-07-22T18:29:08.074Z" },
+    { url = "https://files.pythonhosted.org/packages/31/52/4f9b4c536b5a0424e328d5a5466640d185020f1f0b08b2de0ca939cc0a0b/gevent-26.7.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:eaaa75c9014df3f8c310c64f53f1152af8c6be32e82734396bed91e1d0e6f35c", size = 2132200, upload-time = "2026-07-22T16:48:31.203Z" },
+    { url = "https://files.pythonhosted.org/packages/42/88/1daffa63b257c381df68018e4d3da72b429955cf95a171a46d3220422c8d/gevent-26.7.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f1956032a9926ac9b4152b2a50bc5a2cc020722ec16928ccaf32e227ee0aae47", size = 1814237, upload-time = "2026-07-22T18:07:12.438Z" },
+    { url = "https://files.pythonhosted.org/packages/73/4c/b996cdddca78eac435195cd97dff590c65a9e0052640bcb6f8b6f1e30b1d/gevent-26.7.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d989a1ad6cc54f5c69bb7304360f98b4fda80da2b773f1047db9fba61ae7379a", size = 2157938, upload-time = "2026-07-22T17:02:14.887Z" },
+    { url = "https://files.pythonhosted.org/packages/08/fd/44419d7559a95e238ee45d29df30bad78a91d343cb27b13a6af552b907bb/gevent-26.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:e0c9ce2d80fc0f8894d748a1045ff26ad188e294bad656b29839271800827c85", size = 1685319, upload-time = "2026-07-22T16:26:13.954Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/7a/7df1762ccd9a40ce1ca626f50cb7a75758f2c930aabcc73c91cf00cb3448/gevent-26.7.0-cp312-cp312-win_arm64.whl", hash = "sha256:959effe0c56cdee0bf761e5c4e78ab62880be147a2f2aa31112ca2f7e5754e53", size = 1558945, upload-time = "2026-07-22T16:26:56.737Z" },
+    { url = "https://files.pythonhosted.org/packages/75/63/0fcfbe3f5696e56424f331ec41e0e447cea79c384848d6019e3f7f340f4b/gevent-26.7.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:b1b89eb5566f75aa8b2bbdb0308e1ac8d9113ca7cff85b45366aea9faad639a1", size = 2976844, upload-time = "2026-07-22T16:24:39.275Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/6c/ea2d0afbe760c18df5bd1631dbe5a73d840d9b141cb71e6810157c2ae28a/gevent-26.7.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:449857ce058183442e2d71d83ff0c587a3ddff631e93c6d19a6dffb4814eccad", size = 1802332, upload-time = "2026-07-22T18:11:29.155Z" },
+    { url = "https://files.pythonhosted.org/packages/59/90/36f2258f1bfe8601224f6159066103b832c31e1451ce8dc2cd2408b6ecf4/gevent-26.7.0-cp313-cp313-manylinux_2_28_ppc64le.whl", hash = "sha256:8260a3f38b05fcf3c283417b18617562dbec74f5784f748e4ba3866789d7f3a4", size = 1901253, upload-time = "2026-07-22T18:10:44.402Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/38/86dd67e5c2dfab016a9c935b4338d6cf8f9bfa72dc5a0f3fb879d993127a/gevent-26.7.0-cp313-cp313-manylinux_2_28_s390x.whl", hash = "sha256:30894398d06747b433c8923a6a77ede61259ce6822a99f6c6e7fa0216ccb73c3", size = 1850489, upload-time = "2026-07-22T18:29:09.694Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/33/f5651942a5967483298b6ce6f45572d33120dd0fd01c8991d3fca5b1e8ee/gevent-26.7.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:0b753522498118c9489753de7c612d4baed0edf384d9df2bf9492233ba1c20ff", size = 2129813, upload-time = "2026-07-22T16:48:32.551Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/09/abe8217a8fcd3f0e94c9eec024a5499c0f267cb269ccea6c0e2e812319b9/gevent-26.7.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:055a643026dc28daff2be228555a2097937448cc9b58307edebcf81b9d78ff4b", size = 1815121, upload-time = "2026-07-22T18:07:13.988Z" },
+    { url = "https://files.pythonhosted.org/packages/40/d6/dbae1cd2d27b62664cefa086035530eb21203d45b12f466272441c048c9c/gevent-26.7.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4e1dc6a2712de67fd210e1f1a408601f6908b042f6420e188106f2f37f94ec71", size = 2155913, upload-time = "2026-07-22T17:02:16.35Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/42/90b662f4eb27d7727d4619d5c6be872117f1a9f187b243ec7f6fef988ce7/gevent-26.7.0-cp313-cp313-win_amd64.whl", hash = "sha256:44e5280296129c0915addaefdb37d6e9bc124a77a433b1b1c8ddf1853c53f4e7", size = 1682483, upload-time = "2026-07-22T16:26:30.492Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/84/7297c56b9fff463c4ba2f685dbb913a855df903046dc68d14e8655a29ffe/gevent-26.7.0-cp313-cp313-win_arm64.whl", hash = "sha256:9f08b1aa6729f794409ca137e25f671e0d9bbda4451200c5e28a769375365388", size = 1556053, upload-time = "2026-07-22T16:26:14.365Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/bb/ab60d496cbdc0293ebbd6c2070b34da0632bd7a2ca20163c17e18d2d2dc9/gevent-26.7.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:0e0e3bf7ae0f82dbc5c6be26b4781e86c97f1e28d516b7a9746ac8b04bcc6948", size = 2992503, upload-time = "2026-07-22T16:24:36.503Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/35/75f27c06a82a5b22600aaccbd9567d89bb4091be43e96c02981f10aff23d/gevent-26.7.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:740050b53048207b080a1e183a377c47809ad0b7b7b0cd7eab0dea1045f7e480", size = 1809173, upload-time = "2026-07-22T18:11:30.724Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/5f/a6b32b4db3fa76bd8a070f0f46f5306123bf6336e7a0ca0cd2f9b99473df/gevent-26.7.0-cp314-cp314-manylinux_2_28_ppc64le.whl", hash = "sha256:67983607eb6c7bafa362c5c43b69a27145b936c34a3d6441ed42413d62fae0a6", size = 1906630, upload-time = "2026-07-22T18:10:45.836Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/87/832495d8fcc05ff7432f038b7c4decbd5632425a2cd5da2ce73cb2d800c4/gevent-26.7.0-cp314-cp314-manylinux_2_28_s390x.whl", hash = "sha256:475848518d708e07d1987c3d94cb8ff53e2b3a69df32e39feda2779cafe400b0", size = 1855278, upload-time = "2026-07-22T18:29:11.517Z" },
+    { url = "https://files.pythonhosted.org/packages/72/8b/2f36c0fa389fa2b7ceb5a8972b0e7da7bc770f9135315cf4246c607ca5fc/gevent-26.7.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:0f8ed457dd616bfe6682569f92730f9ab45aafb1aeca5e80eb2f6b9a2ce26d11", size = 2136155, upload-time = "2026-07-22T16:48:33.865Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/98/09f2cfaa23dbce48e3271e95b0d003f93acece6b5cfd40f4cebe3850d79b/gevent-26.7.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:15373c68cf1fa14114bec2f09b16e2c65374bd5309e897e0a28740b09ce329e0", size = 1822108, upload-time = "2026-07-22T18:07:15.397Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d8/05a294165c17569f04284ad3c889684c8780544885b4cdf77b1432947d0c/gevent-26.7.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:73f3d53f2f390369e290c933b75bd87f1f2261f2f2f2175aa667c43ee3049bad", size = 2162814, upload-time = "2026-07-22T17:02:18.066Z" },
+    { url = "https://files.pythonhosted.org/packages/59/89/58a545c4eda33e106d6887a0387adc2249abc14c779e3eb88bbfdf3768d6/gevent-26.7.0-cp314-cp314-win_amd64.whl", hash = "sha256:f11b558d544ad2249029ba023cd6519ec3a0eee54a3d027e6515c1eaa322422a", size = 1706971, upload-time = "2026-07-22T16:27:02.263Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/cd/413f293e54961e5c89c54235370e3603ec0f561e7ace8357980410efbf78/gevent-26.7.0-cp314-cp314-win_arm64.whl", hash = "sha256:3871f4ca59ec2328c3ef638a0fe01a28a825443a133368dc78eb5ceadcad7609", size = 1585078, upload-time = "2026-07-22T16:30:48.145Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3a/47f29f632aaa38aa12410f57f1732fc50bfd4d4006d2e7e022ce731cabc9/gevent-26.7.0-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:3e3d6e20a94239ad353b776e72b8ce18c35dbe4e98c279aef3932651553d8404", size = 2996208, upload-time = "2026-07-22T16:23:23.859Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b3/4620f1ce81ecec9890229806c73f07dd022e40f76a552bd430391e7316c4/gevent-26.7.0-cp315-cp315-manylinux_2_28_aarch64.whl", hash = "sha256:ddbd3cc76b9bc69df651a216c2a62fc6415ad463b3ac9c6cbbbb8b7b8224af17", size = 1811545, upload-time = "2026-07-22T18:11:32.224Z" },
+    { url = "https://files.pythonhosted.org/packages/97/fd/d285212ffd5585d511299e13e61d76262def8e826e9f20c92cb85df406f2/gevent-26.7.0-cp315-cp315-manylinux_2_28_ppc64le.whl", hash = "sha256:01ceab7e608dc1b9859d9511a0a29d7ce2e7d909ab19fddc860e70a2ed5b10ce", size = 1910418, upload-time = "2026-07-22T18:10:47.709Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e0/c5d666e6065652918cfb6e6a3cf8f721d0e152c57cec217ad81792a1323b/gevent-26.7.0-cp315-cp315-manylinux_2_28_s390x.whl", hash = "sha256:2e6c917b2b8baeb6080797a6b25e35e1fd784319a05bb92b87c53546e5578eb2", size = 1857891, upload-time = "2026-07-22T18:29:13.13Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/67/e945ed458fa98b34572876bfd0d35fe4fa3f1159f43660b71d982b7cb63e/gevent-26.7.0-cp315-cp315-manylinux_2_28_x86_64.whl", hash = "sha256:df75a1748b26030f2f7f10042cc45640b22954d9d0dc6b4b6f0dbe0b6751a2d4", size = 2138121, upload-time = "2026-07-22T16:48:35.358Z" },
+    { url = "https://files.pythonhosted.org/packages/99/55/622468fa1a3c4cf51f20e14813f5cc1592fe6e44a42ccca9195a0b18c769/gevent-26.7.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:ee1b389587e5d5c1eb19d0455b5b4d7a0fb5c5287af4e226ec66d9dfd2548107", size = 1825114, upload-time = "2026-07-22T18:07:16.667Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/7a/151a2afcacf487ca25faf8b1bdd6c5b4ace2f7c1e6b4eaffe0a5e6e1df61/gevent-26.7.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:c2918641ba756f46aa01ab9dd82d6dfceec403c77c2787298746b411dcf0288e", size = 2165990, upload-time = "2026-07-22T17:02:19.817Z" },
+]
+
+[[package]]
+name = "geventhttpclient"
+version = "2.3.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "brotli" },
+    { name = "certifi" },
+    { name = "gevent" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d7/ff/cb3db11fca4223b2753ae170d1a09c9d32bfbfa3e8d4a6181324db686830/geventhttpclient-2.3.9.tar.gz", hash = "sha256:16807578dc4a175e8d97e6e39d65a10b04b5237a8c55f7a5ef39044e869baeb8", size = 84353, upload-time = "2026-03-03T08:09:03.336Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/8f/a6a787443af8defaae8bab96e056f2e0d48ffcb4eb2724d83727c465335f/geventhttpclient-2.3.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:39afb8046fe04358a85956555aa6a1d931710bac386a2fceb5c24bbd4d7c10e7", size = 70141, upload-time = "2026-03-03T08:08:08.415Z" },
+    { url = "https://files.pythonhosted.org/packages/18/c6/043e74e5ce9ce7cfd206f2ba572ded6bfe7278fb73d0d81aef0e913e9b5d/geventhttpclient-2.3.9-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:04b8feec69fd662eb46b4f81013206f5a23d179b195cbaf590d4a59f641ed0fc", size = 51776, upload-time = "2026-03-03T08:08:09.206Z" },
+    { url = "https://files.pythonhosted.org/packages/16/b2/f65c47ec71278f02c22e5d7120db855fe9c1d8034994c6c4ac8ed9b2328a/geventhttpclient-2.3.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5b542025a0c9905c847d1459e598ccbdcd21dc0dd050cc1d3813ce7e01bd350f", size = 51523, upload-time = "2026-03-03T08:08:10.119Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/12/bed280730e754bc8f1691481a58cff71eca16f439dc6629ad6843ffc9988/geventhttpclient-2.3.9-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c582a6697c82a948d3d42094da941544606a0ebee31fc0aa6731e248eeba0e9b", size = 115393, upload-time = "2026-03-03T08:08:11.239Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/eb/def9770ae049a64b698c78186ebe1281900da581401a043c206efe2957ca/geventhttpclient-2.3.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:39011c8cdd7ef8b6ab07592525f83018cd1504e8133cce5114bfcee5547b9bb5", size = 116043, upload-time = "2026-03-03T08:08:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/62/50/877f2ddd8ebebb0e060bfc34ed5d3721689e96c6debb218f5bac9fa04339/geventhttpclient-2.3.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2b91fb31523725ddc777c14b444ccedaf2043dcb9af0ede29056a9b8146c79a7", size = 122061, upload-time = "2026-03-03T08:08:13.194Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/00/6ef955f9eb1cfd7412ee20e5f7bee2459f3a9aad3330b4c193729a968ee2/geventhttpclient-2.3.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d91139a4fafd77fa985535966d7a6c2e64753f340ab1395508ee83cd8de70c38", size = 111963, upload-time = "2026-03-03T08:08:15.33Z" },
+    { url = "https://files.pythonhosted.org/packages/28/10/965899a6c557055974b2aca048d478451aa144876171fbe023959fd8f42a/geventhttpclient-2.3.9-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:0ff40ca5b848f96c6390bd8cc3a4c4598c119be08125cf1c30103201adc00940", size = 118841, upload-time = "2026-03-03T08:08:16.173Z" },
+    { url = "https://files.pythonhosted.org/packages/67/e1/e559f1ee8b0d26870cabae401bb32706390ade2f4e540695fbb6ed908bdb/geventhttpclient-2.3.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c9091db18eeb53626a81e9280d602ae9e29706ee4c1e7a05edc8b07cc632b3fc", size = 112618, upload-time = "2026-03-03T08:08:17.301Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/25/03b06f42ddb202f2a7da0f8dc3759ac4a09213bad6122e218397268832d0/geventhttpclient-2.3.9-cp312-cp312-win32.whl", hash = "sha256:4110273531fc9ac2ec197a44a90d9c7b4266b51a070747368e38213be281d5c2", size = 48750, upload-time = "2026-03-03T08:08:18.204Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/32/918822056ecc395a1f4e81e292a4549779fd255dd533b036aac80023b691/geventhttpclient-2.3.9-cp312-cp312-win_amd64.whl", hash = "sha256:98f3582a1c9effb56bc2db4f43d382cedd921217a139d5737eeaad3a1e307047", size = 49383, upload-time = "2026-03-03T08:08:19.157Z" },
+    { url = "https://files.pythonhosted.org/packages/12/0c/ec3e7926e5a24780ad0f2d422799966f2f13342c793ed9f37f0c03282f58/geventhttpclient-2.3.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9d0568d38cf74cecd37fd1ef65459f60ecd26dbc0d33bc2a1e0d8df4af24f07d", size = 70144, upload-time = "2026-03-03T08:08:19.932Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d7/d28f76482880f9233de07fb9422db26b983a901cad4670bba8bc1170f988/geventhttpclient-2.3.9-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:02e06a2f78a225b70e616b493317073f3e2fddd4e51ddfc44569d188f368bd8d", size = 51779, upload-time = "2026-03-03T08:08:20.696Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ff/930be8f0e4f84d1b229b1ec394463ea36701991d888f4856904e292a6b0b/geventhttpclient-2.3.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3eec8e442214d4086e40a3ae7fe1e1e3ecbc422157d8d2118059cf9977336d9f", size = 51516, upload-time = "2026-03-03T08:08:21.802Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/ac/952c51392527f707c1f08401d0b477cdd1840a487dffa6e9fce444d54122/geventhttpclient-2.3.9-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a18b28d2f8bc7fcfc721227733bccb647602399db6b0fd093c00ff9699717b74", size = 115412, upload-time = "2026-03-03T08:08:22.615Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/1f/1b61f8dae1efb670f7728cd727c35ff294b89af727db268f9e2d90102a97/geventhttpclient-2.3.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b16e30dbbc528453a4130210d83638444229357c073eb911421eb44e3367359", size = 116088, upload-time = "2026-03-03T08:08:23.474Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/941c05d483fe8a95672f8f39e7410292f4b617020d1d595b88da5660b132/geventhttpclient-2.3.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:06df5597edf65d4c691052fce3e37620cbc037879a3b872bc16a7b2a0941d59a", size = 122068, upload-time = "2026-03-03T08:08:24.495Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/75/84400d58934f774cef259c8b49292542313c02224c2f11b1b116d720b464/geventhttpclient-2.3.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:47a303bcac3d69569f025d0c81781c5f0c1a48c9f225e43082d1b56e4c0440f8", size = 112054, upload-time = "2026-03-03T08:08:25.663Z" },
+    { url = "https://files.pythonhosted.org/packages/12/ae/12821cad292235d4db8532f58c8bc93db4211862845bf76a4c06e6ed1416/geventhttpclient-2.3.9-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:e73b25415e83064f5a334e83495d97b138e66f67a98cfcad154068c257733973", size = 118837, upload-time = "2026-03-03T08:08:26.816Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/d3/34e80569f3563eb26f5d7bb971677de0b53b16d720f87373cc7aeee51c04/geventhttpclient-2.3.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:98ff3350d8be75586076140bde565c35ccdd72a6840b88f94037ec6595407383", size = 112643, upload-time = "2026-03-03T08:08:27.666Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/79/94ace94281e40f7258ba4e7166ae846394d2a673dbe47a0a255eb0d53ca8/geventhttpclient-2.3.9-cp313-cp313-win32.whl", hash = "sha256:af7931f55522cddedf84e837769c66d9ceb130b29182ad1e2d0201f501df899f", size = 48741, upload-time = "2026-03-03T08:08:28.507Z" },
+    { url = "https://files.pythonhosted.org/packages/89/67/15b1ba79dfbab515c0d42a01b6545adef7dad00968eaa89ec21cca030c2e/geventhttpclient-2.3.9-cp313-cp313-win_amd64.whl", hash = "sha256:14daf2f0361f19b0221f900d7e9d563c184bb7186676e61fe848495b1f2483d3", size = 49371, upload-time = "2026-03-03T08:08:29.319Z" },
+    { url = "https://files.pythonhosted.org/packages/16/9f/57d5acd0d95417a29661dfa91a8657be8026a9df17cafc6ba4f20bc2a687/geventhttpclient-2.3.9-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6c06e243de53f54942b098f81622917f4a33c16f44733c9371ea98a2cd5ce12e", size = 70423, upload-time = "2026-03-03T08:08:30.106Z" },
+    { url = "https://files.pythonhosted.org/packages/29/8b/ad6eb43b136fdb2f4954dc21073911d7703ea95fd88a3cc7512714508ce3/geventhttpclient-2.3.9-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:549155d557de403612336ca36cd93a049e67acbf9a29e6b6b971d0f4cb56786d", size = 51902, upload-time = "2026-03-03T08:08:30.892Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/64/2d2cfd9dd9ae0a6d4138b8a88f0b4524657a48a7c81ead6986a3e955deda/geventhttpclient-2.3.9-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:31b463324d5fde983657247b2faea77f8f8a40f3f7ac0c2897a2fe3afa27d610", size = 51564, upload-time = "2026-03-03T08:08:31.717Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f3/4585fabea4f45c4c21cd128d61ebbf43a78c73d520c70471734d41177b1d/geventhttpclient-2.3.9-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e1ac3a39e3c4ae36024ddf1694eb82b0cc22c4516f176477f94f98bcd56ce6cf", size = 115449, upload-time = "2026-03-03T08:08:32.75Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/e8/d7d82f527c632cbdeffa34858557db3da238f68f2fbb9bd80f2ec2c64510/geventhttpclient-2.3.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d3d24480c3a2cc88311c41a042bc12ab8e4104dad6029591ecbf5a1e933e8a44", size = 116152, upload-time = "2026-03-03T08:08:33.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/63/25ee53c3efa9ded9976e4f5ac8c6f8e8cef941bbbc847290e7f5c0254c40/geventhttpclient-2.3.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2b244adcbf5814a29d5cea8b2fc079f9242d92765191faa4dc5eccc0421840ae", size = 122145, upload-time = "2026-03-03T08:08:34.809Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/8c/15c5d71e6011f317f7decb26fd15e1e6caf780b09297af3018599311e6df/geventhttpclient-2.3.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:83dc6f037a50b7d2dc45af58a7e7978016a06320a5f823d1bd544c85d69f2058", size = 112134, upload-time = "2026-03-03T08:08:35.716Z" },
+    { url = "https://files.pythonhosted.org/packages/02/5b/fd7b17c37a9f9002a5fd8d690c97ada372393fcfb9358dd62026e089ae96/geventhttpclient-2.3.9-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:caf8779ca686497e0fab1048b026b4e48fb14fb9e88ddbfd14ca1a1a4c4bfa89", size = 118879, upload-time = "2026-03-03T08:08:36.953Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/b5/c1559f43ef56100d64bf1b227844bf229101fdb58b556e2336b4307bda0d/geventhttpclient-2.3.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cd4efebba798c7f585aa1ceb9aba9524b12ebc51b26ad62de5234b8264d9b94d", size = 112593, upload-time = "2026-03-03T08:08:37.842Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/22/a61a9cb76feede0d4429154d391c275debde78b6602f52c95aeed6dce1ff/geventhttpclient-2.3.9-cp314-cp314-win32.whl", hash = "sha256:7b60c0b650c77d2644374149c38dfee34510e88e569ca85f38fe15f40ecaea1c", size = 49390, upload-time = "2026-03-03T08:08:38.996Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/05/b8d71edd82c9b07b9be0c3e5d6faf94583c6a098e2e9e5ee2b14a6312c5e/geventhttpclient-2.3.9-cp314-cp314-win_amd64.whl", hash = "sha256:c4d5e1b9b1ac9baab42a1789bbfae7e97e40e8e83e09a32b353c6eb985f36071", size = 49881, upload-time = "2026-03-03T08:08:40.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/5f/2f7f8f63968d26d7233fb9b9e5b1a5015989b90f95e997e9dc98283b0a86/geventhttpclient-2.3.9-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ae44cec808193bb70b634fabdfdd89f0850744ace5668dc98063d633cf50c417", size = 70812, upload-time = "2026-03-03T08:08:41.073Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/89/7887f802adee5990c10dd9c44b20a3205e046773061266ce5cffb99e30b9/geventhttpclient-2.3.9-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:53977ca41809eaef73cf38af170484baa53bde5f16bafbca7b77b670c343f48f", size = 52087, upload-time = "2026-03-03T08:08:42.063Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/07/23cc505111abb65cb5a68e5cd123b1ffc1ad7893a1bc46945b9ed3d03245/geventhttpclient-2.3.9-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0f66a33c95e4d6d343fc6ace458b13c613684bf7cfd6832b61cc9c42eaf394f3", size = 51772, upload-time = "2026-03-03T08:08:42.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/97/461fd5c73858b2daaaba2ecefd2ff64aa8f2242c48c939e75caba9ec3cb2/geventhttpclient-2.3.9-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:cfe23d419aa676492677374bdd37e364c921895d1090a180173be5d5f87f82b9", size = 118329, upload-time = "2026-03-03T08:08:44.07Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/08/0ede3d90ab92a105f24b758b0bfb2d5e7f34c017d22d76d87524e75e93cc/geventhttpclient-2.3.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8e3b279da39ad3eee69a5df9e1b602f87bcd2cec7eb258d3cc801e2170682383", size = 119974, upload-time = "2026-03-03T08:08:45.231Z" },
+    { url = "https://files.pythonhosted.org/packages/98/8f/0ef02946bbbbd91ba4c3da99657d90e250c00409710ed377e4e4540b90c3/geventhttpclient-2.3.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:38535589a564822c64d1b4c2a5d6dcc27159d0d7d76500f2c8c8d21d9dd54880", size = 125764, upload-time = "2026-03-03T08:08:46.446Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e1/d8f385fd6a3538cf1fd57a3fd47b133fba2e32c6be86e75805117d96ff1f/geventhttpclient-2.3.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a6436cd77885a8ef7cdc6d225cddd732560a17e92969c74e997836cf3135baa0", size = 115599, upload-time = "2026-03-03T08:08:47.393Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/55/ec651647ee2f7fdfee8d7a75ba682064e0e5012696f9aa83c0392d54fdeb/geventhttpclient-2.3.9-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:5000c9fb0553818c4e4c1de248ee4e9a56de0a245a30ef76b687542a935f4645", size = 122254, upload-time = "2026-03-03T08:08:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/77/7d/20606d1a4ae085eb3935e4d3625e7208911d0f1a0006c9fd962d88254d92/geventhttpclient-2.3.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:52516d5c153fcef0d3d2447e533244dc6360e8c2a190b958861137db6f227605", size = 115383, upload-time = "2026-03-03T08:08:49.454Z" },
+    { url = "https://files.pythonhosted.org/packages/85/16/d20ac6ac73d63fe326ffe357a8e91c4f43b9e790faeeb9b15774eecf2550/geventhttpclient-2.3.9-cp314-cp314t-win32.whl", hash = "sha256:14eaa836bde26a70952e95ca462018f3a47c1c92642327315aa6502e54141016", size = 49749, upload-time = "2026-03-03T08:08:50.339Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f6/95d1ed1ace7902d8e1ce698db31931cb87d4abe621ec2df24e69daf49ae9/geventhttpclient-2.3.9-cp314-cp314t-win_amd64.whl", hash = "sha256:b9bbcbc7d5d875e5180f2b1f1c6fa8e092ef80d9debfb6ba22a4ec28f0565395", size = 50300, upload-time = "2026-03-03T08:08:51.482Z" },
+]
+
+[[package]]
 name = "ghp-import"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -480,6 +694,73 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/d8/7cc97c142388aef03f622e001c572c4f84e9252a439549d483f555771970/greenlet-3.5.5.tar.gz", hash = "sha256:adb4bae02e91a8e863e48b177e4014bdcac8a6b5e047ea1df687a61534b85e6c", size = 207585, upload-time = "2026-08-10T15:09:36.136Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/7e/9ecd0285e3153532ae07aeb88063c43c72b4221cf0d4d123b02f3682e3ff/greenlet-3.5.5-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:49520f0c95a48b42cf55414b8e8479beb274ea70431afc33e3f79903c71f4380", size = 295809, upload-time = "2026-08-10T13:25:34.023Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/60e4bbcc89252037b18087f2ec16405d5b2d5be42dde191bbf3667e96102/greenlet-3.5.5-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55272212cbc5f43d1d723725ab931f1939969b7e9523882ca58b55061769d053", size = 611910, upload-time = "2026-08-10T14:14:35.18Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/17/cd5134be659cd4a443e7a61ae670dabec165a814c51162916d637b6dd38e/greenlet-3.5.5-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:655bca754a2ef4efcb0eb48a94d3f4593536d0f3d48f8ed44343c01d16a92f95", size = 624198, upload-time = "2026-08-10T14:27:25.229Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/30/87c212b5c684d0e72974f1063b7a9687631e8985902c06e1016542c874e7/greenlet-3.5.5-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6ca5d6ae0739e5764f2cfcfaa562ac5a990cbdaedca93251c5e3cf07c362371f", size = 629504, upload-time = "2026-08-10T14:30:07.967Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ac/5c5b959999b6f09c3026b5dfe171575bc3121c5236ce74f495096f25b203/greenlet-3.5.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:147b25a42e5ca5be3d42356e8f608b37af715a1c196e9bf9d1627f3341adfe1d", size = 621439, upload-time = "2026-08-10T13:40:49.391Z" },
+    { url = "https://files.pythonhosted.org/packages/63/2c/eb487fafc9f50ffff2b1e0b697f70fb34bf150821c08ab225aacf5583a7e/greenlet-3.5.5-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:1b5ed9162c0c098e0bbc2cf88a94f433c1b8926f831745252e099e5d83e17759", size = 432462, upload-time = "2026-08-10T14:30:02.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/8b/6acf112ed8aee499f25b4d6949820fb02ac950ff9c1f3d793bd5be0599f2/greenlet-3.5.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:27493374cff1d1b7919dc8126547f2aea582737e3046147b434b1e12de56389b", size = 1581342, upload-time = "2026-08-10T14:15:05.653Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/d7/734e5f198888876b42d7616ff6644c075baf6b8a2412deadd6b0e1b8b20c/greenlet-3.5.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:12e2ee66c2aba86133f10fd99d6a8856c6d351ffb7be0e4d52ef2cc5fbb705b2", size = 1645744, upload-time = "2026-08-10T13:40:30.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/30/1f42b88dc587b5899ee50616ad56ee40cafaf225df4fb829f10183c62a5c/greenlet-3.5.5-cp312-cp312-win_amd64.whl", hash = "sha256:49ddacd36af37735fab103846f4ee4d18a492dde72730d1699c0c8ebe30d9f18", size = 324171, upload-time = "2026-08-10T13:28:44.472Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e5/4dee4d8d2e603fe5fdd7b444e63219f7b9bd852c60c6214511c7157cbe88/greenlet-3.5.5-cp312-cp312-win_arm64.whl", hash = "sha256:5f1b1ff4828cdc1aba4266aff814085d04a1d07959287219af021b838b265d52", size = 308362, upload-time = "2026-08-10T13:26:46.839Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/3d/8cef5f724ec0d4add2af8961d504535ec60c3cca9e464f6d03bdba29d85b/greenlet-3.5.5-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:b79fd2a5bc099b5e744f34c4c9a58954a5f4cb7529fb4b6e8446057d61b6edaa", size = 294730, upload-time = "2026-08-10T13:27:51.206Z" },
+    { url = "https://files.pythonhosted.org/packages/88/4b/8e7aa3f514273aecff30a16ab1bac09ff54cfc7e6860fdd8058c37ff2499/greenlet-3.5.5-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:634cf15a233a949136879dd388e25d3296e16f3f1e217d2456797b8579ebc6ed", size = 614536, upload-time = "2026-08-10T14:14:36.589Z" },
+    { url = "https://files.pythonhosted.org/packages/85/48/4e95e9dd5a8a397dc6a6345dd7f1935113d0fca4f85e89d3976da9cd988d/greenlet-3.5.5-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:499adea519f748407fc6806d20eedabac2884fd73b9f38d81236e190ba20dfef", size = 626924, upload-time = "2026-08-10T14:27:27.048Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/84/eaa476d6bf3816828d0d70e80dcc36bf30a058233bd889e707e693f6e860/greenlet-3.5.5-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f7278591501941bb2456af102bb9cd59aab48c6cfd6e2dd68fa1290bb0c49a42", size = 632726, upload-time = "2026-08-10T14:30:09.874Z" },
+    { url = "https://files.pythonhosted.org/packages/89/5d/398a1c71fa7a277deeb376c999979de6786f08fc2d5747a0b9d6e11738dd/greenlet-3.5.5-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2eabb980975cba5b93a95f6f69287d05fc05ac955bfd6a320a7c083eeb52c0b0", size = 623906, upload-time = "2026-08-10T13:40:50.501Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/f2/0cc2849ede68579291e9c59b3ab6ec1958f98681cca5b14d8fc75bf674a4/greenlet-3.5.5-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:4dfc7c4470354e7b09184d1a3a985761053a2fd694ddb5b5c80242afc2c8c90b", size = 434966, upload-time = "2026-08-10T14:30:03.729Z" },
+    { url = "https://files.pythonhosted.org/packages/04/1b/745450fc5ea9e0cb17d840d248f284db3363de736d362c7d2d883e3eadba/greenlet-3.5.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:03115c2e0a371999bf8ae616aa8d653f96641d4705c457aebaa187276e9f7537", size = 1581430, upload-time = "2026-08-10T14:15:06.853Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/29/d51b296e3191bb15d3d81ec375af1909e4466c0f395d744ed475801798a9/greenlet-3.5.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4441153ffba21b90d3ca89fe3d31f5c093ae6c0bf0cfdfc98f54cde22f95b62e", size = 1645684, upload-time = "2026-08-10T13:40:32.133Z" },
+    { url = "https://files.pythonhosted.org/packages/12/63/369f1a1625e64e9e31df3963c6044056e3fdfa3fa3fdba3c54ffefa6e987/greenlet-3.5.5-cp313-cp313-win_amd64.whl", hash = "sha256:95c5b1f4b3a193f8a0c2de4bfdcb48d119f7f1063941f1de1f2168051b3e52dd", size = 324075, upload-time = "2026-08-10T13:26:58.974Z" },
+    { url = "https://files.pythonhosted.org/packages/45/78/649cb5c09d4d81f6dd1444e75474a7206784743283a21d24171562ac4899/greenlet-3.5.5-cp313-cp313-win_arm64.whl", hash = "sha256:1af90aa4bc129883b340cdd6957a3bc74f60528a4993bbd1f53aaebe1d9981cc", size = 308260, upload-time = "2026-08-10T13:27:50.795Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/8c/080e881fa2be95ff1ddbd6994b2bab3b1a78df3b3fcab39306011764fcc7/greenlet-3.5.5-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d4a389a852e392a6366058651a20fa5ba40d979865aa81bea2ccbdc44805070d", size = 295309, upload-time = "2026-08-10T13:26:03.032Z" },
+    { url = "https://files.pythonhosted.org/packages/25/cc/0ac614e6586c0e42d4cc281a5819150f4f43685744a4c5ff77139286409d/greenlet-3.5.5-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:70b157cd319873e8b544ddc2de158f55bbd0a9b0218c8ce9332039801518e328", size = 661185, upload-time = "2026-08-10T14:14:37.867Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b9/6808725354be8ad305dfe5172377664fc9642d4fc043be246b3314cf4482/greenlet-3.5.5-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8bdfd1424abcf26832961e766570cae79efdb9599d709088c9cb6ef82b194926", size = 673419, upload-time = "2026-08-10T14:27:28.652Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/52/f005d579acde46c3d1cc3cab1c9f3d5708c8a3006a4120e8cf5da801afe9/greenlet-3.5.5-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d98ef6f92e67c6dbf299dbfd8facc1b0d2d9cedf91e325e73b3d0373fe4309d8", size = 677863, upload-time = "2026-08-10T14:30:11.663Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2e/40c509967da7f254680826a2fa0dd22138ec79946c70b97542d74cde8b43/greenlet-3.5.5-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:182de51c6b572a705f2fafaab2e783bcf7d2760940229dfe73086cbae037af3e", size = 670822, upload-time = "2026-08-10T13:40:51.833Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/8a/a75f8a2bdcef3c358a3147cdc9db3aa83755f0a038f766ab0bedb66f512c/greenlet-3.5.5-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:159df1942d88e8f784cbb38d6f18bdb365cd11319cfbb3e89623de2b97892d53", size = 480554, upload-time = "2026-08-10T14:30:05.171Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/22/c3c2eee4a8fe191d6d1d183086c56133d646024e3d70bfd414829f64560b/greenlet-3.5.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8fec3f165dfe332e490c3247c0f6c23b0bfc45f06496ad7f00ddb00e3d35e4dc", size = 1628469, upload-time = "2026-08-10T14:15:08.11Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/87/25babd09b94cb1f03e71db815fde463f0262e40cfbd953d58a8d77311351/greenlet-3.5.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c6ce25fee6cabc8bf22cb8b52e642cbb821be5b9aec8094d07ff03378141b8e9", size = 1691952, upload-time = "2026-08-10T13:40:33.502Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/3d/5cc9701117ea4dc0eb7bf1f4f9b7888a6e2e5277ddfae095805ace50f2b6/greenlet-3.5.5-cp314-cp314-win_amd64.whl", hash = "sha256:7dffc5c859fe6059974df1e37d7923d654a83e2ae18fdd616994270e001115e1", size = 327458, upload-time = "2026-08-10T13:27:02.868Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6b/594fa2de7fae7629168a404a4305d7d7e31a5742c50a801b1839543cb93d/greenlet-3.5.5-cp314-cp314-win_arm64.whl", hash = "sha256:5e2afcfc4d4305dd715809b03da5cbe437c8984f61d8917751eb5fe4aefa3e07", size = 311146, upload-time = "2026-08-10T13:27:25.046Z" },
+    { url = "https://files.pythonhosted.org/packages/24/e0/50cd600b469e5734c72709b6b1838b6bc63f307b573c772c3132d6ecfe92/greenlet-3.5.5-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:0e5a7de979d764aea1f5b6e95cf92b5b37741b9823702041f34b126e7f690277", size = 305471, upload-time = "2026-08-10T13:26:20.568Z" },
+    { url = "https://files.pythonhosted.org/packages/75/a3/77acd66dfc6387b5219b2080806c0cabb73c10eb1bb44b413c40a62015ba/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fef01bd457f11fc158b130ca0027a3c365693280e8e231b65bdaf57999f39f5b", size = 672470, upload-time = "2026-08-10T14:14:39.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/71/0d178142dca3ec19f46fb2212ae73d30ad53b9d548dc64804086033a7089/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5173a72310725a74afc82c164f0e52cb8ad0de62f2bb623f24f6c0cc07d80272", size = 679973, upload-time = "2026-08-10T14:27:30.072Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ac/0d7887aa4bbfc9eba075cc428244dfc96f623478454d5ec81180d0d6bd5a/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5e9ec2e7c98e895fcea0c5cc57b2606cf86ece6d0a56578f3eb225e2af4f0387", size = 681587, upload-time = "2026-08-10T14:30:13.519Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/31/46eb8567302eaf787abf88d09df014e14ae3baf460af1b8b0efdbd3efcd5/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44f08341873200ba8a60a8bc14ace3d91f1754f7fa7bc66157714a8cd420a476", size = 676634, upload-time = "2026-08-10T13:40:53.004Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/18/8d58ba1c429b0383e3219a3d0e0bba241d0444d8ed05b73349953c7d7c7b/greenlet-3.5.5-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:102817506f6090b5176c746a82603341a549b40e5c3d5b72a4c672228a918c41", size = 510175, upload-time = "2026-08-10T14:30:07.047Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/e9/b88bbf5b29970cb84172dc2c32aa3e5e579ceb94c808e81c826454138850/greenlet-3.5.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d246c0db9a2513cd45f019ba178ea4d4d4705bd210ee465e2c15d76a1ab13874", size = 1637320, upload-time = "2026-08-10T14:15:09.317Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/8c/7631ed29cc6f0392f11830076e172ce4885e70b0bc2c1bce1731176d4b4e/greenlet-3.5.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:72507285b5caa1d17904a3f7c322ca780823a54170a0e04ec3f37bcc60d4db71", size = 1697412, upload-time = "2026-08-10T13:40:34.924Z" },
+    { url = "https://files.pythonhosted.org/packages/da/0f/f7dd935f9c4cb1be49098770587f54d8a78518e55c89bce86c4fb4109057/greenlet-3.5.5-cp314-cp314t-win_amd64.whl", hash = "sha256:7805655781fb8f28a55d05fe57ed61f5f10f1892fb587673e3bb5264f28041f0", size = 331514, upload-time = "2026-08-10T13:29:20.611Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e5/681b01f8fbc1b55232822f99e8f8afeb78a55a7c76a7bf9dbdc7ccb03a6d/greenlet-3.5.5-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:c0db80fcd5b8aece93f66c64f78a786bbb6b96c5fe63ef5a5a4581ecf8bab206", size = 295975, upload-time = "2026-08-10T13:28:45.985Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f2/69b488cd9e7267bf4b0fe8cdebf25d8d6df680d21bdf41150d23e23d6652/greenlet-3.5.5-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b241c32f912ada659808d68e308c568baf577eebf757d15471472de0c18cfad", size = 666823, upload-time = "2026-08-10T14:14:40.222Z" },
+    { url = "https://files.pythonhosted.org/packages/84/d4/d5bc2fdebbdda0c94555925ba79948b8395d75a7f6a36cc85dce5bab9f11/greenlet-3.5.5-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ef6a08349401d8eaf3cb12688ac8557de95788556b8631ef17555a4a173022c0", size = 677613, upload-time = "2026-08-10T14:27:31.543Z" },
+    { url = "https://files.pythonhosted.org/packages/65/53/4e13642efc4d7ad6554ecb2242a5be42666b2e1a067323e88dfc0124a04b/greenlet-3.5.5-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:37faa97daccb6d9f4c2141ce3118d023c3c5506864a7d8bdf726f665018c1f76", size = 681436, upload-time = "2026-08-10T14:30:14.839Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/93/542d8a3a90f3b35c6ad8bf7e56a03010287f2cafa289a5b7985b5207db39/greenlet-3.5.5-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f2e3d061b8e13aec2f0441689b3c71b244a20e5d274a52cb0f7e31bd1d139552", size = 675930, upload-time = "2026-08-10T13:40:54.205Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/32/188447c9a468d6977d2989397226b0c6b65ab6f4cf943f931643328512fc/greenlet-3.5.5-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:b18007dc2473a7942fd157366b55f01da6fed7ce85318591005b419e0a439474", size = 487404, upload-time = "2026-08-10T14:30:08.903Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b5/89c9f2e8460d71101037d47a1feed11928615a5edd42370be290e0657eeb/greenlet-3.5.5-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:9ab5f5b93655e77fe0d6c2dfd22b5eac751bb1f876d8ec21761b7c1fb9266007", size = 1633878, upload-time = "2026-08-10T14:15:10.693Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/60/297de93f3b02ac78a5e04d32bb8bbe3080f4a73d8ed95016561463b70618/greenlet-3.5.5-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:f0e5a21bd4452a88cf032fc43c4a5b307ab1380eacb63b5988f9c0317885e773", size = 1696597, upload-time = "2026-08-10T13:40:36.252Z" },
+    { url = "https://files.pythonhosted.org/packages/18/25/54c6eaff4f337fb670215e89eb2d00d9499487b658e709d4b477be4a342e/greenlet-3.5.5-cp315-cp315-win_amd64.whl", hash = "sha256:469dbb0a78625642f4a626cfd0c6e8bccc0385b5e49189b6308bbe849ec88a8e", size = 327700, upload-time = "2026-08-10T13:28:06.752Z" },
+    { url = "https://files.pythonhosted.org/packages/67/67/857e88a36301caa0e029870132c2478bd55d896630321432afab03a3115f/greenlet-3.5.5-cp315-cp315-win_arm64.whl", hash = "sha256:2d57406c3efd32d7a81e17a674314e8bd00792cdab49ea3228a49aa1bfb2e769", size = 311750, upload-time = "2026-08-10T13:34:08.815Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e2/3144c0a116067ac1e30457b0139a94d60d1d36a86e015de68e9ac87cb3bc/greenlet-3.5.5-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:68184dfcf50ccaa8e864770fe0633a7e27250ea9329f8192ef47ee9ecfd78e1c", size = 306387, upload-time = "2026-08-10T13:27:00.897Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/a1/cb4223a7e9b9f43b8807e8eb212358bfe2dfaa174a9ea2889eb1714dcba2/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ec0dc0e59dc9c61af5c47348365ccbbd7addfafe0a93b00336ff3da2907bdc6", size = 676472, upload-time = "2026-08-10T14:14:41.417Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/cd/a154b4498e5d8f12ada291cfb3b8d596eadde2177f5bf09a9be699d2a446/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e604f58e35833fc46ef20302bcb314dddbfd3fcf33a4f936216d51dd678d63ae", size = 684238, upload-time = "2026-08-10T14:27:32.946Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/f4/e450a68a152f819491d8c7df6a8254e761d87e6a78759268961f8c5bd4dd/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2888a3a38bc5ee5bb6c438372197152e815837e4fab7ed7a1f86ef18ffd58ad1", size = 686022, upload-time = "2026-08-10T14:30:15.96Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/bb/b0031d260c2968a3c87deebc51d80c64e499377f993aafe06ee3b7488cc2/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:40239b5384f96da3963585cc6d7eaa9b56f8ae67e8d92cc82dd9e202fc847de3", size = 681246, upload-time = "2026-08-10T13:40:55.402Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/17e63d6bf3b9c9b9dbea981b7f643a71f79603bdfb4f1c3a9cf353e22aed/greenlet-3.5.5-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:1e8d9391fe77f15649589a907cef972dbbd6352ef7ff7dc0492f658c0c26495f", size = 516951, upload-time = "2026-08-10T14:30:10.907Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/07/da554b71ab88e649da146e1065d86a48a5c5d92e50ab74ef41b504aa7f56/greenlet-3.5.5-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:a1eaccf5c3a1d3e46dead602c72e6836731e8e245c9de6a27764567b6b62d4c0", size = 1642735, upload-time = "2026-08-10T14:15:11.92Z" },
+    { url = "https://files.pythonhosted.org/packages/78/76/26a3782a051677668af9d92beaa47cd87ba9dd5072f762961144a03dd4c6/greenlet-3.5.5-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:19e4e026fe20691f333b8eb1a3bc9625eceba8c3f9d62ec5a6f8581afbc6b5a5", size = 1700925, upload-time = "2026-08-10T13:40:37.656Z" },
+    { url = "https://files.pythonhosted.org/packages/28/d9/fe7baf4190c2ae71f267efb9de21b3172bb35bc0ed1ef53dd6027d658e33/greenlet-3.5.5-cp315-cp315t-win_amd64.whl", hash = "sha256:712aee154f648bde84634654bb38bb78c69ac640c37a45c9effed800735049d8", size = 331829, upload-time = "2026-08-10T13:26:48.851Z" },
+    { url = "https://files.pythonhosted.org/packages/df/af/419a4e383bd600858a9b67e9b280a60fdc383ee3f2fe5b6c0c1ef04e74d1/greenlet-3.5.5-cp315-cp315t-win_arm64.whl", hash = "sha256:7f049911ee81a16a03c33d5450d8d5867d27f596ca5fb201b86f4524e874468b", size = 315093, upload-time = "2026-08-10T13:29:34.949Z" },
 ]
 
 [[package]]
@@ -643,6 +924,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/2b/6752b28d88c3a19b3bc0b9e1838443b6760d5c862b4f4b37955402659e24/libcst-1.9.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a2faaf92500d0226358125630f5aab4758e8aad3f2d70a10892ec3c700781a54", size = 2368043, upload-time = "2026-07-29T19:25:28.344Z" },
     { url = "https://files.pythonhosted.org/packages/e2/94/775825b2637f8ab05694b6a4b3802ae6783b4e799f9b58d2400c7e2d4369/libcst-1.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0c7b548512db25af9c2997a95fa731bd6b6928ecbad6c0915d7482d8bb42d34f", size = 2176432, upload-time = "2026-07-29T19:25:29.921Z" },
     { url = "https://files.pythonhosted.org/packages/fb/3d/88ad67427c6fd9db929e087912b0a540e5140e5cb77e7ca4170edaac8531/libcst-1.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:497d5329345f1f5df84e41b0bbd00204b64a2fd30dfe3cfaeaebca633a31e877", size = 2052931, upload-time = "2026-07-29T19:25:31.397Z" },
+    { url = "https://files.pythonhosted.org/packages/39/e4/ad790b043a38b10cea13166c8dd716654ad8b227c20f12eebf6326191cd9/libcst-1.9.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:a5068bf6114f6f4d79af7a6c80a28d1deb50441150ea1db13b5458ab34bec159", size = 2043987, upload-time = "2026-08-11T05:54:02.122Z" },
+    { url = "https://files.pythonhosted.org/packages/15/6b/d3cd8275cc54ffc9817ade91442b3e6e9edd1a4518bd4e6dda13e3152dbe/libcst-1.9.0-cp315-cp315-manylinux_2_28_aarch64.whl", hash = "sha256:7acfd18adcdd32dcf41ce676cf121002afcbe9ad2c72dc0c18d78465beedc228", size = 2204003, upload-time = "2026-08-11T05:54:04.031Z" },
+    { url = "https://files.pythonhosted.org/packages/da/62/87eddccb11d5d221d50ac4fff4b6e9b8d48c547028d01f7d0fbc5c8a1d75/libcst-1.9.0-cp315-cp315-manylinux_2_28_x86_64.whl", hash = "sha256:86361e2b426bd1b403e52375703c8b764e226e571adcb30442510710681edbf0", size = 2256053, upload-time = "2026-08-11T05:54:06.228Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/a44126aeb9fca8b4e342e0cc803ea00ca8f6cd5712619a7897b3eba13797/libcst-1.9.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:8c14abe844bec8b021111b3985474e49f5af799c020e8e40dedcac87c97a40c5", size = 2270576, upload-time = "2026-08-11T05:54:08.01Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/51/3af3dd44b117d66486e0ed61e43a16b7fc8cc5c372e1dd4ca0e70b888d46/libcst-1.9.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:8930971d2299b7006bb5d10c10038f44efb6da89d5bca2823595e31a9cdb96af", size = 2378573, upload-time = "2026-08-11T05:54:10.093Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/e8/e545087d298dbf6494e84a8092f0f5dbd62eedacabd4ecd6b364367b4804/libcst-1.9.0-cp315-cp315-win_amd64.whl", hash = "sha256:5891ce9cff815077614f509e3a23888c5ddb8081d6188e8ba1172c0ccc369022", size = 2177937, upload-time = "2026-08-11T05:54:12.168Z" },
+    { url = "https://files.pythonhosted.org/packages/84/17/93a00a8e03494a84db102dd0e3d35b8876b1084ca2c194b331a168d86eb1/libcst-1.9.0-cp315-cp315-win_arm64.whl", hash = "sha256:1260b5d070a3324447a53a00387225a55472a62077ce01922d30a2a78cc4b138", size = 2058633, upload-time = "2026-08-11T05:54:13.817Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/00/c3751b12eb81822ea0b6131d374a98bc6c024c4b9ec5f6ea8f53dc23e967/libcst-1.9.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:02ee2dbdb5c218116f16a021350fc267a14be205b50d81c33f5d73857ab6fbf7", size = 2036178, upload-time = "2026-08-11T05:54:15.545Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/12/48ff486eb5adc593f4818569e8896b74b672414ab4722a74b17e4c4cf31e/libcst-1.9.0-cp315-cp315t-manylinux_2_28_aarch64.whl", hash = "sha256:3e5b684191a0462b2d40a73261ea7f4da6a49e7a030b7e0fceca46bebb51dfe5", size = 2195496, upload-time = "2026-08-11T05:54:17.625Z" },
+    { url = "https://files.pythonhosted.org/packages/51/18/b13a4669864d41a4801fed7b86ede1049dc9a1e1dde250a7ee1f9c3b1285/libcst-1.9.0-cp315-cp315t-manylinux_2_28_x86_64.whl", hash = "sha256:2b150c4f298fe54eb0fe73abf71f57db74d070796140a8c206c9615b6861f01e", size = 2245769, upload-time = "2026-08-11T05:54:19.343Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c7/cf2d46744825e84afbd7228fdeeea8d23cf6c4b2074253c27efb7705c653/libcst-1.9.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:50b913e37187f00a6fb88962009364e1cf1b1284aa1762304f34b52b972f2218", size = 2260576, upload-time = "2026-08-11T05:54:21.444Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/4d/5433d3d62250b2e4325938db101766bcab2a006819684713bcccb6259a88/libcst-1.9.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:9f92c75283030fd58fb7d6e560168a00381e0e3368ec8a026a3ec8a828a05f93", size = 2368709, upload-time = "2026-08-11T05:54:23.276Z" },
+    { url = "https://files.pythonhosted.org/packages/87/39/9f0e1690727623f99489895db0e42048a3e1e8cea0627517c593e437fd83/libcst-1.9.0-cp315-cp315t-win_amd64.whl", hash = "sha256:4adf97bb1aff8039b0bd4991e2f838be6e4fad552821b26b71a5d1a653c2582f", size = 2177866, upload-time = "2026-08-11T05:54:25.144Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/79/9dc7811883e67ea771057e8937bc536eb3e77f3635fc5a93cd85b6fe1ea8/libcst-1.9.0-cp315-cp315t-win_arm64.whl", hash = "sha256:8f0dd08a5773d7051e105250b2a2c73d8065ea9b2d68e7e1bdc5244660e75f93", size = 2052908, upload-time = "2026-08-11T05:54:26.835Z" },
 ]
 
 [[package]]
@@ -655,6 +950,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
+]
+
+[[package]]
+name = "locust"
+version = "2.46.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "configargparse" },
+    { name = "flask" },
+    { name = "flask-cors" },
+    { name = "flask-login" },
+    { name = "gevent" },
+    { name = "geventhttpclient" },
+    { name = "msgpack" },
+    { name = "psutil" },
+    { name = "pytest" },
+    { name = "python-engineio" },
+    { name = "python-socketio", extra = ["client"] },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "pyzmq" },
+    { name = "requests" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/f7/dfdbc33ad48daaeb3046688df0a461749db730282cc6b3558b7495ac36d6/locust-2.46.3.tar.gz", hash = "sha256:b1d313db9df0a4036d4d905b1dc8585d020a7299239a1bb2e2885b71389253c0", size = 1478452, upload-time = "2026-08-01T10:21:10.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/2e/44a77d6c439d4482b86b422b1703f608593009e8e74a05715fcfd4cd03ac/locust-2.46.3-py3-none-any.whl", hash = "sha256:a51e03cc27280eb2770f5aefacc3eb4c290eafe0feb19c64fa3c99e31fa21265", size = 1498002, upload-time = "2026-08-01T10:21:08.744Z" },
 ]
 
 [[package]]
@@ -896,6 +1217,58 @@ wheels = [
 ]
 
 [[package]]
+name = "msgpack"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/f9/c0a1c127f9049db9155afc316952ea571720dd01833ff5e4d7e8e6352dbb/msgpack-1.2.1.tar.gz", hash = "sha256:04c721c2c7448767e9e3f2520a475663d8ee0f09c31890f6d2bd70fd636a9647", size = 183960, upload-time = "2026-06-18T16:13:52.594Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/dd/9e8cbd8f5582ca4b590336f2b91ee5662f6a6ca562b565abaf696a0f81ff/msgpack-1.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2ef59c659f289eddf8aa6623823f19fa2f40a4029266889eac7a2505dd210c35", size = 83531, upload-time = "2026-06-18T16:12:58.249Z" },
+    { url = "https://files.pythonhosted.org/packages/50/2e/ebdb85a8da151397a2790363676b7ed7c125924fe618e4c6d8befb0cc62c/msgpack-1.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3567748a5107cb40cdf66a275430c2f87c07777698f4bfd25c35f44d533258c", size = 82657, upload-time = "2026-06-18T16:12:59.396Z" },
+    { url = "https://files.pythonhosted.org/packages/26/aa/753ad8b007b464e1d8aa0c8e650b9c5f4f725e658fc5ac8a7635c55b7f6e/msgpack-1.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60926b75d00c8e816ef98f3034f484a8bc64242d66839cef4cf7e503142316a0", size = 410634, upload-time = "2026-06-18T16:13:00.383Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/fd/6adabd4f6d5e686f97dd02ce7fce3fe4cf672cbac36b8f67ff4040e8ad8b/msgpack-1.2.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:020e881a764b20d8d7ca1a54fc01b8175519d108e3c3f194fddc200bda95951a", size = 419989, upload-time = "2026-06-18T16:13:01.776Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cc/85039b7b0eb168aaad7383a23c97e291a11f08351cb45a606ce865e4e3f1/msgpack-1.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4202c74688ca06591f78cb18988228bd4cca2cc75d57b60008372892d2f1e6e6", size = 377544, upload-time = "2026-06-18T16:13:03.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/bf/35963899493b32030c85fc513b723ae66144ac70c11ebc52e889e16e3d99/msgpack-1.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8b267ce94efb76fbd1b3373511420074ee3187f0f7811bf394531de13294735a", size = 400842, upload-time = "2026-06-18T16:13:05.012Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/df/8e2ac970c8f99264cd9997d1c73df5466bc19da3301d7dc5500862a9b089/msgpack-1.2.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:e4f1d0f8f98ade9634e01fb704a408f9336c0a8f1117b369f5db83dc7551d8b1", size = 374108, upload-time = "2026-06-18T16:13:06.232Z" },
+    { url = "https://files.pythonhosted.org/packages/17/dd/fa8bd265110dfa51c20cb529f9e6d240a16fafe7e645004c6af2d01353ba/msgpack-1.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f02cf17a6ca1abe29b5f980644f7551f94d71f2011509b26d8625ce038f0df64", size = 414939, upload-time = "2026-06-18T16:13:07.478Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b9/8377a5ad8953fc0437c70cc98d9ae29f27fe5ac5109fbec0812085865735/msgpack-1.2.1-cp312-cp312-win32.whl", hash = "sha256:0c0d9802354507bcba62af19c17918e3eb437cc25e6f50657d511b5856a77aac", size = 64504, upload-time = "2026-06-18T16:13:08.822Z" },
+    { url = "https://files.pythonhosted.org/packages/57/7f/ce1e377df7e62461fefd9eb23bfb93a4a523f40a517b377b8f844d836828/msgpack-1.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:5c24aa15d5963051e1a5c62b12c50cd705992502b5ec1f3bece6046f33c9fc24", size = 71421, upload-time = "2026-06-18T16:13:09.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/32/ebfe84c9929f08f188d56c7a2fd913406a9ddad76a634697c1c43b8112e6/msgpack-1.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:4227224aaec8f7fbcbfbd4272319347b2bb4030366502600f8c45588c5187b07", size = 64775, upload-time = "2026-06-18T16:13:11.056Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ac/dcddcab6f6c20ecb387ca5e980371cdb3f87ff69aeca388be97eebc4c074/msgpack-1.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0a70e3cf2804a300d921bb0940426e35f4e489a23adfb77a808892241db0a064", size = 83151, upload-time = "2026-06-18T16:13:12.173Z" },
+    { url = "https://files.pythonhosted.org/packages/64/71/fbcfa83a1d6a9c6091942d1cfd070962244664b87427a9a49a6897b1b219/msgpack-1.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:491cc39455ca765fad51fb451bf2915eb2cf41192ab5801ce8d67c1d614fe056", size = 82351, upload-time = "2026-06-18T16:13:13.194Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/10/ddf7b06db879e8792d13934ddda09ff20bd2a583fd84c9b59aae9b0e650b/msgpack-1.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f310233ef7fb9c14e201c93639fe5f5260b005f56f0b29048e999c30935596cc", size = 407518, upload-time = "2026-06-18T16:13:14.233Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d3/36a46a8ed992b781acbc05928bd5bee3c810cb0c3563bf81a7b0c04a1a76/msgpack-1.2.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:787c9bebb5833e8f6fc8abca3c0597683d8d87f56a8842b6b89c75a5f3176e2d", size = 416405, upload-time = "2026-06-18T16:13:15.435Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/84/e8e9598b557c0ba6ddae901a73780a4c75ac667dddf59414b1e56a42fb34/msgpack-1.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dc871b997a9370d855b7394465f2f350e847a5b806dd38dcc9c989e7d87da155", size = 376257, upload-time = "2026-06-18T16:13:17.022Z" },
+    { url = "https://files.pythonhosted.org/packages/40/16/738fe6d875ad7e2a9429c165322a4ec088f4f273cdfae63d96a89c467961/msgpack-1.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:85f57e960d877f2977f6430896191b04a21f8901b3b4baf2e4604329f4db5402", size = 397469, upload-time = "2026-06-18T16:13:18.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/be/6d5952df75a7f24f35833af764c3a6860780364cb3a0030beb8099e1b2b4/msgpack-1.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1233ee2dd0cefba127583de50ea654677277047d238303521db35def3d7b2e7c", size = 372802, upload-time = "2026-06-18T16:13:19.685Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/39/e2ef7dbf0473bcb8dc7c50bf782a892d67414877b63e47fc88eb189ef5e6/msgpack-1.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e3dc2feb0876209d9c38aa56cb1de169bd6c4348f1aa48271f241226590993e6", size = 411273, upload-time = "2026-06-18T16:13:21.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c5/133f4512a56e983a93445c836c9d94d88f3bc2e0980ff4b9e577bd8416ce/msgpack-1.2.1-cp313-cp313-win32.whl", hash = "sha256:6d09badf350af2be9d189184e04e64cf54ad93569ab3d96fca58bd3e84aad707", size = 64471, upload-time = "2026-06-18T16:13:22.293Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/98/577e10b055096a7dd40732358cabaf7180a20c79ed1dcdbb618e4b9deac7/msgpack-1.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:33f14fba63278b714efe6ad07e50ea5f03d91537aa6a1c5f1ceca4cf44013ca9", size = 71274, upload-time = "2026-06-18T16:13:23.455Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ee/0c0048e7cfbef23c6a94791b8959ab28155232e7956de8a305b5ff588f05/msgpack-1.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc5febcd4c99effbc02b528e49d6fd0760b2b7d48c05239e345a5fa6e743d9a", size = 64795, upload-time = "2026-06-18T16:13:24.687Z" },
+    { url = "https://files.pythonhosted.org/packages/77/58/cce442852c6b9e1639c7c8ac8fd9143121cb32dab0f308df4d1426a8eb9c/msgpack-1.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:05f340e47e7e47d2da8db9b53e1bb1d294369e9ef45a747441309f6650b8351d", size = 83610, upload-time = "2026-06-18T16:13:25.724Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5c/15b4c7a0182f75ffa90751958ba36a9c01cafee367d49a3edc10ed140b01/msgpack-1.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:810b916696c86ef0deb3b74588480224df4c1b071136c34183e4a2a4284d7ac7", size = 83138, upload-time = "2026-06-18T16:13:26.781Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a6/99e58722feaffc5f2fbcc0c8c0d1451ab9f84097f7af87291b46af2390f4/msgpack-1.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ca0dacff965c47afdc3749a8469d7302a8f801d6a28758d55120d75e66ce6889", size = 406090, upload-time = "2026-06-18T16:13:28.072Z" },
+    { url = "https://files.pythonhosted.org/packages/19/03/8c63e8cf52958534ef688625965ab04c269a6cadd8caef16758b380a821a/msgpack-1.2.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e2bf9280bceb5efca998435904b5d3e9fdbcc11d90dc9df30aec7973252b720", size = 412106, upload-time = "2026-06-18T16:13:29.427Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d2/155d9e71b40e41fd934bc0c48b9b2770f22263e1ac20aad8e29fdca7be3f/msgpack-1.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa6c4be5d1c02a42b066ca6ddb71adf36432868fdcdb6ee87e634e86e0674190", size = 374851, upload-time = "2026-06-18T16:13:30.631Z" },
+    { url = "https://files.pythonhosted.org/packages/98/48/deaf2326262a8d5ea3295ce9649912ecd3f551ba7ec8e33c665d2ba583f3/msgpack-1.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec0e675d59150a6269ddc9139087c722292664a37d071a849c05c473350f1f2d", size = 396168, upload-time = "2026-06-18T16:13:31.977Z" },
+    { url = "https://files.pythonhosted.org/packages/10/2a/b4410f906c2ec0008f1608d3ab5143afc3ad3f4e6da0fed3ea2231d0bef4/msgpack-1.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:dd3bfe82d53edfe4b7fc9a7ec9761e23a7a5b1dac22264505af428253c29ed24", size = 371959, upload-time = "2026-06-18T16:13:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/59/86/1edc67270099a528fa2093ea60fe191233cd238e4bd30cfacf7db79fc959/msgpack-1.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5ad5467fc3f68b5468e06c5f788d712e9f8ffc8b0cd1bcb160c105c1ee92dae7", size = 408457, upload-time = "2026-06-18T16:13:34.567Z" },
+    { url = "https://files.pythonhosted.org/packages/82/90/8b630fef07d8c5ab457b71ff2c217910c83d333c7a68472c186e87cc504a/msgpack-1.2.1-cp314-cp314-win32.whl", hash = "sha256:98b58bdb89c46190e4609bb36abe17c6d4105ad13f9c5f8f6f64d320f8ced3fb", size = 65942, upload-time = "2026-06-18T16:13:36.056Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f1/467b81e98b24dd3885d7b1857728797b4ffc76a7a7483af4fb321a07de3c/msgpack-1.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:74847557e28ce71bd3c438a447ca90e4b507e997ddbdef8a12a7b283b86c156b", size = 72627, upload-time = "2026-06-18T16:13:37.079Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/1d/5d8c4c89985feb6acefb82a09e501c60392261856d2408d20bfe4f0360b1/msgpack-1.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:b50b727bd652bdc37d950336c848ef20ec54a4cafc38dce19b1cd86ad625d0f7", size = 66908, upload-time = "2026-06-18T16:13:38.23Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/02/ad2afb678b4de94496cd432b581759b756a92c1192d8c767edd6b132efdc/msgpack-1.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:8d00f177ca88a77c1cf848d204a38f249751650b601cb6532acc68805d8a8273", size = 86000, upload-time = "2026-06-18T16:13:39.44Z" },
+    { url = "https://files.pythonhosted.org/packages/54/74/0b797484013128837f3b1cbb6cea019277c4de4e377dc512b4d9a0f92940/msgpack-1.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5bb9c386f0a329c035ddbab4b72d1028bf9627add8dda41070288563d57ed1b1", size = 86544, upload-time = "2026-06-18T16:13:40.447Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/b4/b774d7eb95561739907fec675582f83203cf41c597a418c2589b4bfb8e9d/msgpack-1.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20466cca18c49c7292a8984bc15d65857b171e7264bdcb5f96baf8be238791fc", size = 427661, upload-time = "2026-06-18T16:13:41.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/f9/3243191dc9937e00756c8bc1b0272fed8f23758e43df2a3b46f533e5090f/msgpack-1.2.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:196300e7e5d6e74d50f1607ab9c06c4a1484c383cd22defd727902591f7e8dde", size = 426375, upload-time = "2026-06-18T16:13:42.936Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c7/1693111db9944ba4ad4b67a1e788400d78a0b6af7a6523dc7e4e58f8274b/msgpack-1.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:575957e79cd51903a4e8495a242442949641e08f1efd5197b43bebd3ea7682b4", size = 380495, upload-time = "2026-06-18T16:13:44.306Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/2b/92f86956a0c13e8662f7e2ad630c4eb4db07497b967589bd5245e018b2c1/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8c2ed1e48cc0f460bf3c7780e7137ff21a4e18433451916f2442c1b21036cd7d", size = 410897, upload-time = "2026-06-18T16:13:45.629Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ea/1479f72d200313a76fc2f823a79d1e07ed052ab7b8a0280640aa7b95de42/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5f6277e5f783c36786a145e0247fc189a03f35f84b251646e53592d2bc12b355", size = 378519, upload-time = "2026-06-18T16:13:46.998Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/4d/fa006060ffa1011d32bfae826fe766fe73e02982183601633b7121058ab3/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f9389552ecf4784886345ead0647e4edc96bee37cbab05b75540f542f766c48c", size = 419815, upload-time = "2026-06-18T16:13:48.205Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/aab6c946570496b78e67804721f3d5e2d62a93081b9b37df77764ef56347/msgpack-1.2.1-cp314-cp314t-win32.whl", hash = "sha256:c1c79a604a2969a868a78b6ebd27a887e00c624f14f66b3038e0590cb23332d1", size = 70914, upload-time = "2026-06-18T16:13:49.385Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0a/e608956488a2af014cfe6e3d665e090b8ee42aa14b07f8f95b8880d66b09/msgpack-1.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f12038a35fabd52e56a3547bab42401af49a45caa6dd00b34c44de235bc93ee2", size = 77999, upload-time = "2026-06-18T16:13:50.467Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/8a/27e2e57055176e366a46b85d02d68e7a5bcfbdd8474c9706375d965f24d3/msgpack-1.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:0adcf06ffde0777c0e1a9b771a2b1c4226ba1bbf748c8efcc02fcdeca3299107", size = 71160, upload-time = "2026-06-18T16:13:51.498Z" },
+]
+
+[[package]]
 name = "mutmut"
 version = "3.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -983,6 +1356,34 @@ wheels = [
 ]
 
 [[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
 name = "py-cpuinfo"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1024,6 +1425,9 @@ docs = [
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
 ]
+load = [
+    { name = "locust" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1055,6 +1459,7 @@ docs = [
     { name = "mkdocs-material", specifier = ">=9.6.0,<10" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.29.0,<2" },
 ]
+load = [{ name = "locust", specifier = ">=2.31,<3" }]
 
 [[package]]
 name = "py-identity-model-fastapi-example"
@@ -1344,6 +1749,56 @@ wheels = [
 ]
 
 [[package]]
+name = "python-engineio"
+version = "4.13.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "simple-websocket" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/d8/65cc479ab697a2e7fdee83a9bd8a06b61ec68bf763a58a302cf161bf38bb/python_engineio-4.13.5.tar.gz", hash = "sha256:b5764d62243e3ffbc4c76dda3d7897c329dc52294c80c27105f9faa054e76897", size = 80035, upload-time = "2026-08-12T22:52:23.78Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/01/f804208061b504894546fddc479f6075e0f00dfe88cb1703dafaa8c3c67e/python_engineio-4.13.5-py3-none-any.whl", hash = "sha256:05c9f4951d242ad33d613b4245299562e5f64e4199f00e5390f9888505831704", size = 59963, upload-time = "2026-08-12T22:52:22.5Z" },
+]
+
+[[package]]
+name = "python-socketio"
+version = "5.16.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bidict" },
+    { name = "python-engineio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/5e/87d6b547c87c6d64f4a05f5bfaf6f42e9b786561216434290fdaa83f8667/python_socketio-5.16.4.tar.gz", hash = "sha256:f7fa4a43cc8e687930b5c6e44d6e2efc2071eca4bef49b8bb3dc0827f7f92235", size = 128140, upload-time = "2026-08-06T23:11:21.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/d9/463feca73ec119a135d90c9f40c0172b4758150b5ed442f0ca1e8fed807a/python_socketio-5.16.4-py3-none-any.whl", hash = "sha256:0eb9c7687e7fbf59e60d714fd62afba77dfaf8ef8a06a0bff05a86c351accc2f", size = 82098, upload-time = "2026-08-06T23:11:19.851Z" },
+]
+
+[package.optional-dependencies]
+client = [
+    { name = "requests" },
+    { name = "websocket-client" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1423,6 +1878,49 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/05/10/f42c48fa5153204f42eaa945e8d1fd7c10d6296841dcb2447bf7da1be5c4/pyyaml_ft-8.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:052561b89d5b2a8e1289f326d060e794c21fa068aa11255fe71d65baf18a632e", size = 810403, upload-time = "2025-06-10T15:32:11.051Z" },
     { url = "https://files.pythonhosted.org/packages/d5/d2/e369064aa51009eb9245399fd8ad2c562bd0bcd392a00be44b2a824ded7c/pyyaml_ft-8.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3bb4b927929b0cb162fb1605392a321e3333e48ce616cdcfa04a839271373255", size = 835581, upload-time = "2025-06-10T15:32:12.897Z" },
     { url = "https://files.pythonhosted.org/packages/c0/28/26534bed77109632a956977f60d8519049f545abc39215d086e33a61f1f2/pyyaml_ft-8.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:de04cfe9439565e32f178106c51dd6ca61afaa2907d143835d501d84703d3793", size = 171579, upload-time = "2025-06-10T15:32:14.34Z" },
+]
+
+[[package]]
+name = "pyzmq"
+version = "27.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "implementation_name == 'pypy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/e7/038aab64a946d535901103da16b953c8c9cc9c961dadcbf3609ed6428d23/pyzmq-27.1.0-cp312-abi3-macosx_10_15_universal2.whl", hash = "sha256:452631b640340c928fa343801b0d07eb0c3789a5ffa843f6e1a9cee0ba4eb4fc", size = 1306279, upload-time = "2025-09-08T23:08:03.807Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5e/c3c49fdd0f535ef45eefcc16934648e9e59dace4a37ee88fc53f6cd8e641/pyzmq-27.1.0-cp312-abi3-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1c179799b118e554b66da67d88ed66cd37a169f1f23b5d9f0a231b4e8d44a113", size = 895645, upload-time = "2025-09-08T23:08:05.301Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e5/b0b2504cb4e903a74dcf1ebae157f9e20ebb6ea76095f6cfffea28c42ecd/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3837439b7f99e60312f0c926a6ad437b067356dc2bc2ec96eb395fd0fe804233", size = 652574, upload-time = "2025-09-08T23:08:06.828Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/9b/c108cdb55560eaf253f0cbdb61b29971e9fb34d9c3499b0e96e4e60ed8a5/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43ad9a73e3da1fab5b0e7e13402f0b2fb934ae1c876c51d0afff0e7c052eca31", size = 840995, upload-time = "2025-09-08T23:08:08.396Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/bb/b79798ca177b9eb0825b4c9998c6af8cd2a7f15a6a1a4272c1d1a21d382f/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0de3028d69d4cdc475bfe47a6128eb38d8bc0e8f4d69646adfbcd840facbac28", size = 1642070, upload-time = "2025-09-08T23:08:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/80/2df2e7977c4ede24c79ae39dcef3899bfc5f34d1ca7a5b24f182c9b7a9ca/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_i686.whl", hash = "sha256:cf44a7763aea9298c0aa7dbf859f87ed7012de8bda0f3977b6fb1d96745df856", size = 2021121, upload-time = "2025-09-08T23:08:11.907Z" },
+    { url = "https://files.pythonhosted.org/packages/46/bd/2d45ad24f5f5ae7e8d01525eb76786fa7557136555cac7d929880519e33a/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f30f395a9e6fbca195400ce833c731e7b64c3919aa481af4d88c3759e0cb7496", size = 1878550, upload-time = "2025-09-08T23:08:13.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/2f/104c0a3c778d7c2ab8190e9db4f62f0b6957b53c9d87db77c284b69f33ea/pyzmq-27.1.0-cp312-abi3-win32.whl", hash = "sha256:250e5436a4ba13885494412b3da5d518cd0d3a278a1ae640e113c073a5f88edd", size = 559184, upload-time = "2025-09-08T23:08:15.163Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7f/a21b20d577e4100c6a41795842028235998a643b1ad406a6d4163ea8f53e/pyzmq-27.1.0-cp312-abi3-win_amd64.whl", hash = "sha256:9ce490cf1d2ca2ad84733aa1d69ce6855372cb5ce9223802450c9b2a7cba0ccf", size = 619480, upload-time = "2025-09-08T23:08:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c2/c012beae5f76b72f007a9e91ee9401cb88c51d0f83c6257a03e785c81cc2/pyzmq-27.1.0-cp312-abi3-win_arm64.whl", hash = "sha256:75a2f36223f0d535a0c919e23615fc85a1e23b71f40c7eb43d7b1dedb4d8f15f", size = 552993, upload-time = "2025-09-08T23:08:18.926Z" },
+    { url = "https://files.pythonhosted.org/packages/60/cb/84a13459c51da6cec1b7b1dc1a47e6db6da50b77ad7fd9c145842750a011/pyzmq-27.1.0-cp313-cp313-android_24_arm64_v8a.whl", hash = "sha256:93ad4b0855a664229559e45c8d23797ceac03183c7b6f5b4428152a6b06684a5", size = 1122436, upload-time = "2025-09-08T23:08:20.801Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b6/94414759a69a26c3dd674570a81813c46a078767d931a6c70ad29fc585cb/pyzmq-27.1.0-cp313-cp313-android_24_x86_64.whl", hash = "sha256:fbb4f2400bfda24f12f009cba62ad5734148569ff4949b1b6ec3b519444342e6", size = 1156301, upload-time = "2025-09-08T23:08:22.47Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ad/15906493fd40c316377fd8a8f6b1f93104f97a752667763c9b9c1b71d42d/pyzmq-27.1.0-cp313-cp313t-macosx_10_15_universal2.whl", hash = "sha256:e343d067f7b151cfe4eb3bb796a7752c9d369eed007b91231e817071d2c2fec7", size = 1341197, upload-time = "2025-09-08T23:08:24.286Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1d/d343f3ce13db53a54cb8946594e567410b2125394dafcc0268d8dda027e0/pyzmq-27.1.0-cp313-cp313t-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:08363b2011dec81c354d694bdecaef4770e0ae96b9afea70b3f47b973655cc05", size = 897275, upload-time = "2025-09-08T23:08:26.063Z" },
+    { url = "https://files.pythonhosted.org/packages/69/2d/d83dd6d7ca929a2fc67d2c3005415cdf322af7751d773524809f9e585129/pyzmq-27.1.0-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d54530c8c8b5b8ddb3318f481297441af102517602b569146185fa10b63f4fa9", size = 660469, upload-time = "2025-09-08T23:08:27.623Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/cd/9822a7af117f4bc0f1952dbe9ef8358eb50a24928efd5edf54210b850259/pyzmq-27.1.0-cp313-cp313t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f3afa12c392f0a44a2414056d730eebc33ec0926aae92b5ad5cf26ebb6cc128", size = 847961, upload-time = "2025-09-08T23:08:29.672Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/12/f003e824a19ed73be15542f172fd0ec4ad0b60cf37436652c93b9df7c585/pyzmq-27.1.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c65047adafe573ff023b3187bb93faa583151627bc9c51fc4fb2c561ed689d39", size = 1650282, upload-time = "2025-09-08T23:08:31.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/4a/e82d788ed58e9a23995cee70dbc20c9aded3d13a92d30d57ec2291f1e8a3/pyzmq-27.1.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:90e6e9441c946a8b0a667356f7078d96411391a3b8f80980315455574177ec97", size = 2024468, upload-time = "2025-09-08T23:08:33.543Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/94/2da0a60841f757481e402b34bf4c8bf57fa54a5466b965de791b1e6f747d/pyzmq-27.1.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:add071b2d25f84e8189aaf0882d39a285b42fa3853016ebab234a5e78c7a43db", size = 1885394, upload-time = "2025-09-08T23:08:35.51Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/6f/55c10e2e49ad52d080dc24e37adb215e5b0d64990b57598abc2e3f01725b/pyzmq-27.1.0-cp313-cp313t-win32.whl", hash = "sha256:7ccc0700cfdf7bd487bea8d850ec38f204478681ea02a582a8da8171b7f90a1c", size = 574964, upload-time = "2025-09-08T23:08:37.178Z" },
+    { url = "https://files.pythonhosted.org/packages/87/4d/2534970ba63dd7c522d8ca80fb92777f362c0f321900667c615e2067cb29/pyzmq-27.1.0-cp313-cp313t-win_amd64.whl", hash = "sha256:8085a9fba668216b9b4323be338ee5437a235fe275b9d1610e422ccc279733e2", size = 641029, upload-time = "2025-09-08T23:08:40.595Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/fa/f8aea7a28b0641f31d40dea42d7ef003fded31e184ef47db696bc74cd610/pyzmq-27.1.0-cp313-cp313t-win_arm64.whl", hash = "sha256:6bb54ca21bcfe361e445256c15eedf083f153811c37be87e0514934d6913061e", size = 561541, upload-time = "2025-09-08T23:08:42.668Z" },
+    { url = "https://files.pythonhosted.org/packages/87/45/19efbb3000956e82d0331bafca5d9ac19ea2857722fa2caacefb6042f39d/pyzmq-27.1.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ce980af330231615756acd5154f29813d553ea555485ae712c491cd483df6b7a", size = 1341197, upload-time = "2025-09-08T23:08:44.973Z" },
+    { url = "https://files.pythonhosted.org/packages/48/43/d72ccdbf0d73d1343936296665826350cb1e825f92f2db9db3e61c2162a2/pyzmq-27.1.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1779be8c549e54a1c38f805e56d2a2e5c009d26de10921d7d51cfd1c8d4632ea", size = 897175, upload-time = "2025-09-08T23:08:46.601Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/2e/a483f73a10b65a9ef0161e817321d39a770b2acf8bcf3004a28d90d14a94/pyzmq-27.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7200bb0f03345515df50d99d3db206a0a6bee1955fbb8c453c76f5bf0e08fb96", size = 660427, upload-time = "2025-09-08T23:08:48.187Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d2/5f36552c2d3e5685abe60dfa56f91169f7a2d99bbaf67c5271022ab40863/pyzmq-27.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01c0e07d558b06a60773744ea6251f769cd79a41a97d11b8bf4ab8f034b0424d", size = 847929, upload-time = "2025-09-08T23:08:49.76Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/2a/404b331f2b7bf3198e9945f75c4c521f0c6a3a23b51f7a4a401b94a13833/pyzmq-27.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:80d834abee71f65253c91540445d37c4c561e293ba6e741b992f20a105d69146", size = 1650193, upload-time = "2025-09-08T23:08:51.7Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/0b/f4107e33f62a5acf60e3ded67ed33d79b4ce18de432625ce2fc5093d6388/pyzmq-27.1.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:544b4e3b7198dde4a62b8ff6685e9802a9a1ebf47e77478a5eb88eca2a82f2fd", size = 2024388, upload-time = "2025-09-08T23:08:53.393Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/01/add31fe76512642fd6e40e3a3bd21f4b47e242c8ba33efb6809e37076d9b/pyzmq-27.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cedc4c68178e59a4046f97eca31b148ddcf51e88677de1ef4e78cf06c5376c9a", size = 1885316, upload-time = "2025-09-08T23:08:55.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/59/a5f38970f9bf07cee96128de79590bb354917914a9be11272cfc7ff26af0/pyzmq-27.1.0-cp314-cp314t-win32.whl", hash = "sha256:1f0b2a577fd770aa6f053211a55d1c47901f4d537389a034c690291485e5fe92", size = 587472, upload-time = "2025-09-08T23:08:58.18Z" },
+    { url = "https://files.pythonhosted.org/packages/70/d8/78b1bad170f93fcf5e3536e70e8fadac55030002275c9a29e8f5719185de/pyzmq-27.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:19c9468ae0437f8074af379e986c5d3d7d7bfe033506af442e8c879732bedbe0", size = 661401, upload-time = "2025-09-08T23:08:59.802Z" },
+    { url = "https://files.pythonhosted.org/packages/81/d6/4bfbb40c9a0b42fc53c7cf442f6385db70b40f74a783130c5d0a5aa62228/pyzmq-27.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dc5dbf68a7857b59473f7df42650c621d7e8923fb03fa74a526890f4d33cc4d7", size = 575170, upload-time = "2025-09-08T23:09:01.418Z" },
 ]
 
 [[package]]
@@ -1546,6 +2044,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/e3/54b496ac724e60e61cc3447f02690105901ca6d90da0377dffe49ff99fc7/setproctitle-1.3.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1fae595d032b30dab4d659bece20debd202229fce12b55abab978b7f30783d73", size = 33958, upload-time = "2025-09-05T12:50:39.841Z" },
     { url = "https://files.pythonhosted.org/packages/ea/a8/c84bb045ebf8c6fdc7f7532319e86f8380d14bbd3084e6348df56bdfe6fd/setproctitle-1.3.7-cp314-cp314t-win32.whl", hash = "sha256:02432f26f5d1329ab22279ff863c83589894977063f59e6c4b4845804a08f8c2", size = 12745, upload-time = "2025-09-05T12:50:41.377Z" },
     { url = "https://files.pythonhosted.org/packages/08/b6/3a5a4f9952972791a9114ac01dfc123f0df79903577a3e0a7a404a695586/setproctitle-1.3.7-cp314-cp314t-win_amd64.whl", hash = "sha256:cbc388e3d86da1f766d8fc2e12682e446064c01cea9f88a88647cfe7c011de6a", size = 13469, upload-time = "2025-09-05T12:50:42.67Z" },
+]
+
+[[package]]
+name = "simple-websocket"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wsproto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/d4/bfa032f961103eba93de583b161f0e6a5b63cebb8f2c7d0c6e6efe1e3d2e/simple_websocket-1.1.0.tar.gz", hash = "sha256:7939234e7aa067c534abdab3a9ed933ec9ce4691b0713c78acb195560aa52ae4", size = 17300, upload-time = "2024-10-10T22:39:31.412Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/59/0782e51887ac6b07ffd1570e0364cf901ebc36345fea669969d2084baebb/simple_websocket-1.1.0-py3-none-any.whl", hash = "sha256:4af6069630a38ed6c561010f0e11a5bc0d4ca569b36306eb257cd9a192497c8c", size = 13842, upload-time = "2024-10-10T22:39:29.645Z" },
 ]
 
 [[package]]
@@ -1829,6 +2339,15 @@ wheels = [
 ]
 
 [[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
+]
+
+[[package]]
 name = "websockets"
 version = "16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1871,4 +2390,72 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
+]
+
+[[package]]
+name = "wsproto"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116, upload-time = "2025-11-20T18:18:01.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584", size = 24405, upload-time = "2025-11-20T18:18:00.454Z" },
+]
+
+[[package]]
+name = "zope-event"
+version = "6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/41/faa10af34d48d9cd6fa0249a1162943ad84a9590bd1a06939981e6640416/zope_event-6.2.tar.gz", hash = "sha256:b97d5d6327067ee6b9dfcbdf606ade9ade70991e19c162e808ea39e5fcf0f8d3", size = 18958, upload-time = "2026-04-28T06:24:10.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/33/848922889e946d4befc415c219fe516af75c49555d8e736e183bfd30db42/zope_event-6.2-py3-none-any.whl", hash = "sha256:5e755153ac4faf64c10a4b6dd3307680166a3edf65b38df22df592610f8fa874", size = 6525, upload-time = "2026-04-28T06:24:09.176Z" },
+]
+
+[[package]]
+name = "zope-interface"
+version = "8.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/dc/50550cfcbb2ea3cbca5f1d7ed05c8aa840f831a0f2d63aec0a953f7c590e/zope_interface-8.5.tar.gz", hash = "sha256:7a3ba1c5877f0f3e3906b02ddf793abed2becc2948116414ce0e1dd820b68d6d", size = 257957, upload-time = "2026-05-26T06:50:14.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/cc/b84123a948f3162a34623e188922827cd845244fdd043ed20f8d02228caa/zope_interface-8.5-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:8e6ee90c2e6de7c37058d5fa41f123c8b13a312db8d1e0fb5840d7f4bcdff9c9", size = 212165, upload-time = "2026-05-26T06:49:26.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/cbceec44f1b27208a76c1a688c131302685852406a23df5aab68324109cc/zope_interface-8.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c1adc90d3576b3b4c4de4953e6002c37bef28b78d7fa54c1bbfd0c50f022fe7c", size = 212341, upload-time = "2026-05-26T06:49:28.182Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/c3/005032195ff3b210c139b7c560ed5c534e844b0907d8e44d2b3d8919305e/zope_interface-8.5-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:e6347b8d8d12c5eca6502450a92be30079b7acfade2c4f693efa0deb8871b06e", size = 265296, upload-time = "2026-05-26T06:49:29.741Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/66/1036543d6a66bc04c19df3cf650f3ad938a002ab0a443c24e23e8de5e8b9/zope_interface-8.5-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5e970dabea777a24b0b0bbf9dae3ab75ce8b2d8e948edf4875627034b21f3560", size = 270689, upload-time = "2026-05-26T06:49:31.767Z" },
+    { url = "https://files.pythonhosted.org/packages/30/4c/8b56259558cace4414e753ca6740396a1f59d4a95ddb55b4658600408670/zope_interface-8.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f0b48ccadaa9839e09ff81e969703cecb3f402c813bfe8b958652e699bea69f5", size = 270280, upload-time = "2026-05-26T06:49:33.489Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ea/649908c83aa8fdb7faf2ddca4d3cf6fb8f2157121267dc56e8f72681e26c/zope_interface-8.5-cp312-cp312-win_amd64.whl", hash = "sha256:e0e311f1277468c08fd59a2b41f71b43d25dff639789d364747acd1705c0df6e", size = 215019, upload-time = "2026-05-26T06:49:35.607Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/97/da13037b4c563e4df32eedbc819f8c00b754af494f68211e3dffd48d52da/zope_interface-8.5-cp312-cp312-win_arm64.whl", hash = "sha256:652b73107a04159ec6c020db6c1543d4f1e8f4d069bd2aac88a947820923517b", size = 213569, upload-time = "2026-05-26T06:49:37.317Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/8c/4c15755d701f2ec0e80d64a18e1ebaf5be2c584c0ec153fd516f5d13eada/zope_interface-8.5-cp313-cp313-macosx_10_9_x86_64.whl", hash = "sha256:28e80457c134d1fa57a7d758004dece348654e1b1467ac22dcdc20fc1d127c52", size = 212512, upload-time = "2026-05-26T06:49:38.996Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/2e/4360c54c465db042cc8fbeeec92abac28b4cedbf6ba63c1f092fd08a190f/zope_interface-8.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:09495ce9d559c06b70f2d4855b3e4f48a822a9ddc8be1d30c5b4e5be14ae1ace", size = 212541, upload-time = "2026-05-26T06:49:41.186Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a5/692a2b8d70f78e848793231d5fae5fecbf8d0cccd73430fdc34802a6d3c1/zope_interface-8.5-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:7849ad8fa90763cc1087f4dda78ca3a233e950b3e08fac7079297c9cafbbd7bb", size = 265191, upload-time = "2026-05-26T06:49:43.449Z" },
+    { url = "https://files.pythonhosted.org/packages/70/8d/454a9cfc7a050c394ab4f11b3371f7897828b7415e096afff724637e65e0/zope_interface-8.5-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5578c9421ca409a1f39f153d6f7803e4cde01da592ec75a9ac5e1b777d18d33b", size = 270626, upload-time = "2026-05-26T06:49:45.425Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8c/db8409cfa3575b8e9b4800babd7d49f8228433cd1f0c56814bd0ada49c33/zope_interface-8.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e1bd7d96b4ca5fa311f54c9eac16dce4886b428c1531dbe06067763ccdf123b4", size = 270444, upload-time = "2026-05-26T06:49:47.025Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/df/a386940e41469ef615e100a216d8b386521e9e598817147f87932ca203c4/zope_interface-8.5-cp313-cp313-win_amd64.whl", hash = "sha256:0c8123d2a4dfde2a613c7cb772605477724782c20bc2e0ad1d9435376a6a44a3", size = 215021, upload-time = "2026-05-26T06:49:48.478Z" },
+    { url = "https://files.pythonhosted.org/packages/89/75/477eb5669b6b2a7a843decd1a075e9b1971a8720017654143a7183abd3d9/zope_interface-8.5-cp313-cp313-win_arm64.whl", hash = "sha256:6d02be14f3173c6c7288bc2fdf530090c01c3cf8764ad46c68024686f364278e", size = 213610, upload-time = "2026-05-26T06:49:50.01Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/19/5032e954827fdf02db2d2f49737ac4378bb9cfc2cd95a8f2e2a5ae2ec01a/zope_interface-8.5-cp314-cp314-macosx_10_9_x86_64.whl", hash = "sha256:ffaecf013251a89d0de6feb49a46eba48ad8cbbf8a40aeb6045e459e7bec6784", size = 212597, upload-time = "2026-05-26T06:49:51.63Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/53/3ef644012cf8a6a234a2d6134aab5a5c65ac5467c86296865501d4fbc406/zope_interface-8.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:126fa9d1c52295ae076d4cf968634f0a1826afa408a20808b57ff72877b8f69f", size = 212626, upload-time = "2026-05-26T06:49:53.236Z" },
+    { url = "https://files.pythonhosted.org/packages/32/67/bc8b4f465d388039255003e230c284a175cedf1203c692f23cb7bff64efe/zope_interface-8.5-cp314-cp314-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:3090e3a663d20194756a59a272e0c8508b889341e31d5894223331fe6b4f9b21", size = 266827, upload-time = "2026-05-26T06:49:54.873Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/eb/37d05b935ede53d79690fecc8d201440084418e590bcfc05f384451c7593/zope_interface-8.5-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9342fb74e2afefdb081bf1df727d209ea56995c6e13f5a0540e6d7aff4beafb8", size = 270139, upload-time = "2026-05-26T06:49:57.116Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/0b/fd0c54579e2ce8dc6cf1a757903f3374bc6fbda929a46af9e0f53cb0e5f0/zope_interface-8.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6c54725d818f1b57a7efb8b16528326e1f3c257b602b32393fd255c45af8799d", size = 270338, upload-time = "2026-05-26T06:49:58.698Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/1d/c420dcd777bb761067ea92879ac766694a5ca78608185f1aecea64cbfc11/zope_interface-8.5-cp314-cp314-win_amd64.whl", hash = "sha256:29d74febbae1afeb6834c4ccbf42e242a673c860060f09e53142825270456140", size = 215789, upload-time = "2026-05-26T06:50:00.405Z" },
+    { url = "https://files.pythonhosted.org/packages/62/94/50b5eb8f94e527edceac14f9955e58917424ea79bb572ddc18548561cbc2/zope_interface-8.5-cp314-cp314-win_arm64.whl", hash = "sha256:633c8c49396f38df030340797c533e9fe460d1b5d1e42d88e55e938e525f548c", size = 213757, upload-time = "2026-05-26T06:50:01.973Z" },
+    { url = "https://files.pythonhosted.org/packages/17/6f/5d5f32c4dfcdb16ce2ec5363da686840f13c13e1a1214cb70b49e1cd6d9f/zope_interface-8.5-cp314-cp314t-macosx_10_9_x86_64.whl", hash = "sha256:133999820fdbae513c36c03d6f29ef87317aaa3edef39112222b155083664714", size = 213591, upload-time = "2026-05-26T06:50:03.529Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/55/de0c3459ff717fce3342f9a29464c281fdeb0d36c3171ee88d119d5f0650/zope_interface-8.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8bd75c96966e573232f0599deaff717564828031c7f05563ccc1ac35c5ee0304", size = 213733, upload-time = "2026-05-26T06:50:05.101Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/d97430abd5ae9677e8b9295b58720c0064a5b557dbb6b8bf5928484cf0d8/zope_interface-8.5-cp314-cp314t-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:14b0e9799351d4c34fe99afd67f0cdd76e55ba15c66a98699d5fc22ea8241e08", size = 294905, upload-time = "2026-05-26T06:50:07.384Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ec/a0f8f3dad6e74992f4654bdd94802be0929eabca7b871cac3b6fbb5e961b/zope_interface-8.5-cp314-cp314t-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0cd6a732ac84b94eb1ef9222a117347a27efd294ee16810ffdf7ecd307677ed5", size = 300885, upload-time = "2026-05-26T06:50:08.997Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/6881b48803a0ee8d23eb5efa30fce3ed218a2bd9de5758ce489d224fee81/zope_interface-8.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:798b7c87d0e59a7d5d086d642208d0d8700ff0d55c4029134b3c479c3bfb110f", size = 304672, upload-time = "2026-05-26T06:50:10.563Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/0e/b4c01320859ff1d585438bc231fd60bd258d096359bccf6654fecdf0cffb/zope_interface-8.5-cp314-cp314t-win_amd64.whl", hash = "sha256:0fc3a9d45f114d27eaa1e53beeb144533689edca8a9f66505b1e8e8b3f075e42", size = 217241, upload-time = "2026-05-26T06:50:12.171Z" },
 ]


### PR DESCRIPTION
## Summary
Adds the TH-1.5 Locust load/soak harness (design §4/§5) driving the booted resource server (T301) with the pre-minted replay pool (T300) and the controllable mock OP (T300) for failure injection.

- **Merged the T299 cache-observability foundation** (`core/cache_metrics.py` `get_cache_counters().snapshot()`, per-process hit/miss/refresh counters in `aio/token_validation.py`) — the cache-hit-rate surface TH-1.5 reports.
- **Counter accuracy:** miss/refresh now count *attempted* upstream fetches including failed (429/5xx) round-trips, gated on a side-effect-free scheme re-check (`_upstream_fetch_attempted`) rather than `response.is_successful`, so an upstream outage no longer reads as zero upstream volume.
- **Mock-OP upstream-fetch counters** (per-path discovery/jwks/token/introspect) + read/reset `/_stats` route; **RS `/metrics`** unauthenticated readout of the cache counters.
- **`src/tests/load/`**: `scenarios.py` (S1–S12 table + profile tiers), `pool.py` (replay pool + post-expiry-401 = expected classification), `locustfile.py` (out-of-process Locust — parent never imports locust to avoid gevent/asyncio deadlock), `runner.py`, `test_load_ci_short.py` (real-Locust `@integration` DoD).
- Profiles: **CI_SHORT** = S1,S2,S3,S6,S8; **DIAGNOSTIC** = S5/S9/S10; **NIGHTLY** = S4/S7/S11/S12 (S4 needs a >60s TTL rollover — the cache has a hard 60s floor).
- `pyproject.toml` `load` dependency-group (locust, not a runtime/optional dep), pyrefly excludes for locust-importing modules, ruff per-file S101/PLR2004; `Makefile` `test-harness-load` (+ nightly stub).

## Stacking
Branched on the T300+T301+T302 harness stack (#521/#522/#523) and merges the T299 counters branch (#520); all four are still open/unmerged, so the diff vs `main` includes those foundation files until the owner merges the stack. Review T311's own contribution as `src/tests/load/**` + the mock_op/rs_app counter readouts + the `_upstream_fetch_attempted` counter-accuracy fix.

Refs #474, epic #462

## Review Findings Addressed
5 reviewers (Blind/Edge/Acceptance/Sentinel/Viper): **P0 = 0** (Sentinel 0 BLOCK, Acceptance 0 FAIL, Viper 0 findings — locust/gevent are a PEP 735 dev group, never shipped to pip consumers). 5 P1s fixed in `51e3561`+`6315c79`: counter under-count on 429/5xx, `cache_hit_rate` 1.0-when-empty → 0.0, S2 alg-cost ratio now computable (per-class p50/p95/p99 + p999), RS `/metrics` reuses fastapi `_default_excluded_paths()`, and honest CI_SHORT profile (S4→nightly, S10 scaffold flagged, stale "S1-S8" docstrings corrected). Delta re-review clean.

## Test plan
- [x] Unit tests pass (`make lint` — ruff + format + pyrefly + 80% coverage GREEN)
- [x] Integration tests pass — **real Locust DoD** `make test-harness-load`: 10 passed, S3 cold stampede coalesced to exactly 1 discovery + 1 JWKS fetch (single-flight), S1 warm all-hits, zero 5xx across all scenarios
- [x] Security gate passes — `make security-gate BASE=origin/main`: 158 in-scope mutants in the changed `_refresh_jwks`/counter functions all killed or waived-equivalent (4 log-string mutants waived with justification)
- [x] Lint passes
- [x] Independent review agents passed
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)