### PR TITLE
test(integration): prove caching by upstream-fetch count, not wall-clock

### DIFF
--- a/src/tests/integration/test_token_validation.py
+++ b/src/tests/integration/test_token_validation.py
@@ -13,9 +13,13 @@ from py_identity_model.exceptions import (
     TokenExpiredException,
     TokenValidationException,
 )
+from py_identity_model.sync.token_validation import (
+    clear_discovery_cache,
+    clear_jwks_cache,
+)
 
 from .conftest import DEFAULT_VALIDATION_OPTIONS as DEFAULT_OPTIONS
-from .test_utils import _is_valid_jwt_format
+from .test_utils import _is_valid_jwt_format, count_upstream_fetches
 
 
 # JWT format: three dot-separated segments
@@ -90,8 +94,10 @@ def test_token_validation_with_invalid_config_throws_exception(
         )
 
 
-def test_cache_succeeds(test_config, client_credentials_token, require_https):
-    """Test caching using cached fixtures."""
+def test_cache_succeeds(
+    test_config, client_credentials_token, require_https, provider_caches_responses
+):
+    """JWKS is always cached; discovery is cached when the provider permits it."""
     assert client_credentials_token.token is not None
 
     validation_config = TokenValidationConfig(
@@ -101,15 +107,32 @@ def test_cache_succeeds(test_config, client_credentials_token, require_https):
         require_https=require_https,
     )
 
-    for _ in range(5):
-        validate_token(
-            jwt=client_credentials_token.token["access_token"],
-            disco_doc_address=test_config["TEST_DISCO_ADDRESS"],
-            token_validation_config=validation_config,
-        )
+    num_validations = 5
+    clear_discovery_cache()
+    clear_jwks_cache()
+    with count_upstream_fetches() as fetches:
+        for _ in range(num_validations):
+            validate_token(
+                jwt=client_credentials_token.token["access_token"],
+                disco_doc_address=test_config["TEST_DISCO_ADDRESS"],
+                token_validation_config=validation_config,
+            )
 
