### PR TITLE
test(integration): real cross-issuer proof with tokens from both Docker IdPs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,50 @@ jobs:
         if: always()
         run: docker compose -f test-fixtures/keycloak/docker-compose.yml down
 
+  integration-tests-cross-issuer:
+    # Both Docker IdPs up side by side so a REAL token minted by one is rejected
+    # by an RS trusting the other (true cross-issuer, not a forged mock). The
+    # single-provider jobs above can't do this — they run one IdP each.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: 3.13
+
+      - name: Cache uv dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: make ci-setup
+
+      - name: Start node-oidc-provider fixture
+        run: docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml up -d --build --wait
+
+      - name: Start Keycloak fixture
+        run: docker compose -f test-fixtures/keycloak/docker-compose.yml up -d --build --wait
+
+      - name: Cross-issuer real-token rejection (node-oidc <-> Keycloak)
+        run: uv run --all-packages pytest src/tests/integration/test_cross_issuer_real_idps.py -m integration -v
+
+      - name: Tear down Keycloak fixture
+        if: always()
+        run: docker compose -f test-fixtures/keycloak/docker-compose.yml down
+
+      - name: Tear down node-oidc-provider fixture
+        if: always()
+        run: docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml down
+
   example-tests:
     if: inputs.run-example-tests
     runs-on: ubuntu-latest
@@ -397,7 +441,7 @@ jobs:
 
   ci-complete:
     if: always()
-    needs: [lint, unit-tests, fastapi-tests, integration-tests-ory, integration-tests-descope, integration-tests-node-oidc, integration-tests-keycloak, example-tests, build, security-gate, load-smoke]
+    needs: [lint, unit-tests, fastapi-tests, integration-tests-ory, integration-tests-descope, integration-tests-node-oidc, integration-tests-keycloak, integration-tests-cross-issuer, example-tests, build, security-gate, load-smoke]
     runs-on: ubuntu-latest
     steps:
       - name: Check CI results
@@ -410,6 +454,7 @@ jobs:
             "${{ needs.integration-tests-descope.result }}" \
             "${{ needs.integration-tests-node-oidc.result }}" \
             "${{ needs.integration-tests-keycloak.result }}" \
+            "${{ needs.integration-tests-cross-issuer.result }}" \
             "${{ needs.example-tests.result }}" \
             "${{ needs.build.result }}" \
             "${{ needs.security-gate.result }}" \

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,18 @@ test-harness-matrix: ## Run the TH-1.3 token correctness matrix (mock-OP forged 
 		(docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml down && exit 1)
 	docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml down
 
+.PHONY: test-harness-cross-issuer
+test-harness-cross-issuer: ## Real cross-issuer proof: a token from one Docker IdP (node-oidc/Keycloak) is rejected by an RS trusting the other
+	@echo "Starting node-oidc + Keycloak fixtures side by side..."
+	docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml up -d --build --wait
+	docker compose -f test-fixtures/keycloak/docker-compose.yml up -d --build --wait
+	@echo "Cross-presenting real tokens across issuers through the booted RS..."
+	uv run --all-packages pytest src/tests/integration/test_cross_issuer_real_idps.py -m integration -v || \
+		(docker compose -f test-fixtures/keycloak/docker-compose.yml down; \
+		docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml down; exit 1)
+	docker compose -f test-fixtures/keycloak/docker-compose.yml down
+	docker compose -f test-fixtures/node-oidc-provider/docker-compose.yml down
+
 .PHONY: test-harness-load
 test-harness-load: ## Run the TH-1.5 CI-short load profile (real Locust vs the booted RS + mock OP)
 	@echo "Driving the CI-short Locust profile through the booted RS (real HTTP)..."

