### PR TITLE
ci(load): nightly capacity + soak RSS/FD report artifacts on the free runner (TH-4 T316)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -65,7 +65,19 @@ jobs:
         run: make ci-setup
 
       - name: Load soak (S4/S7/S11/S12 — real Locust vs the booted RS)
+        env:
+          HARNESS_SOAK_REPORT: soak-report.txt
         run: make test-harness-load-nightly
+
+      # RSS/FD trend numbers the pass/fail soak assertions otherwise hide. Written
+      # before the assertions run, so it survives a failing gate — upload always.
+      - name: Upload soak RSS/FD report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: soak-report
+          path: soak-report.txt
+          if-no-files-found: warn
 
   load-capacity:
     name: Load capacity (ramp-to-breakpoint)

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,11 +7,14 @@ name: Nightly
 #  * load-soak    — the long-window load/soak profile (S4 TTL-rollover + S7/S11/
 #                   S12 LRU-thrash / RSS-FD soak) that is too slow for the PR gate.
 #  * load-capacity — the TH-4 open-model ramp-to-breakpoint (C1/C2): find the
-#                   goodput knee + max-sustainable RPS. On the default 2-vCPU
-#                   runner the generator/mock-OP/RS are co-located, so the knee is
-#                   a DIRECTIONAL ceiling + regression signal, not the RS's
-#                   absolute limit. Point this at a larger runner (T316) to raise
-#                   the co-located ceiling.
+#                   goodput knee + max-sustainable RPS, and upload the ramp curve
+#                   as a downloadable artifact. Runs on the free GitHub-hosted
+#                   `ubuntu-latest` (4-vCPU/16GB on this public repo); the
+#                   generator/mock-OP/RS are co-located, so the knee is a
+#                   DIRECTIONAL ceiling + regression signal, NOT the RS's absolute
+#                   isolated limit (that needs a deployed target, out of scope).
+#                   No paid larger runner is used — directional-on-free is the
+#                   accepted trade-off.
 
 on:
   schedule:
@@ -66,9 +69,10 @@ jobs:
 
   load-capacity:
     name: Load capacity (ramp-to-breakpoint)
-    # runs-on: ubuntu-latest is a 2-vCPU co-located box → the knee is directional.
-    # Swap to a larger GitHub-hosted label (e.g. ubuntu-latest-8-cores) once
-    # provisioned to raise the co-located ceiling (TH-4.5 / T316).
+    # Free GitHub-hosted runner (4-vCPU/16GB on this public repo). Generator,
+    # mock OP and RS are co-located, so the knee is a directional ceiling +
+    # regression signal, not the RS's absolute limit. No paid larger runner is
+    # used; the ramp curve is uploaded as an artifact for trend-tracking.
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -93,4 +97,17 @@ jobs:
         run: make ci-setup
 
       - name: Capacity ramp (C1/C2 — find the goodput knee vs the booted RS)
+        env:
+          HARNESS_CAPACITY_REPORT: capacity-report.txt
         run: make test-harness-load-capacity
+
+      # Upload even on failure: the ramp curve is most useful when a rung breached
+      # unexpectedly. The report is written before the assertions run, so it
+      # exists whenever the ramp itself completed.
+      - name: Upload capacity report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: capacity-report
+          path: capacity-report.txt
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -158,9 +158,10 @@ conformance/results/hosted/rp-logs/
 .ralph/
 PROMPT.md
 
-# Capacity ramp report (TH-4) — written by the load-capacity run, uploaded as a
-# CI artifact, never committed.
+# Load-report artifacts (TH-4) — written by the load-capacity / load-soak runs,
+# uploaded as CI artifacts, never committed.
 capacity-report.txt
+soak-report.txt
 
 # Terraform
 infra/**/.terraform/

--- a/.gitignore
+++ b/.gitignore
@@ -158,6 +158,10 @@ conformance/results/hosted/rp-logs/
 .ralph/
 PROMPT.md
 
+# Capacity ramp report (TH-4) — written by the load-capacity run, uploaded as a
+# CI artifact, never committed.
+capacity-report.txt
+
 # Terraform
 infra/**/.terraform/
 infra/**/*.tfstate*