-    # Both discovery and JWKS use TTL-based dict caches — validated by
-    # performance (5 validations complete without 5 separate HTTP round-trips).
+    # Proof of caching (not timing). JWKS ignores Cache-Control: no-store
+    # (is_uncacheable_for_jwks) and is therefore always cached — a broken JWKS
+    # cache would refetch on every validation. Discovery honors no-store, so it
+    # is only cache-guaranteed when the provider's Cache-Control permits it
+    # (provider_caches_responses); against a no-store provider discovery
+    # re-fetches per validation by design.
+    assert fetches["jwks"] == 1, (
+        f"JWKS should be fetched exactly once across {num_validations} "
+        f"validations, got {fetches} — JWKS caching is not in effect"
+    )
+    if provider_caches_responses:
+        assert fetches["disco"] == 1, (
+            f"discovery should be fetched exactly once across {num_validations} "
+            f"validations when the provider permits caching, got {fetches}"
+        )
 
 
 def test_benchmark_validation(
@@ -129,30 +152,28 @@ def test_benchmark_validation(
         require_https=require_https,
     )
 
-    # Warm the lru_cache (discovery + JWKS) before benchmarking.
-    # The conftest fixtures fetch discovery/JWKS via get_discovery_document/get_jwks
-    # directly, but validate_token uses its own _get_disco_response/_get_jwks_response
-    # lru_cache wrappers — a separate cache that starts cold in each pytest-xdist worker.
-    # Without this warmup, the first iteration makes real HTTP requests that can hit
-    # Ory's rate limits (429 + 1s retry backoff), pushing the benchmark over budget.
-    validate_token(
-        jwt=client_credentials_token.token["access_token"],
-        disco_doc_address=test_config["TEST_DISCO_ADDRESS"],
-        token_validation_config=validation_config,
-    )
-
+    num_validations = 100
+    clear_discovery_cache()
+    clear_jwks_cache()
     start_time = datetime.datetime.now(tz=datetime.UTC)
-
-    for _ in range(100):
-        validate_token(
-            jwt=client_credentials_token.token["access_token"],
-            disco_doc_address=test_config["TEST_DISCO_ADDRESS"],
-            token_validation_config=validation_config,
-        )
+    with count_upstream_fetches() as fetches:
+        for _ in range(num_validations):
+            validate_token(
+                jwt=client_credentials_token.token["access_token"],
+                disco_doc_address=test_config["TEST_DISCO_ADDRESS"],
+                token_validation_config=validation_config,
+            )
     elapsed_time = datetime.datetime.now(tz=datetime.UTC) - start_time
-    print(elapsed_time)
-    # 100 token validations should complete in under 1 second with caching
-    assert elapsed_time.total_seconds() < 1
+    # Informational only — wall-clock is environment-dependent and is NOT the
+    # caching assertion (the fetch-count check below is).
+    print(f"{num_validations} validations in {elapsed_time}")
+
+    # Proof of caching: one discovery + one JWKS fetch serve the entire loop;
+    # the other validations are cache hits. A broken cache => one fetch each.
+    assert fetches == {"disco": 1, "jwks": 1}, (
+        f"expected exactly one discovery + one JWKS fetch across "
+        f"{num_validations} validations, got {fetches} — caching is not in effect"
+    )
 
 
 def test_claim_validation_function_succeeds(

--- a/src/tests/integration/test_token_validation_cache.py
+++ b/src/tests/integration/test_token_validation_cache.py
@@ -29,6 +29,7 @@ from py_identity_model.sync.token_validation import (
 from .conftest import DEFAULT_VALIDATION_OPTIONS as DEFAULT_OPTIONS
 from .test_utils import (
     _is_valid_jwt_format,
+    count_upstream_fetches,
     get_alternate_provider_expired_token,
 )
 
@@ -77,7 +78,11 @@ class TestMultipleTokensFromSameProvider:
     """Test that multiple tokens from the same provider work correctly."""
 
     def test_multiple_tokens_validation_succeeds(
-        self, test_config, token_endpoint, validation_config
+        self,
+        test_config,
+        token_endpoint,
+        validation_config,
+        provider_caches_responses,
     ):
         """
         Generate multiple tokens from the same provider and validate each one.
@@ -93,24 +98,40 @@ class TestMultipleTokensFromSameProvider:
         num_tokens = 3
         tokens = generate_tokens(test_config, token_endpoint, num_tokens)
 
-        # Validate each token (may be duplicates for some providers)
+        # Validate each token (may be duplicates for some providers). All tokens
+        # share the provider and one signing key, so the JWKS cache must serve
+        # every validation after the first from cache.
+        clear_discovery_cache()
+        clear_jwks_cache()
         validated_claims = []
-        for i, token in enumerate(tokens):
-            claims = validate_token(
-                jwt=token,
-                disco_doc_address=test_config["TEST_DISCO_ADDRESS"],
-                token_validation_config=validation_config,
-            )
-            assert claims is not None, f"Token {i + 1} validation failed"
-            validated_claims.append(claims)
+        with count_upstream_fetches() as fetches:
+            for i, token in enumerate(tokens):
+                claims = validate_token(
+                    jwt=token,
+                    disco_doc_address=test_config["TEST_DISCO_ADDRESS"],
+                    token_validation_config=validation_config,
+                )
+                assert claims is not None, f"Token {i + 1} validation failed"
+                validated_claims.append(claims)
 
         # If provider includes jti, verify uniqueness
         if "jti" in validated_claims[0]:
             jtis = [c["jti"] for c in validated_claims]
             assert len(set(jtis)) == num_tokens, "Each token should have unique jti"
 
-        # Caching is verified by performance — 3 validations complete
-        # without 3 separate discovery+JWKS HTTP round-trips.
+        # Caching proof (not timing). JWKS ignores no-store and is always cached,
+        # so a broken JWKS cache would refetch per validation. Discovery honors
+        # no-store, so it is only cache-guaranteed when the provider permits it
+        # (against a no-store provider discovery re-fetches by design).
+        assert fetches["jwks"] == 1, (
+            f"JWKS should be fetched exactly once across {num_tokens} "
+            f"validations, got {fetches} — JWKS caching is not in effect"
+        )
+        if provider_caches_responses:
+            assert fetches["disco"] == 1, (
+                f"discovery should be fetched exactly once across {num_tokens} "
+                f"validations when the provider permits caching, got {fetches}"
+            )
 
 
 @pytest.mark.usefixtures("clear_validation_caches")
@@ -212,37 +233,34 @@ class TestBenchmarkWithPreGeneratedTokens:
         num_unique_tokens = 5
         tokens = generate_tokens(test_config, token_endpoint, num_unique_tokens)
 
-        # Warm up the cache with one validation
-        validate_token(
-            jwt=tokens[0],
-            disco_doc_address=test_config["TEST_DISCO_ADDRESS"],
-            token_validation_config=validation_config,
-        )
-
-        # Now benchmark: validate each token multiple times
         validations_per_token = 20
         total_validations = num_unique_tokens * validations_per_token
 
+        clear_discovery_cache()
+        clear_jwks_cache()
         start_time = datetime.datetime.now(tz=datetime.UTC)
-
-        for _ in range(validations_per_token):
-            for token in tokens:
-                validate_token(
-                    jwt=token,
-                    disco_doc_address=test_config["TEST_DISCO_ADDRESS"],
-                    token_validation_config=validation_config,
-                )
-
+        with count_upstream_fetches() as fetches:
+            for _ in range(validations_per_token):
+                for token in tokens:
+                    validate_token(
+                        jwt=token,
+                        disco_doc_address=test_config["TEST_DISCO_ADDRESS"],
+                        token_validation_config=validation_config,
+                    )
         elapsed_time = datetime.datetime.now(tz=datetime.UTC) - start_time
+        # Informational only — timing is environment-dependent and is NOT the
+        # caching assertion (the fetch-count check below is).
         print(f"\n{total_validations} validations completed in {elapsed_time}")
         print(
             f"Average: {elapsed_time.total_seconds() / total_validations * 1000:.2f}ms per validation"
         )
 
-        # 100 validations should complete in under 1 second with caching
-        assert elapsed_time.total_seconds() < 1, (
-            f"Benchmark too slow: {elapsed_time.total_seconds():.2f}s for "
-            f"{total_validations} validations"
+        # Proof of caching: all num_unique_tokens tokens share one provider, so
+        # the whole loop drives exactly one discovery + one JWKS fetch. A broken
+        # cache would fetch on every validation.
+        assert fetches == {"disco": 1, "jwks": 1}, (
+            f"expected exactly one discovery + one JWKS fetch across "
+            f"{total_validations} validations, got {fetches} — caching is not in effect"
         )
 
     def test_benchmark_single_token_repeated(
@@ -265,33 +283,28 @@ class TestBenchmarkWithPreGeneratedTokens:
             )
         token = client_credentials_token.token["access_token"]
 
-        # Warm up
-        validate_token(
-            jwt=token,
-            disco_doc_address=test_config["TEST_DISCO_ADDRESS"],
-            token_validation_config=validation_config,
-        )
-
         num_validations = 100
+        clear_discovery_cache()
+        clear_jwks_cache()
         start_time = datetime.datetime.now(tz=datetime.UTC)
-
-        for _ in range(num_validations):
-            validate_token(
-                jwt=token,
-                disco_doc_address=test_config["TEST_DISCO_ADDRESS"],
-                token_validation_config=validation_config,
-            )
-
+        with count_upstream_fetches() as fetches:
+            for _ in range(num_validations):
+                validate_token(
+                    jwt=token,
+                    disco_doc_address=test_config["TEST_DISCO_ADDRESS"],
+                    token_validation_config=validation_config,
+                )
         elapsed_time = datetime.datetime.now(tz=datetime.UTC) - start_time
+        # Informational only — timing is environment-dependent and is NOT the
+        # caching assertion (the fetch-count check below is).
         print(f"\n{num_validations} validations of same token: {elapsed_time}")
         print(
             f"Average: {elapsed_time.total_seconds() / num_validations * 1000:.2f}ms per validation"
         )
 
-        # Single token repeated should be very fast due to full cache utilization
-        assert elapsed_time.total_seconds() < 1, (
-            f"Single token benchmark too slow: {elapsed_time.total_seconds():.2f}s"
+        # Proof of caching: the same token validated num_validations times drives
+        # exactly one discovery + one JWKS fetch; the rest are cache hits.
+        assert fetches == {"disco": 1, "jwks": 1}, (
+            f"expected exactly one discovery + one JWKS fetch across "
+            f"{num_validations} validations, got {fetches} — caching is not in effect"
         )
-
-        # Both discovery and JWKS use TTL-based dict caches — validated by
-        # performance (100 validations < 1s proves caching works)

--- a/src/tests/integration/test_utils.py
+++ b/src/tests/integration/test_utils.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 from pathlib import Path
 
@@ -6,6 +7,7 @@ from dotenv import dotenv_values, load_dotenv
 from py_identity_model.aio.http_client import _reset_async_http_client
 from py_identity_model.ssl_config import get_ssl_verify
 from py_identity_model.sync.http_client import _reset_http_client
+import py_identity_model.sync.token_validation as _sync_token_validation
 
 
 # JWT format: three dot-separated segments
@@ -50,6 +52,47 @@ def _is_valid_jwt_format(token: str) -> bool:
     return token.count(".") == JWT_SEGMENT_SEPARATOR_COUNT and all(
         len(part) > 0 for part in token.split(".")
     )
+
+
+@contextlib.contextmanager
+def count_upstream_fetches():
+    """Count real upstream discovery + JWKS fetches on the sync cached path.
+
+    Wraps — does not replace — the module-level ``get_discovery_document`` and
+    ``get_jwks`` names in :mod:`py_identity_model.sync.token_validation`, so the
+    genuine upstream fetch still runs (live signature validation keeps working)
+    while every round-trip is tallied. A cache *hit* calls neither wrapped
+    function, so the tally is a direct, non-timing proof of caching: N
+    validations that share a provider must drive exactly ONE discovery and ONE
+    JWKS fetch, not N. Clear the caches before entering the block so the first
+    validation is a guaranteed miss and the resulting count is deterministic
+    regardless of cache state left by earlier tests.
+
+    (HTTP-layer retries live *below* ``get_discovery_document``/``get_jwks``, so
+    a transiently-retried fetch is still a single counted call.)
+
+    Yields:
+        A live ``{"disco": int, "jwks": int}`` tally, updated as fetches occur.
+    """
+    real_get_discovery_document = _sync_token_validation.get_discovery_document
+    real_get_jwks = _sync_token_validation.get_jwks
+    counts = {"disco": 0, "jwks": 0}
+
+    def counting_get_discovery_document(*args, **kwargs):
+        counts["disco"] += 1
+        return real_get_discovery_document(*args, **kwargs)
+
+    def counting_get_jwks(*args, **kwargs):
+        counts["jwks"] += 1
+        return real_get_jwks(*args, **kwargs)
+
+    _sync_token_validation.get_discovery_document = counting_get_discovery_document
+    _sync_token_validation.get_jwks = counting_get_jwks
+    try:
+        yield counts
+    finally:
+        _sync_token_validation.get_discovery_document = real_get_discovery_document
+        _sync_token_validation.get_jwks = real_get_jwks
 
 
 def get_alternate_provider_expired_token() -> str | None:


### PR DESCRIPTION
## What
Replace the vacuous/flaky wall-clock "caching proof" (`assert elapsed < 1s`) in the discovery/JWKS cache integration tests with a real fetch-count assertion.

## Why
`assert elapsed < 1s` passes even if the cache is broken — a fast endpoint re-fetching N times still finishes under a second — so it never actually proved caching, and it doubles as a flaky CI wall-clock gate. Surfaced by the Phase-0 review as the most regression-hiding test-quality issue on `main`.

## How
A shared `count_upstream_fetches()` context manager (`test_utils.py`) **wraps — does not replace —** `get_discovery_document`/`get_jwks` on the sync cached path, so the genuine upstream fetch still runs (live signature validation keeps working) while every round-trip is tallied. After clearing the caches, N validations that share a provider must drive exactly **one** discovery + **one** JWKS fetch; a broken cache would drive N. Wall-clock is kept as an informational `print` only.

Tests updated: `test_cache_succeeds`, `test_benchmark_validation`, `test_multiple_tokens_validation_succeeds`, `test_benchmark_with_multiple_unique_tokens`, `test_benchmark_single_token_repeated`.

Runtime-clean: touches only `src/tests/integration/`. `test`-typed → no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)