### PR TITLE
test(harness): harden token-correctness matrix to prove the right controls

### DIFF
--- a/src/tests/harness/corpus.py
+++ b/src/tests/harness/corpus.py
@@ -22,10 +22,15 @@ with its real key) reuse the committed expired tokens + cross-provider
 
 from __future__ import annotations
 
+import base64
 from dataclasses import dataclass
+import hashlib
+import hmac
+import json
 import time
 from typing import TYPE_CHECKING, Any
 
+from cryptography.hazmat.primitives import serialization
 import jwt
 
 
@@ -34,6 +39,40 @@ if TYPE_CHECKING:
 
 
 CORPUS_AUDIENCE = "mock-api"
+
+
+def _b64url(raw: bytes) -> bytes:
+    """Base64url without padding — the JWS segment encoding."""
+    return base64.urlsafe_b64encode(raw).rstrip(b"=")
+
+
+def _forge_alg_confusion(mock_op: MockOP, claims: dict) -> str:
+    """Forge the classic RS256->HS256 algorithm-confusion token.
+
+    HMAC-SHA256 the token using the victim's RSA **public key** bytes as the
+    shared secret, with a header ``kid`` naming that RSA key. This is the real
+    attack: an RS that honoured the token-header ``alg`` would HMAC-"verify" it
+    with the public key it already holds and accept a forgery. A correct RS pins
+    the algorithm to the JWK's key type and rejects it.
+
+    The secret MUST be the public key (not an arbitrary string): an arbitrary
+    secret is rejected even by a *vulnerable* RS (the HMAC simply won't match the
+    public-key bytes), so it would not actually exercise the algorithm allow-list.
+    PyJWT's high-level ``encode`` refuses an asymmetric HMAC key, so the JWS is
+    hand-rolled.
+    """
+    pub_pem = mock_op.primary_key.private_key.public_key().public_bytes(
+        serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    header = _b64url(
+        json.dumps(
+            {"alg": "HS256", "typ": "JWT", "kid": mock_op.primary_key.kid}
+        ).encode()
+    )
+    payload = _b64url(json.dumps(claims).encode())
+    signing_input = header + b"." + payload
+    signature = _b64url(hmac.new(pub_pem, signing_input, hashlib.sha256).digest())
+    return (signing_input + b"." + signature).decode()
 
 
 @dataclass(frozen=True)
@@ -174,21 +213,29 @@ def build_corpus(mock_op: MockOP) -> dict[str, ForgedToken]:
     )
     add(
         "wrong_alg",
-        jwt.encode(
-            _base_claims(mock_op, now),
-            # >= 32 bytes to avoid PyJWT's InsecureKeyLengthWarning; the exact
-            # secret is irrelevant — the point is HS256 against an RSA kid.
-            "harness-hmac-confusion-secret-key-32b",
-            algorithm="HS256",
-            headers={"kid": mock_op.primary_key.kid},
-        ),
-        "HS256 signed while claiming an RSA kid (alg-confusion)",
+        # The REAL RS256->HS256 confusion: HMAC'd with the RSA public key as the
+        # secret (not an arbitrary string, which a vulnerable RS would also
+        # reject), so only the algorithm allow-list stands between accept and
+        # reject. See _forge_alg_confusion.
+        _forge_alg_confusion(mock_op, _base_claims(mock_op, now)),
+        "HS256 forged with the RSA public key as the HMAC secret (real "
+        "alg-confusion against an RSA kid)",
         rejects=True,
     )
     add(
         "alg_none",
-        jwt.encode(_base_claims(mock_op, now), "", algorithm="none"),
-        "unsigned token with alg:none",
+        # kid names the single published RSA key so JWKS resolution is
+        # unambiguous — the ONLY control that can then reject this token is the
+        # RFC 8725 alg:none defence. Without a kid it would be rejected earlier
+        # by no-kid/multiple-keys ambiguity, masking whether the none-check runs.
+        jwt.encode(
+            _base_claims(mock_op, now),
+            "",
+            algorithm="none",
+            headers={"kid": mock_op.primary_key.kid},
+        ),
+        "unsigned alg:none token with a resolvable kid (isolates the RFC 8725 "
+        "none-defence as the sole rejection cause)",
         rejects=True,
     )
     return {entry.name: entry for entry in entries}