--- a/src/tests/integration/test_cross_issuer_real_idps.py
+++ b/src/tests/integration/test_cross_issuer_real_idps.py
@@ -1,0 +1,171 @@
+"""Real cross-issuer proof against the bundled Docker IdPs (epic #462).
+
+The mock-OP matrix proves cross-issuer rejection deterministically in one process
+(``test_correctness_matrix.test_cross_issuer_...``). This proves the same property
+with **real tokens from two real IdPs running side by side** — the bundled
+node-oidc-provider (:9010) and Keycloak (:8080) Docker fixtures.
+
+For each provider it mints a genuine client-credentials access token, then:
+
+* the provider's OWN token reaches ``/protected`` on an RS trusting that provider
+  (200) — proving the token is really valid, so a cross rejection is not just a
+  malformed-token artefact; and
+* every OTHER provider's token is rejected by that same RS (401) — the real
+  cross-issuer / mix-up: a validly-signed token from issuer A must not be honoured
+  by a resource server that trusts issuer B (A's key/kid is absent from B's JWKS
+  and A's ``iss`` does not match B's discovery issuer).
+
+Needs BOTH fixtures reachable; skips cleanly when either is down (so it no-ops in
+a single-provider env). Run via ``make test-harness-cross-issuer`` or the
+``integration-tests-cross-issuer`` CI job (which starts both fixtures).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+import jwt
+import pytest
+
+from py_identity_model import (
+    ClientCredentialsTokenRequest,
+    DiscoveryDocumentRequest,
+    get_discovery_document,
+    request_client_credentials_token,
+)
+
+from ..harness.rs_server import boot_rs
+
+
+pytest.importorskip("fastapi_identity_model")
+pytest.importorskip("uvicorn")
+
+pytestmark = pytest.mark.integration
+
+# src/tests/integration/test_*.py -> parents[3] is the repo root (holds .env.*).
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+@dataclass(frozen=True)
+class ProviderConfig:
+    """The client-credentials config for one bundled Docker IdP."""
+
+    name: str
+    env_file: str
+
+
+# The two IdPs that run as Docker fixtures in this repo (remote providers —
+# Descope/Ory — are not brought up here, so they are out of scope for a
+# side-by-side cross-issuer run).
+PROVIDERS = (
+    ProviderConfig(name="node-oidc", env_file=".env.node-oidc"),
+    ProviderConfig(name="keycloak", env_file=".env.keycloak"),
+)
+
+
+def _read_env(env_file: str) -> dict[str, str]:
+    """Parse a committed ``.env.<provider>`` fixture file into a dict."""
+    values: dict[str, str] = {}
+    for raw in (_REPO_ROOT / env_file).read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        values[key.strip()] = val.strip()
+    return values
+
+
+def _mint_real_token(cfg: ProviderConfig) -> str:
+    """Mint a genuine client-credentials access token from *cfg*'s live IdP.
+
+    Skips (not fails) when the fixture is unreachable, so the module no-ops in a
+    single-provider environment rather than reporting a spurious failure.
+    """
+    env = _read_env(cfg.env_file)
+    disco = get_discovery_document(
+        DiscoveryDocumentRequest(address=env["TEST_DISCO_ADDRESS"])
+    )
+    if not disco.is_successful or not disco.token_endpoint:
+        pytest.skip(f"{cfg.name} discovery unreachable: {disco.error}")
+    token_response = request_client_credentials_token(
+        ClientCredentialsTokenRequest(
+            client_id=env["TEST_CLIENT_ID"],
+            client_secret=env["TEST_CLIENT_SECRET"],
+            address=disco.token_endpoint,
+            scope=env.get("TEST_SCOPE") or "openid",
+        )
+    )
+    if not token_response.is_successful or token_response.token is None:
+        pytest.skip(f"{cfg.name} token mint failed: {token_response.error}")
+    access_token = token_response.token.get("access_token", "")
+    assert access_token, f"{cfg.name} returned no access_token"
+    return access_token
+
+
+def _audience_and_scope(token: str) -> tuple[str | None, str | None]:
+    """Extract a usable RS audience + required scope from a real access token.
+
+    The RS is configured from the token itself (not a hardcoded per-provider
+    value) so a positive control accepts the token on its own merits. ``aud`` may
+    be a list (pyjwt accepts the configured audience if it is a member), so the
+    first entry is used; the first granted scope drives ``require_scope``.
+    """
+    claims = jwt.decode(token, options={"verify_signature": False})
+    aud = claims.get("aud")
+    if isinstance(aud, (list, tuple)):
+        aud = aud[0] if aud else None
+    raw_scope = claims.get("scope") or claims.get("scp") or ""
+    scopes = raw_scope.split() if isinstance(raw_scope, str) else list(raw_scope)
+    return aud, (scopes[0] if scopes else None)
+
+
+def _get_protected(base_url: str, token: str) -> int:
+    return httpx.get(
+        f"{base_url}/protected",
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=10.0,
+    ).status_code
+
+
+@pytest.fixture(scope="module")
+def real_idp_tokens() -> dict[str, str]:
+    """A real client-credentials access token from every bundled Docker IdP."""
+    return {cfg.name: _mint_real_token(cfg) for cfg in PROVIDERS}
+
+
+def test_real_cross_issuer_tokens_are_rejected(real_idp_tokens):
+    """A real token from each Docker IdP is accepted only by its own issuer's RS.
+
+    For every provider: boot an RS trusting that provider (audience + scope taken
+    from the provider's own minted token), confirm the provider's token is
+    accepted (200 — genuinely valid), then confirm every OTHER provider's real
+    token is rejected (401 — the cross-issuer negative).
+    """
+    for owner, token in real_idp_tokens.items():
+        env = _read_env(next(p.env_file for p in PROVIDERS if p.name == owner))
+        audience, scope = _audience_and_scope(token)
+        assert audience, f"{owner} token carried no audience to bind the RS to"
+
+        boot_kwargs = {
+            "discovery_url": env["TEST_DISCO_ADDRESS"],
+            "audience": audience,
+        }
+        if scope:
+            boot_kwargs["require_scope"] = scope
+
+        with boot_rs(**boot_kwargs) as rs_base:
+            own = _get_protected(rs_base, token)
+            assert own == httpx.codes.OK, (
+                f"{owner}'s own real token was not accepted by its own RS "
+                f"(got {own}) — cannot trust the cross-issuer negative"
+            )
+            for other, other_token in real_idp_tokens.items():
+                if other == owner:
+                    continue
+                cross = _get_protected(rs_base, other_token)
+                assert cross == httpx.codes.UNAUTHORIZED, (
+                    f"RS trusting {owner!r} accepted {other!r}'s real token "
+                    f"(got {cross}, want 401) — CROSS-ISSUER LEAK"
+                )


### PR DESCRIPTION
## Real cross-issuer proof with tokens from both Docker IdPs

Closes the first deferred item from the harness audit: the mock-OP matrix proves
cross-issuer rejection deterministically in one process, but nothing proved it
with **real tokens from two real IdPs running side by side**. This does.

### What

`test_cross_issuer_real_idps.py` mints a genuine client-credentials token from
**each** bundled Docker fixture — node-oidc-provider (`:9010`) and Keycloak
(`:8080/realms/py-identity-model`) — and for each provider:

- boots an RS trusting that provider (audience + scope taken from the provider's
  own token) and confirms the provider's token is **accepted (200)** — proving
  the token is genuinely valid, so a cross rejection isn't a malformed-token
  artefact; then
- confirms every **other** provider's real token is **rejected (401)** — the real
  mix-up: a validly-signed token from issuer A is not honoured by an RS that
  trusts issuer B (A's kid/key is absent from B's JWKS and A's `iss` ≠ B's
  discovery issuer).

### Evidence (local run against both live fixtures)

```
node-oidc: iss=http://localhost:9010            aud=urn:test:api  scope=openid
keycloak:  iss=http://localhost:8080/realms/…    aud=account       scope=openid

RS trusts      node-oidc    keycloak     (token minted by ↓ column)
node-oidc            200         401
keycloak             401         200
```

### CI

New `integration-tests-cross-issuer` job stands up **both** fixtures (the
single-provider jobs run one IdP each and can't do this), runs the test under
`--all-packages`, and is added to the `ci-complete` gate. The test **skips
cleanly** when either IdP is unreachable, so it no-ops in the single-provider
jobs and only runs fully where both are up. `make test-harness-cross-issuer`
runs it locally (brings both fixtures up/down).

### Notes

- Stacked on #529 (`test/harden-token-correctness`). Merge order: #529 → this.
- The second deferred item — `allowed_issuers` pinning (RT-SPOOF-F1) coverage —
  is still open and independent of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