--- a/src/tests/load/README.md
+++ b/src/tests/load/README.md
@@ -136,8 +136,13 @@ mock OP, and the RS share one runner, so the knee is where *that co-located
 config* saturates — a real ceiling relative to itself and a solid regression
 signal, but **not** the RS's isolated limit. That needs a deployed target (RS as
 a real service, distributed generator over a network), which is out of scope
-here. Every report line says so. On the default 2-vCPU runner the knee is also
-capacity-capped; point the nightly job at a larger runner to raise it.
+here. Every report line says so.
+
+The nightly `load-capacity` job runs on the **free** GitHub-hosted `ubuntu-latest`
+(4-vCPU/16GB on this public repo) and **uploads the ramp curve as a
+`capacity-report` artifact** for trend-tracking. No paid larger runner is
+used — directional-on-free is the accepted trade-off; a true isolated ceiling
+would need the deployed-target lab above, not a bigger CI box.
 
 ## Calibrated SLO baseline
 

--- a/src/tests/load/runner.py
+++ b/src/tests/load/runner.py
@@ -579,6 +579,21 @@ def render_capacity_report(results: list[CapacityResult]) -> str:
     return "\n".join(lines)
 
 
+def write_capacity_report(results: list[CapacityResult], path: str | Path) -> Path:
+    """Render *results* and write the report to *path*; return the written path.
+
+    The nightly ``load-capacity`` job sets ``HARNESS_CAPACITY_REPORT`` so this
+    file can be uploaded as a downloadable artifact — the ramp curve + knee per
+    scenario, which otherwise lives only in the job log. Parent directories are
+    created so a nested artifact path just works.
+    """
+    out = Path(path)
+    if out.parent != Path():
+        out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(render_capacity_report(results))
+    return out
+
+
 @contextlib.contextmanager
 def _scenario_stack(workers: int = 1) -> Iterator[tuple[MockOP, str, int]]:
     """Fresh mock OP + booted RS for a single scenario (clean cache each time).

--- a/src/tests/load/runner.py
+++ b/src/tests/load/runner.py
@@ -579,19 +579,64 @@ def render_capacity_report(results: list[CapacityResult]) -> str:
     return "\n".join(lines)
 
 
-def write_capacity_report(results: list[CapacityResult], path: str | Path) -> Path:
-    """Render *results* and write the report to *path*; return the written path.
+def _write_report(text: str, path: str | Path) -> Path:
+    """Write *text* to *path* as UTF-8, creating parent dirs; return the path.
 
-    The nightly ``load-capacity`` job sets ``HARNESS_CAPACITY_REPORT`` so this
-    file can be uploaded as a downloadable artifact — the ramp curve + knee per
-    scenario, which otherwise lives only in the job log. Parent directories are
-    created so a nested artifact path just works.
+    UTF-8 is explicit (not the locale default) because both reports carry
+    non-ASCII glyphs — the capacity report's ``—`` and the soak header's ``Δ`` —
+    which would raise ``UnicodeEncodeError`` under a POSIX/ASCII CI locale.
     """
     out = Path(path)
     if out.parent != Path():
         out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text(render_capacity_report(results))
+    out.write_text(text, encoding="utf-8")
     return out