--- a/src/tests/integration/test_correctness_matrix.py
+++ b/src/tests/integration/test_correctness_matrix.py
@@ -22,10 +22,14 @@ Run via ``make test-harness-matrix`` (Docker node-oidc + ``--all-packages`` so
 importorskips cleanly.
 """
 
+import base64
 from collections import namedtuple
+import hashlib
+import hmac
 import time
 from urllib.parse import urlparse
 
+from cryptography.hazmat.primitives import serialization
 import httpx
 import jwt
 import pytest
@@ -169,14 +173,108 @@ def test_f02_cnf_bound_accepted_today(mock_matrix):
 
 
 def test_nothing_silently_accepted(mock_matrix):
-    """Every class outside the accepted set is rejected (never a silent 200)."""
+    """Every class outside the accepted set is rejected with a CLIENT error.
+
+    A negative token must draw a 401/403, never a 200 (silent accept) and never
+    a 5xx: a 500/503 also satisfies "not 200" but means the middleware faulted
+    rather than cleanly rejecting, so ``!= 200`` alone would mask a server-error
+    regression. Asserting the status is exactly a client rejection closes that.
+    """
     for name, forged in mock_matrix.corpus.items():
         if name in ACCEPTED_200_CLASSES:
             continue
         response = _get_protected(mock_matrix.base_url, forged.jwt)
-        assert response.status_code != httpx.codes.OK, (
-            f"class {name!r} was silently accepted (200)"
+        assert response.status_code in (
+            httpx.codes.UNAUTHORIZED,
+            httpx.codes.FORBIDDEN,
+        ), f"class {name!r} drew {response.status_code} (want 401/403, not 200/5xx)"
+
+
+def test_cross_issuer_token_from_a_different_issuer_is_rejected(mock_matrix):
+    """A token 100% valid for a DIFFERENT issuer is rejected by this RS.
+
+    Stands up a second, fully independent mock OP (issuer B — its own keys,
+    discovery and JWKS) and mints a valid access token in B's world. Presented to
+    an RS trusting B the token is accepted (200), so it is genuinely valid; but
+    presented to this suite's RS (trusting issuer A) it is rejected (401). The
+    rejection is therefore specifically cross-issuer: A's JWKS holds no key that
+    verifies B's signature and B's ``iss`` does not match A's discovery issuer.
+
+    This is the real mix-up that the forged ``wrong_iss`` class (A's own key with
+    the ``iss`` claim mutated) cannot exercise — there, no second issuer exists.
+    """
+    with (
+        serve_mock_op() as op_b,
+        boot_rs(
+            discovery_url=op_b.discovery_url,
+            audience=CORPUS_AUDIENCE,
+            require_scope="read",
+        ) as rs_b,
+    ):
+        b_token = op_b.mint_access_token(scopes="read")["access_token"]
+        accepted_by_b = _get_protected(rs_b, b_token).status_code
+        rejected_by_a = _get_protected(mock_matrix.base_url, b_token)
+
+    assert accepted_by_b == httpx.codes.OK, "token is not actually valid for issuer B"
+    assert rejected_by_a.status_code == httpx.codes.UNAUTHORIZED
+    assert rejected_by_a.json() == GENERIC_401_BODY
+
+
+def test_alg_none_and_confusion_reject_via_their_intended_control(mock_matrix):
+    """The two alg negatives reject via the RIGHT control, not a coincidental one.
+
+    Both classes previously passed for partly the wrong reason (``alg_none`` via
+    no-kid/multiple-key ambiguity rather than the none-defence; ``wrong_alg`` via
+    an arbitrary HMAC secret that a *vulnerable* RS would also reject). This pins
+    the isolation so the tests cannot silently rot back into vacuous passes:
+
+    * ``alg_none`` carries a ``kid`` that resolves to a real published key, so the
+      sole remaining rejection path is the RFC 8725 ``alg:none`` defence.
+    * ``wrong_alg`` is HMAC'd with the RSA **public key** as the secret and claims
+      the RSA ``kid``, so only the algorithm allow-list can reject it — verified
+      by recomputing the HMAC over the public key and matching the signature.
+    """
+    op = mock_matrix.op
+    published_kids = {op.primary_key.kid, op.ec_key.kid}
+
+    none_tok = mock_matrix.corpus["alg_none"].jwt
+    none_hdr = jwt.get_unverified_header(none_tok)
+    assert none_hdr["alg"] == "none"
+    assert (
+        none_hdr.get("kid") in published_kids
+    )  # resolvable → none-defence is sole cause
+
+    conf_tok = mock_matrix.corpus["wrong_alg"].jwt
+    conf_hdr = jwt.get_unverified_header(conf_tok)
+    assert conf_hdr["alg"] == "HS256"
+    assert conf_hdr.get("kid") == op.primary_key.kid  # HS256 claiming an RSA kid
+    pub_pem = op.primary_key.private_key.public_key().public_bytes(
+        serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    header_b64, payload_b64, sig_b64 = conf_tok.split(".")
+    expected_sig = (
+        base64.urlsafe_b64encode(
+            hmac.new(
+                pub_pem, f"{header_b64}.{payload_b64}".encode(), hashlib.sha256
+            ).digest()
         )
+        .rstrip(b"=")
+        .decode()
+    )
+    assert sig_b64 == expected_sig, (
+        "wrong_alg is not HMAC'd with the RSA public key — not the real "
+        "alg-confusion attack (an arbitrary secret would prove nothing)"
+    )
+
+    # Both are still rejected by the booted RS.
+    assert (
+        _get_protected(mock_matrix.base_url, none_tok).status_code
+        == httpx.codes.UNAUTHORIZED
+    )
+    assert (
+        _get_protected(mock_matrix.base_url, conf_tok).status_code
+        == httpx.codes.UNAUTHORIZED
+    )
 
 
 def _mint_scopeless_access_token(op) -> str:


### PR DESCRIPTION
## Harden the token-correctness matrix to prove the *right* controls

An adversarial audit of the token-validation harness (three independent reads +
an empirical probe against a booted RS) found the **runtime is sound** but the
**committed tests proved less than they appeared** — several negatives rejected
for a *coincidental* reason, so a test could stay green even if the control it
claims to prove were broken. This makes the suite actually prove it.

### Verified first (empirically, against a real booted RS)

A probe presented the full corpus plus hand-crafted adversarial tokens to a real
uvicorn RS. Every class behaved correctly, including the two that mattered most:
a genuine **cross-issuer** token (100% valid for a different issuer) was rejected,
and the **real RS256→HS256 confusion** (HMAC'd with the victim's RSA public key)
was rejected. So the middleware is fine — the gap was in the *proof*.

### Fixes

1. **`alg_none` was hollow.** Built with no `kid` against a 2-key JWKS, it was
   rejected by no-kid/multiple-key *ambiguity* — **before** reaching the RFC 8725
   none-defence. Delete the none-check and it would still pass. Fixed: give it a
   resolvable `kid` so the none-defence is the *sole* rejection cause.
2. **`wrong_alg` was over-determined.** Signed with an arbitrary HMAC secret, so a
   *vulnerable* RS would also reject it (the HMAC just wouldn't match). Fixed: it's
   now the real attack — HMAC'd with the RSA **public key** as the secret — so only
   the algorithm allow-list stands between accept and reject.
3. **No true cross-issuer test.** `wrong_iss` was A's own key with the `iss` claim
   mutated — no second issuer. Added `test_cross_issuer_token_from_a_different_issuer_is_rejected`:
   a token valid for an independent mock issuer B is **accepted by an RS trusting B**
   (proving it's genuinely valid) and **rejected by the RS trusting A** — so the
   rejection is specifically cross-issuer, not incidental.
4. **Isolation lock.** `test_alg_none_and_confusion_reject_via_their_intended_control`
   asserts each alg negative is constructed to reject via its intended control
   (kid-resolvable none; HMAC-over-public-key confusion), so the tests can't
   silently rot back. **Verified the lock has teeth:** the old weak constructions
   fail its assertions.
5. **`test_nothing_silently_accepted` accepted 5xx.** `status != 200` passes on a
   500/503 (middleware fault), masking a server-error regression. Tightened to
   `in (401, 403)` — a negative must draw a *client* rejection.

### Not included (deferred, tracked separately)

- A **real two-IdP** cross-issuer test in CI (node-oidc + Keycloak in one job).
- **`allowed_issuers` pinning** (RT-SPOOF-F1) coverage.

### Tests

All 20 Group A matrix tests pass (self-contained, mock-OP-backed, no Docker);
`make lint` green. Group B (real node-oidc) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