+
+
+def write_capacity_report(results: list[CapacityResult], path: str | Path) -> Path:
+    """Render *results* and write the capacity report to *path*.
+
+    The nightly ``load-capacity`` job sets ``HARNESS_CAPACITY_REPORT`` so this
+    file can be uploaded as a downloadable artifact — the ramp curve + knee per
+    scenario, which otherwise lives only in the job log.
+    """
+    return _write_report(render_capacity_report(results), path)
+
+
+def render_soak_report(results: list[LoadResult]) -> str:
+    """A human/artifact-readable RSS/FD trend table per soak scenario (T313).
+
+    Turns the sampled ``LoadResult.resources`` into the numbers the pass/fail
+    soak assertions hide: start/peak/end RSS (MB), FD counts, and the growth
+    deltas that are the actual leak signal. An unsampled scenario is shown as
+    ``not sampled`` rather than fabricated zeros.
+    """
+    lines = [
+        "Soak RSS/FD trend (per scenario) — growth = peak - start",
+        f"{'scenario':<9}{'rssMB0':>8}{'rssMBpk':>9}{'rssMBΔ':>8}"
+        f"{'fd0':>6}{'fdPk':>6}{'fdΔ':>5}{'n':>5}  title",
+    ]
+    for r in results:
+        res = r.resources
+        if res is None or not res.sampled:
+            lines.append(f"{r.scenario_id:<9}{'not sampled':>36}  {r.title}")
+            continue
+        lines.append(
+            f"{r.scenario_id:<9}{res.rss_start_mb:>8.1f}{res.rss_max_mb:>9.1f}"
+            f"{res.rss_growth_mb:>8.1f}{res.fd_start:>6}{res.fd_max:>6}"
+            f"{res.fd_growth:>5}{res.num_samples:>5}  {r.title}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def write_soak_report(results: list[LoadResult], path: str | Path) -> Path:
+    """Render the soak RSS/FD trend and write it to *path*.
+
+    The nightly ``load-soak`` job sets ``HARNESS_SOAK_REPORT`` so the RSS/FD
+    numbers are uploaded as a downloadable artifact instead of being hidden
+    behind a green pass/fail.
+    """
+    return _write_report(render_soak_report(results), path)
 
 
 @contextlib.contextmanager

--- a/src/tests/load/test_capacity_logic.py
+++ b/src/tests/load/test_capacity_logic.py
@@ -17,6 +17,7 @@ from ..load.runner import (
     LoadResult,
     _breach_reasons,
     render_capacity_report,
+    write_capacity_report,
 )
 from ..load.scenarios import (
     SCENARIOS_BY_ID,
@@ -188,6 +189,24 @@ def test_report_flags_missing_breakpoint():
 def test_found_breakpoint_property():
     assert _capacity_result(breaks_at=2000).found_breakpoint is True
     assert _capacity_result(breaks_at=None).found_breakpoint is False
+
+
+def test_write_capacity_report_writes_rendered_report(tmp_path):
+    """The artifact writer persists exactly what the renderer produces."""
+    results = [_capacity_result(breaks_at=2000)]
+    out = write_capacity_report(results, tmp_path / "capacity-report.txt")
+    assert out.read_text() == render_capacity_report(results)
+    assert "KNEE" in out.read_text()
+    assert "C1" in out.read_text()
+
+
+def test_write_capacity_report_creates_parent_dirs(tmp_path):
+    """A nested artifact path is created rather than raising FileNotFoundError."""
+    out = write_capacity_report(
+        [_capacity_result(breaks_at=2000)], tmp_path / "nested" / "dir" / "report.txt"
+    )
+    assert out.is_file()
+    assert out.parent == tmp_path / "nested" / "dir"
 
 
 def test_capacity_scenarios_are_well_formed():

--- a/src/tests/load/test_capacity_logic.py
+++ b/src/tests/load/test_capacity_logic.py
@@ -195,9 +195,10 @@ def test_write_capacity_report_writes_rendered_report(tmp_path):
     """The artifact writer persists exactly what the renderer produces."""
     results = [_capacity_result(breaks_at=2000)]
     out = write_capacity_report(results, tmp_path / "capacity-report.txt")
-    assert out.read_text() == render_capacity_report(results)
-    assert "KNEE" in out.read_text()
-    assert "C1" in out.read_text()
+    written = out.read_text(encoding="utf-8")
+    assert written == render_capacity_report(results)
+    assert "KNEE" in written
+    assert "C1" in written
 
 
 def test_write_capacity_report_creates_parent_dirs(tmp_path):

--- a/src/tests/load/test_load_capacity.py
+++ b/src/tests/load/test_load_capacity.py
@@ -20,6 +20,7 @@ for why locust must not be imported in-process). Run via
 from __future__ import annotations
 
 import importlib.util
+import os
 
 import pytest
 
@@ -29,7 +30,11 @@ if importlib.util.find_spec("locust") is None:
 pytest.importorskip("fastapi_identity_model")
 pytest.importorskip("uvicorn")
 
-from ..load.runner import render_capacity_report, run_capacity_profile
+from ..load.runner import (
+    render_capacity_report,
+    run_capacity_profile,
+    write_capacity_report,
+)
 from ..load.scenarios import Profile, profile_scenarios
 
 
@@ -37,15 +42,24 @@ pytestmark = pytest.mark.integration
 
 _CAPACITY_IDS = [s.id for s in profile_scenarios(Profile.CAPACITY)]
 
+# Where the fixture writes the rendered ramp curve + knee so CI can upload it as
+# an artifact. Defaults to the repo/cwd so a local run also leaves a readable
+# report (gitignored); the nightly job overrides it to the artifact path.
+_REPORT_PATH = os.environ.get("HARNESS_CAPACITY_REPORT", "capacity-report.txt")
+
 
 @pytest.fixture(scope="module")
 def capacity_results():
     """Run the CAPACITY profile once; share the per-scenario ramp results.
 
     Each ramp boots its own RS and stops at the first rung that breaches SLO, so
-    a saturating single worker knees within a few rungs — bounded run time.
+    a saturating single worker knees within a few rungs — bounded run time. The
+    rendered report is written to ``_REPORT_PATH`` before the assertions run, so
+    the downloadable artifact exists even when a later assertion fails.
     """
-    return {r.scenario_id: r for r in run_capacity_profile(Profile.CAPACITY)}
+    results = {r.scenario_id: r for r in run_capacity_profile(Profile.CAPACITY)}
+    write_capacity_report(list(results.values()), _REPORT_PATH)
+    return results
 
 
 def test_every_capacity_scenario_ran(capacity_results):

--- a/src/tests/load/test_load_nightly.py
+++ b/src/tests/load/test_load_nightly.py
@@ -16,6 +16,7 @@ this process (gevent ``monkey.patch_all`` would deadlock the in-process mock OP)
 from __future__ import annotations
 
 import importlib.util
+import os
 
 import pytest
 
@@ -25,7 +26,7 @@ if importlib.util.find_spec("locust") is None:
 pytest.importorskip("fastapi_identity_model")
 pytest.importorskip("uvicorn")
 
-from ..load.runner import evaluate_gates, run_profile
+from ..load.runner import evaluate_gates, run_profile, write_soak_report
 from ..load.scenarios import Profile, profile_scenarios
 
 
@@ -33,15 +34,24 @@ pytestmark = pytest.mark.integration
 
 _NIGHTLY_IDS = [s.id for s in profile_scenarios(Profile.NIGHTLY)]
 
+# Where the fixture writes the RSS/FD trend table so CI can upload it as an
+# artifact (the numbers the pass/fail assertions otherwise hide). The nightly
+# job overrides it to the artifact path; local runs leave a gitignored file.
+_SOAK_REPORT_PATH = os.environ.get("HARNESS_SOAK_REPORT", "soak-report.txt")
+
 
 @pytest.fixture(scope="module")
 def nightly_results():
     """Run the NIGHTLY soak profile once; share the per-scenario results.
 
     Each scenario boots its own mock OP + RS. S4 alone runs past the 60s cache
-    TTL, so this fixture takes minutes — module scope so it runs once.
+    TTL, so this fixture takes minutes — module scope so it runs once. The RSS/FD
+    trend is written to ``_SOAK_REPORT_PATH`` before the assertions run, so the
+    artifact exists even when a later assertion fails.
     """
-    return {result.scenario_id: result for result in run_profile(Profile.NIGHTLY)}
+    results = {result.scenario_id: result for result in run_profile(Profile.NIGHTLY)}
+    write_soak_report(list(results.values()), _SOAK_REPORT_PATH)
+    return results
 
 
 def test_every_nightly_scenario_ran(nightly_results):

--- a/src/tests/load/test_resource_sampler.py
+++ b/src/tests/load/test_resource_sampler.py
@@ -18,7 +18,12 @@ from ..load.resource_sampler import (
     ResourceSampler,
     sample_process_tree,
 )
-from ..load.runner import _maybe_sampler
+from ..load.runner import (
+    LoadResult,
+    _maybe_sampler,
+    render_soak_report,
+    write_soak_report,
+)
 
 
 pytestmark = pytest.mark.unit
@@ -123,3 +128,56 @@ def test_maybe_sampler_with_pid_yields_live_sampler():
     with _maybe_sampler(os.getpid()) as sampler:
         assert isinstance(sampler, ResourceSampler)
     assert sampler.result.sampled is True
+
+
+def _load_result(scenario_id: str, resources: ResourceSample | None) -> LoadResult:
+    """A minimal LoadResult carrying the fields the soak report reads."""
+    return LoadResult(
+        scenario_id=scenario_id,
+        title=f"{scenario_id} soak",
+        num_requests=100,
+        num_failures=0,
+        rps=100.0,
+        p50_ms=1.0,
+        p95_ms=2.0,
+        p99_ms=3.0,
+        p999_ms=4.0,
+        server_errors=0,
+        steady_state=True,
+        resources=resources,
+    )
+
+
+def test_render_soak_report_shows_rss_fd_numbers_and_growth():
+    """A sampled scenario's RSS/FD extremes and growth appear in the report."""
+    sample = ResourceSample(
+        rss_start_mb=120.0,
+        rss_max_mb=155.0,
+        rss_end_mb=140.0,
+        fd_start=30,
+        fd_max=41,
+        fd_end=36,
+        num_samples=8,
+    )
+    report = render_soak_report([_load_result("S7", sample)])
+    assert "S7" in report
+    assert "120.0" in report  # rss start
+    assert "155.0" in report  # rss peak
+    assert "35.0" in report  # rss growth (155 - 120)
+    assert "11" in report  # fd growth (41 - 30); "S7" carries no stray "11"
+
+
+def test_render_soak_report_marks_unsampled_scenarios():
+    """An unsampled scenario is labelled, not fabricated as zero growth."""
+    report = render_soak_report([_load_result("S12", None)])
+    assert "S12" in report
+    assert "not sampled" in report
+
+
+def test_write_soak_report_persists_rendered_table(tmp_path):
+    """The writer persists exactly the rendered soak table."""
+    results = [_load_result("S4", ResourceSample(90.0, 92.0, 91.0, 20, 21, 20, 5))]
+    out = write_soak_report(results, tmp_path / "soak-report.txt")
+    written = out.read_text(encoding="utf-8")
+    assert written == render_soak_report(results)
+    assert "S4" in written


### PR DESCRIPTION
## TH-4 T316 (re-scoped to free runners): nightly load-result artifacts

Stacked on #527 → #526. **Merge order: #526 → #527 → this.**

Owner decision (2026-08-16): **no paid larger runner.** T316's original premise
was "provision `ubuntu-latest-8-cores` to raise the co-located ceiling" — dropped.
This re-scopes the capacity/soak nightly to the **free** GitHub-hosted runner and
makes its results **downloadable and viewable** instead of buried in job logs.

### What

- **Capacity-report artifact.** `write_capacity_report` renders the ramp curve +
  knee to a file; the `load-capacity` fixture writes it (before the assertions,
  so it survives a failing assert); the nightly job uploads it as a
  `capacity-report` artifact (`if: always()`).
- **Soak RSS/FD report artifact.** `render_soak_report` / `write_soak_report` emit
  the per-scenario start/peak/end RSS (MB) + FD counts + growth deltas that the
  pass/fail soak assertions otherwise hide; the `load-soak` fixture writes it and
  the nightly job uploads a `soak-report` artifact. Now the leak numbers behind
  T313's green tests are actually inspectable.
- **Corrected the runner framing.** This is a **public** repo, so `ubuntu-latest`
  is already **4-vCPU/16GB** free — not the "2-vCPU" the comments claimed. Dropped
  every "provision a larger runner / `ubuntu-latest-8-cores` / T316" reference in
  `nightly.yml` and the load README; the co-located knee stays **directional**
  (a true isolated ceiling needs a deployed-target lab, not a bigger CI box).
- **UTF-8 report writes** — both reports carry non-ASCII glyphs (`—`, `Δ`), so the
  shared writer forces UTF-8 rather than the locale default (POSIX/ASCII-safe).

### Deliberately NOT included

- **No perf-regression gate.** Co-located knees on a shared free runner are noisy
  run-to-run; a strict gate would flake (worse than none — mechanical-gate
  discipline). The artifacts are the prerequisite for a sane margin-based gate.

### Tests

- 5 new unit tests (writer persistence + parent-dir creation for both reports;
  soak-report renders numbers/growth and marks unsampled scenarios).
- Real integration proof (local): `make test-harness-load-capacity` (7 passed)
  and `make test-harness-load-nightly` (14 passed) each write their report;
  sample knees ~1310/1333 rps, soak RSS/FD bounded.
- `make lint` green (ruff + pyrefly + coverage ≥80%).

### Remaining TH-4

- **T314** — activate the dormant `runner.GATES` from a baseline (next in-session).
- **T313b** — `LoadPool.refresh()` for >300s soaks (deferred; nothing exceeds ~270s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
